### PR TITLE
feat: add benchmarks for Terminal-Bench 2.1, including scripts and ag…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 build/
 dist/
 coverage/
-benchmarks/
 
 # Dependencies
 node_modules/
@@ -41,3 +40,7 @@ package-lock.json
 yarn.lock
 bun.lock
 bun.lockb
+
+jobs/
+terminal-bench-2-1/
+benchmarks/agav-agent/bin/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,280 @@
+# Benchmarks — Terminal-Bench 2.1
+
+Run a chosen set of [Terminal-Bench 2.1](https://www.tbench.ai) tasks **by name**,
+or the whole board for a leaderboard submission.
+
+Terminal-Bench 2.1 is executed through the **Harbor** harness (`harbor run`), using
+the dataset `terminal-bench/terminal-bench-2-1`. Everything here is self-contained in
+this folder.
+
+## Prerequisites
+
+1. **Docker** running (tasks execute in containers).
+2. **Harbor** installed:
+   ```bash
+   uv tool install harbor      # or: pipx install harbor
+   ```
+3. **API key** for whatever model/agent you use, e.g.:
+   ```bash
+   export ANTHROPIC_API_KEY=sk-...
+   ```
+
+## Quick start
+
+```bash
+# Smoke test the harness works at all (first 5 tasks, no model needed):
+harbor run -d terminal-bench/terminal-bench-2-1 -a oracle -l 5
+```
+
+## Run specific tasks by name
+
+1. List the task names you want in [`tasks.txt`](./tasks.txt) (one per line), **or**
+   pass them as arguments.
+2. Run:
+
+   ```bash
+   # from repo root:
+   ./benchmarks/run-tasks.sh
+
+   # or pass names directly (overrides tasks.txt):
+   ./benchmarks/run-tasks.sh some-task-name another-task-name
+   ```
+
+## Run the whole board (leaderboard submission)
+
+For an actual leaderboard submission you run **every** task with at least 5
+trials each. Use `--all`:
+
+```bash
+# All tasks in the dataset, 5 trials each (Terminal-Bench 2.1 minimum):
+./benchmarks/run-tasks.sh --all
+
+# Cheap full-board smoke test first (1 trial each) before the real -k 5 run:
+EXTRA="-k 1" ./benchmarks/run-tasks.sh --all
+```
+
+`--all` drops the per-task filter and defaults to `-k 5`; it can't be combined
+with task names (so a stray argument can't silently narrow a submission). After
+the run, verify every trial produced a valid ATIF trajectory + reward before
+uploading:
+
+```bash
+./benchmarks/verify-run.sh          # checks the most recent job under jobs/
+```
+
+#### Resumable runs (recommended for the full -k 5)
+
+A full 445-trial run is long, so make it **resumable** by pinning `JOB_NAME`.
+Harbor stores the job at `jobs/<JOB_NAME>`; if the run is interrupted (Ctrl-C,
+crash, laptop sleep), re-running the **identical** command skips the completed
+trials and finishes only the rest — completed work is never re-run or re-billed.
+
+```bash
+JOB_NAME=tb21-agav-full ./benchmarks/run-tasks.sh --all   # start (or resume)
+# ...interrupted? just run the exact same line again to continue:
+JOB_NAME=tb21-agav-full ./benchmarks/run-tasks.sh --all
+./benchmarks/verify-run.sh jobs/tb21-agav-full
+```
+
+Notes:
+- The config must match to resume — keep the command identical (same `-k`,
+  model, agent, dataset). Harbor refuses a mismatched resume rather than
+  corrupting the job.
+- Use a **different** `JOB_NAME` for the `-k 1` smoke test vs the `-k 5` run
+  (their configs differ, so they can't share a job dir).
+- Without `JOB_NAME`, each run gets a fresh timestamp dir and is **not**
+  resumable.
+
+Then upload publicly (see [Upload results](#upload-results-harbor-hub--leaderboard)):
+
+```bash
+PUBLIC=1 ./benchmarks/upload.sh
+```
+
+### Run on a native amd64 VM (recommended for submission)
+
+The public leaderboard expects **amd64** for consistency. On an Apple-Silicon
+(arm64) host, task containers run either arm64-native or amd64-under-emulation —
+emulation is slow and can cause timeouts/flakiness that distort scores. So do the
+real `-k 5` submission run on a **native amd64 Linux VM**.
+
+You don't need the (private) agav source on the VM: the prebuilt binaries ship in
+the bundle, and `build-binary.sh` detects them and skips building. Package once
+on this machine:
+
+```bash
+benchmarks/package-for-vm.sh        # -> ./agav-benchmarks-vm.tgz (both prebuilt binaries + scripts)
+```
+
+Then on an amd64 VM (e.g. Ubuntu, ≥8 vCPU / 16 GB RAM / ~100 GB disk for images)
+with **Docker** and **uv** installed:
+
+```bash
+scp agav-benchmarks-vm.tgz user@<vm>:~/
+ssh user@<vm>
+tar -xzf agav-benchmarks-vm.tgz && cd benchmarks
+uv venv .venv && source .venv/bin/activate && uv pip install -e agav-agent
+export OPENAI_API_KEY=sk-...                 # gpt-5.5 key
+
+cd ..
+EXTRA='-k 1' ./benchmarks/run-tasks.sh --all # cheap full-board smoke test first
+./benchmarks/verify-run.sh                    # ATIF valid + real cost projection
+./benchmarks/run-tasks.sh --all              # the real -k 5 submission run
+./benchmarks/verify-run.sh
+harbor auth login && PUBLIC=1 ./benchmarks/upload.sh
+```
+
+`docker version --format '{{.Server.Arch}}'` on the VM should print `amd64`.
+
+### Finding available task names
+
+The `--include-task-name` filter matches on task **name**. To see what names exist
+in the dataset, do a dry run / listing:
+
+```bash
+harbor run -d terminal-bench/terminal-bench-2-1 -a oracle --dry-run
+```
+
+(or browse the dataset on the Terminal-Bench site / its dataset repo).
+
+## Configuration
+
+`run-tasks.sh` reads these environment variables:
+
+| Var       | Default                          | Meaning                                  |
+|-----------|----------------------------------|------------------------------------------|
+| `AGENT`   | `agav`                           | Harbor agent (`agav`, or built-ins like `oracle`, `claude-code`) |
+| `MODEL`   | `openai/gpt-5.5`            | Model identifier (`provider/model`) passed to the agent |
+| `DATASET` | `terminal-bench/terminal-bench-2-1`| Dataset identifier                     |
+| `EXTRA`   | *(empty)*                        | Extra flags forwarded to `harbor`, e.g. `-n 2` for parallelism, or `-k 1` to override the trial count |
+
+Examples:
+
+```bash
+# Oracle agent just replays the reference solution (good for sanity-checking a task):
+AGENT=oracle ./benchmarks/run-tasks.sh my-task
+
+# Run against a real coding agent + model:
+AGENT=claude-code MODEL=anthropic/claude-haiku-4-5 ./benchmarks/run-tasks.sh my-task
+```
+
+## Benchmarking agav itself
+
+A Harbor agent adapter for agav lives in [`agav-agent/`](./agav-agent). agav has
+no published npm package or release binary, and its GitHub repo is private (so it
+can't be cloned in-container). Instead, the adapter uses a single-file agav
+executable **built from your local checkout** ([`build-binary.sh`](./agav-agent/build-binary.sh)),
+uploads it into each task container, and drives it with `agav run "<instruction>"`
+— agav's non-interactive mode, which runs one autonomous turn with auto-accept
+permissions and exits with a status code.
+
+The binary is a Linux **x64** build (Terminal-Bench 2.0 task images are
+amd64/linux). It is built inside an amd64 `oven/bun` container, so it works even
+if the host has no `bun`/`node` and native modules resolve for the right target.
+`run-tasks.sh` builds it automatically (cached; rebuilt only when sources change)
+whenever `AGENT=agav`; you can also build it manually:
+
+```bash
+benchmarks/agav-agent/build-binary.sh          # build if missing/stale
+FORCE=1 benchmarks/agav-agent/build-binary.sh  # force a rebuild
+```
+
+### One-time setup
+
+The adapter and `harbor` must live in the **same** Python environment (the
+adapter declares `harbor` as a dependency, so installing it pulls harbor in).
+Use one dedicated venv and run everything from it:
+
+```bash
+# 1. Create the shared venv and install the adapter (+ harbor) into it:
+uv venv benchmarks/.venv
+source benchmarks/.venv/bin/activate
+uv pip install -e benchmarks/agav-agent
+
+# 2. Verify (uses the venv's python):
+python -c "from agav_terminal_bench import AgavAgent; print('adapter ok')"
+harbor --version
+
+# 3. Export the provider key agav will use inside the container:
+export ANTHROPIC_API_KEY=sk-...        # or OPENAI_API_KEY / GEMINI_API_KEY
+```
+
+> Run `run-tasks.sh` from inside this activated venv so it uses the venv's
+> `harbor` (the one that can import the adapter).
+
+> **Harbor patch (known issue):** Harbor's `upload_dir` can misplace the
+> verifier's `/tests` files if the agent creates a `/tests` dir during a task.
+> If you hit verifier failures, apply the one-liner patch documented in the pi
+> adapter's README: <https://github.com/badlogic/pi-terminal-bench#required-apply-harbor-fix>
+
+### Run agav on your chosen tasks
+
+```bash
+AGENT=agav MODEL=openai/gpt-5.5 ./benchmarks/run-tasks.sh my-task another-task
+```
+
+This switches the harness to `-a agav_terminal_bench:AgavAgent`.
+
+Extra knobs (env vars read on the host):
+
+| Var             | Purpose                                                        |
+|-----------------|----------------------------------------------------------------|
+| `AGAV_MAX_TURNS`| Cap agav's agent iterations per task (e.g. `AGAV_MAX_TURNS=50`) |
+| `FORCE`         | `FORCE=1` forces `build-binary.sh` to rebuild the binary        |
+
+The adapter uploads the locally-built `agav-linux-x64` binary into each task
+container and runs `agav run "<instruction>"`. To benchmark a specific
+commit/branch, check it out locally and re-run (the binary rebuilds when sources
+change, or force it with `FORCE=1`).
+
+### Trajectories (ATIF) — required for leaderboard submission
+
+The adapter runs agav with `--trajectory /logs/agent/agav-trajectory.json`, so
+each run emits a native transcript (ordered messages, tool calls + results
+correlated by id, token usage). After the run, the adapter converts that into a
+Harbor **ATIF** `trajectory.json` (`populate_context_post_run`), which the Hub
+uploader picks up per trial. The public Terminal-Bench leaderboard CI/judge
+audits these trajectories, so agents that upload only free-form logs are
+rejected — this is why the conversion exists. Nothing extra to run; it happens
+automatically whenever `AGENT=agav`.
+
+## Upload results (Harbor Hub / leaderboard)
+
+Uploads go through [`upload.sh`](./upload.sh), which shares every job with the
+**`prapaa`** org by default. (Harbor has no persistent "default org", and
+`harbor run` takes no org at all — the org is only ever attached at *upload*
+time via `--share-org`, so the default lives here.)
+
+```bash
+# Log in once (GitHub OAuth):
+harbor auth login
+
+# Upload the most recent job dir, PRIVATE, shared with prapaa (safe default):
+./benchmarks/upload.sh
+
+# Upload a specific job dir:
+./benchmarks/upload.sh jobs/2026-08-03__18-30-31
+
+# Publish to the PUBLIC leaderboard (real submission):
+PUBLIC=1 ./benchmarks/upload.sh jobs/<dir>
+```
+
+Visibility defaults to **private** so nothing hits the public leaderboard by
+accident — set `PUBLIC=1` for an actual submission.
+
+| Var      | Purpose                                                       |
+|----------|--------------------------------------------------------------|
+| `ORG`    | Org(s) to share with, space-separated (default: `prapaa`; `ORG=""` = owner only) |
+| `PUBLIC` | `PUBLIC=1` → public leaderboard; unset → private             |
+| `HARBOR` | Override the `harbor` executable (auto-detected otherwise)    |
+
+The uploaded job is **owned by your user account** (there is no owning-org in
+Harbor); `prapaa` gets a *share*. Manage shares later with
+`harbor job share <job_id> --org <org>`.
+
+## Notes
+
+- `agav` is the default agent, so `./benchmarks/run-tasks.sh` benchmarks agav
+  directly (see the one-time setup above). Use `AGENT=oracle` to sanity-check a
+  task with its known-good solution without spending model tokens.
+- Results are written to Harbor's run output directory (printed at the end of a run).

--- a/benchmarks/agav-agent/build-binary.sh
+++ b/benchmarks/agav-agent/build-binary.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Build single-file agav executables from the LOCAL checkout, for use by the
+# Harbor agav adapter. The agav GitHub repo is private and cannot be cloned
+# inside a task container, so we build binaries here and upload the one matching
+# each container's architecture (see agav_agent.py::_ARCH_BINARIES).
+#
+# Task images vary by dataset AND host: Terminal-Bench 2.0 images run amd64,
+# but some datasets (e.g. openthoughts-tblite) run arm64-native on Apple Silicon.
+# The container reports its arch via `uname -m`, so we build BOTH targets by
+# default and let the adapter pick. Each target is built inside a matching-arch
+# `oven/bun` container (so native modules resolve for the right target and it
+# works even when the host has no bun/node installed).
+#
+# Outputs:
+#   benchmarks/agav-agent/bin/agav-linux-x64     (linux/amd64)
+#   benchmarks/agav-agent/bin/agav-linux-arm64   (linux/arm64)
+#
+# Usage:
+#   benchmarks/agav-agent/build-binary.sh              # build any missing/stale targets
+#   FORCE=1 benchmarks/agav-agent/build-binary.sh      # always rebuild
+#   ARCHES="arm64" benchmarks/agav-agent/build-binary.sh   # build just one target
+#
+# Requires: Docker running. Nothing outside benchmarks/ is modified.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OUT_DIR="${SCRIPT_DIR}/bin"
+BUN_IMAGE="${BUN_IMAGE:-oven/bun:1}"
+
+# Which targets to build. Override with e.g. ARCHES="arm64".
+ARCHES="${ARCHES:-x64 arm64}"
+
+# arch token -> docker --platform.
+arch_platform() {
+  case "$1" in
+    x64)   echo "linux/amd64" ;;
+    arm64) echo "linux/arm64" ;;
+    *)     echo "error: unknown arch '$1' (supported: x64, arm64)" >&2; return 1 ;;
+  esac
+}
+
+if ! docker info >/dev/null 2>&1; then
+  echo "error: Docker does not appear to be running. Start Docker and retry." >&2
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+build_one() {
+  local arch="$1"
+  local platform out_name out_path
+  platform="$(arch_platform "${arch}")"
+  out_name="agav-linux-${arch}"
+  out_path="${OUT_DIR}/${out_name}"
+
+  # Source-less host (e.g. the amd64 run VM): the agav repo is private and isn't
+  # shipped, so we can't build. Use the prebuilt binary if it's here, else fail
+  # with a clear pointer to build it on a machine that has the checkout.
+  if [[ ! -d "${REPO_ROOT}/source" ]]; then
+    if [[ -f "${out_path}" ]]; then
+      echo "Using prebuilt ${out_path} (no agav source on this host)."
+      return 0
+    fi
+    echo "error: no agav source at ${REPO_ROOT}/source and no prebuilt ${out_path}." >&2
+    echo "       Build it on a host with the agav checkout, then copy bin/${out_name} here." >&2
+    return 1
+  fi
+
+  # Skip rebuild when the binary is newer than every source file (unless FORCE=1).
+  if [[ -z "${FORCE:-}" && -f "${out_path}" ]]; then
+    if [[ -z "$(find "${REPO_ROOT}/source" "${REPO_ROOT}/package.json" \
+                     "${REPO_ROOT}/pnpm-lock.yaml" "${REPO_ROOT}/tsconfig.json" \
+                     -newer "${out_path}" 2>/dev/null)" ]]; then
+      echo "Up to date: ${out_path} (set FORCE=1 to rebuild)"
+      return 0
+    fi
+  fi
+
+  echo "Building ${out_name} from ${REPO_ROOT} via ${BUN_IMAGE} (${platform})..."
+
+  # Copy just the sources into the container's own filesystem (so the host's repo,
+  # and anything outside benchmarks/, is never written to), install, then compile.
+  docker run --rm --platform "${platform}" \
+    -v "${REPO_ROOT}:/src:ro" \
+    -v "${OUT_DIR}:/out" \
+    -e HUSKY=0 \
+    "${BUN_IMAGE}" bash -c '
+      set -euo pipefail
+      mkdir -p /build
+      cp -a /src/package.json /src/pnpm-lock.yaml /src/pnpm-workspace.yaml \
+            /src/tsconfig.json /build/
+      cp -a /src/source /build/source
+      cp -a /src/assets /build/assets 2>/dev/null || true
+      cd /build
+      export HUSKY=0
+      bun install
+      # Ink optional dependency needed by the compiled bundle.
+      bun install react-devtools-core 2>/dev/null || true
+      bun build source/cli.tsx --compile --outfile /out/'"${out_name}"'
+      /out/'"${out_name}"' --version
+    '
+
+  echo "Built: ${out_path} ($(du -sh "${out_path}" | cut -f1))"
+}
+
+for arch in ${ARCHES}; do
+  build_one "${arch}"
+done

--- a/benchmarks/agav-agent/pyproject.toml
+++ b/benchmarks/agav-agent/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "agav-terminal-bench"
+version = "0.1.0"
+description = "Harbor agent adapter to benchmark the agav CLI on Terminal-Bench"
+requires-python = ">=3.11"
+dependencies = [
+    "harbor>=0.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agav_terminal_bench"]

--- a/benchmarks/agav-agent/src/agav_terminal_bench/__init__.py
+++ b/benchmarks/agav-agent/src/agav_terminal_bench/__init__.py
@@ -1,0 +1,5 @@
+"""Harbor agent adapter for benchmarking the agav CLI on Terminal-Bench."""
+
+from agav_terminal_bench.agav_agent import AgavAgent
+
+__all__ = ["AgavAgent"]

--- a/benchmarks/agav-agent/src/agav_terminal_bench/agav_agent.py
+++ b/benchmarks/agav-agent/src/agav_terminal_bench/agav_agent.py
@@ -1,0 +1,368 @@
+"""
+Harbor agent adapter for the agav CLI.
+
+The agav GitHub repo is private, so it cannot be cloned inside a task container.
+Instead we build a single-file agav executable from the *local* checkout ahead of
+time (see ``benchmarks/agav-agent/build-binary.sh``) and upload that binary into
+each task container. agav is then driven in non-interactive mode with
+``agav run "<instruction>"``, which runs a single autonomous turn with
+auto-accept permissions and exits with a status code.
+
+Written against harbor's BaseInstalledAgent interface (install()/run()),
+modelled on harbor's own built-in agents (see harbor/agents/installed/pi.py).
+"""
+
+import json
+import os
+import shlex
+from pathlib import Path
+from typing import Any, override
+
+from harbor.agents.installed.base import (
+    BaseInstalledAgent,
+    CliFlag,
+    with_prompt_template,
+)
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from harbor.models.trajectories import (
+    Agent,
+    FinalMetrics,
+    Observation,
+    ObservationResult,
+    Step,
+    ToolCall,
+    Trajectory,
+)
+from harbor.utils.trajectory_utils import format_trajectory_json
+
+# Prebuilt binaries live in benchmarks/agav-agent/bin/ (this file is at
+# benchmarks/agav-agent/src/agav_terminal_bench/agav_agent.py).
+_BIN_DIR = Path(__file__).resolve().parents[2] / "bin"
+
+# Where the uploaded binary lands inside the container.
+_INSTALL_PATH = "/usr/local/bin/agav"
+_OUTPUT_FILENAME = "agav.txt"
+
+# agav writes its own native run transcript here (inside the container, under
+# /logs/agent which maps to the agent's logs_dir on the host). We convert it into
+# a Harbor ATIF trajectory.json in populate_context_post_run so the Hub uploader
+# picks it up and leaderboard CI / the judge can audit every rewarded trial.
+_NATIVE_TRAJECTORY_FILENAME = "agav-trajectory.json"
+
+# `uname -m` (as reported inside the container) -> prebuilt binary filename.
+# Terminal-Bench 2.0 task images are amd64/linux, so x86_64 is the common case.
+_ARCH_BINARIES = {
+    "x86_64": "agav-linux-x64",
+    "amd64": "agav-linux-x64",
+    "aarch64": "agav-linux-arm64",
+    "arm64": "agav-linux-arm64",
+}
+
+# Map Harbor provider tokens -> agav provider names.
+_PROVIDER_ALIASES = {
+    "google": "gemini",
+    "google-gemini": "gemini",
+    "googleai": "gemini",
+}
+
+# Provider -> host env vars to forward into the container so agav can auth.
+_PROVIDER_KEYS = {
+    "anthropic": ["ANTHROPIC_API_KEY"],
+    "openai": ["OPENAI_API_KEY"],
+    "gemini": ["GEMINI_API_KEY"],
+    "ollama": ["OLLAMA_HOST", "OLLAMA_PORT", "OLLAMA_ENDPOINT", "OLLAMA_API_KEY"],
+}
+
+
+class AgavAgent(BaseInstalledAgent):
+    """Runs the agav CLI as a Terminal-Bench agent via Harbor."""
+
+    # agav emits a native run transcript that we convert to ATIF (see
+    # populate_context_post_run), so the Hub uploader has a trajectory.json per
+    # trial — required for leaderboard submission / the judge's audit.
+    SUPPORTS_ATIF: bool = True
+
+    # Optional cap on agent iterations; set on the host via AGAV_MAX_TURNS.
+    CLI_FLAGS = [
+        CliFlag(
+            "max_turns",
+            cli="--max-turns",
+            type="int",
+            env_fallback="AGAV_MAX_TURNS",
+        ),
+    ]
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "agav"
+
+    @override
+    def get_version_command(self) -> str | None:
+        return f"{_INSTALL_PATH} --version"
+
+    @override
+    def parse_version(self, stdout: str) -> str:
+        return stdout.strip().splitlines()[-1].strip()
+
+    def _local_binary_for_arch(self, arch: str) -> Path:
+        """Resolve the host-side prebuilt binary for the container's arch."""
+        name = _ARCH_BINARIES.get(arch.strip().lower())
+        if name is None:
+            raise RuntimeError(
+                f"No prebuilt agav binary configured for container arch {arch!r}. "
+                f"Known arches: {sorted(_ARCH_BINARIES)}."
+            )
+        binary = _BIN_DIR / name
+        if not binary.is_file():
+            raise RuntimeError(
+                f"Prebuilt agav binary not found: {binary}\n"
+                "Build it first from the repo root with:\n"
+                "    benchmarks/agav-agent/build-binary.sh\n"
+                "(builds a linux-x64 agav binary from your local checkout via Docker)."
+            )
+        return binary
+
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        # Detect the container architecture so we upload a matching binary.
+        arch_result = await self.exec_as_root(environment, command="uname -m")
+        arch = (arch_result.stdout or "").strip()
+        binary = self._local_binary_for_arch(arch)
+
+        # docker cp the single-file executable straight to a PATH location, then
+        # make it world-executable (docker cp lands it owned by root).
+        await environment.upload_file(str(binary), _INSTALL_PATH)
+        await self.exec_as_root(
+            environment,
+            command=f"chmod 755 {shlex.quote(_INSTALL_PATH)}",
+        )
+
+        # Sanity-check the uploaded binary runs in this container.
+        await self.exec_as_agent(
+            environment,
+            command=f"{shlex.quote(_INSTALL_PATH)} --version",
+        )
+
+    @override
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        if not self.model_name or "/" not in self.model_name:
+            raise ValueError("Model name must be in the format provider/model_name")
+
+        harbor_provider, model = self.model_name.split("/", 1)
+        provider = _PROVIDER_ALIASES.get(harbor_provider.lower(), harbor_provider.lower())
+
+        env: dict[str, str] = {}
+        for key in _PROVIDER_KEYS.get(provider, []):
+            val = os.environ.get(key)
+            if val:
+                env[key] = val
+
+        # Anti reward-hacking egress control. When AGAV_EGRESS_PROXY is set on
+        # the host, route ALL of the agent's HTTP(S) traffic (fetch_url tool AND
+        # any shell curl/git) through a denylist proxy that refuses the benchmark
+        # repo / leaked-solution mirrors. This is inert unless the var is set, so
+        # normal direct-network runs are unaffected. It only touches the agent
+        # phase's env (not any task file), so task_checksum is unchanged.
+        # See benchmarks/egress-proxy.py. NO_PROXY keeps localhost task services
+        # (webdrivers, local servers) off the proxy.
+        proxy = os.environ.get("AGAV_EGRESS_PROXY")
+        if proxy:
+            for pkey in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+                env[pkey] = proxy
+            no_proxy = os.environ.get("AGAV_NO_PROXY", "localhost,127.0.0.1,::1")
+            env["NO_PROXY"] = no_proxy
+            env["no_proxy"] = no_proxy
+
+        cli_flags = self.build_cli_flags()
+        if cli_flags:
+            cli_flags += " "
+
+        escaped_instruction = shlex.quote(instruction)
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "mkdir -p /logs/agent 2>/dev/null || true; "
+                # `run` must come first, then the prompt, then flags.
+                f"{shlex.quote(_INSTALL_PATH)} run {escaped_instruction} "
+                f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
+                f"--trajectory /logs/agent/{_NATIVE_TRAJECTORY_FILENAME} "
+                f"{cli_flags}"
+                f"2>&1 | stdbuf -oL tee /logs/agent/{_OUTPUT_FILENAME}"
+            ),
+            env=env,
+        )
+
+    # ------------------------------------------------------------------
+    # ATIF trajectory conversion
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _text_from_blocks(blocks: list[dict[str, Any]]) -> str:
+        """Join the text of any ``text`` content blocks."""
+        parts = [
+            b["text"]
+            for b in blocks
+            if b.get("type") == "text" and b.get("text")
+        ]
+        return "\n".join(parts)
+
+    def _convert_native_to_atif(self, data: dict[str, Any]) -> Trajectory | None:
+        """Convert agav's native run transcript into a Harbor ATIF Trajectory.
+
+        agav records the run as an ordered list of messages. A ``user`` message
+        is either a real user turn (text blocks) or a batch of tool results
+        (``tool_result`` blocks, correlated to a prior assistant turn by
+        ``toolCallId``); an ``assistant`` message carries text plus ``tool_use``
+        blocks. We map each user/assistant turn to a sequential ATIF Step and
+        attach tool results as Observations on the agent step that issued them.
+        """
+        messages = data.get("messages") or []
+        model_name = data.get("model") or self.model_name
+        provider = data.get("provider") or ""
+
+        steps: list[Step] = []
+        step_id = 1
+
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content") or []
+
+            if role == "user":
+                tool_results = [
+                    b for b in content if b.get("type") == "tool_result"
+                ]
+                if tool_results:
+                    # Attach each result to the agent step that issued the call.
+                    for block in tool_results:
+                        call_id = block.get("toolCallId") or ""
+                        output = block.get("toolResult")
+                        result = ObservationResult(
+                            source_call_id=call_id,
+                            content="" if output is None else str(output),
+                        )
+                        for step in reversed(steps):
+                            if step.source != "agent" or not step.tool_calls:
+                                continue
+                            if any(
+                                tc.tool_call_id == call_id
+                                for tc in step.tool_calls
+                            ):
+                                if step.observation is None:
+                                    step.observation = Observation(results=[result])
+                                else:
+                                    step.observation.results.append(result)
+                                break
+                    continue
+
+                # Real user turn: prefer the original (pre-expansion) input.
+                text = msg.get("sourceText") or self._text_from_blocks(content)
+                steps.append(
+                    Step(
+                        step_id=step_id,
+                        source="user",
+                        message=text or "(no content)",
+                    )
+                )
+                step_id += 1
+
+            elif role == "assistant":
+                text = self._text_from_blocks(content)
+                tool_calls = [
+                    ToolCall(
+                        tool_call_id=b.get("toolCallId") or "",
+                        function_name=b.get("toolName") or "",
+                        arguments=b.get("toolInput") or {},
+                    )
+                    for b in content
+                    if b.get("type") == "tool_use"
+                ]
+                step_kwargs: dict[str, Any] = {
+                    "step_id": step_id,
+                    "source": "agent",
+                    "message": text or "(tool use)",
+                    "model_name": model_name,
+                }
+                if tool_calls:
+                    step_kwargs["tool_calls"] = tool_calls
+                steps.append(Step(**step_kwargs))
+                step_id += 1
+
+        if not steps:
+            return None
+
+        usage = data.get("usage") or {}
+        total_in = usage.get("input_tokens") or 0
+        total_out = usage.get("output_tokens") or 0
+        total_cache = usage.get("cache_read_tokens") or 0
+
+        extra = {
+            k: v
+            for k, v in {
+                "provider": provider or None,
+                "started_at": data.get("started_at"),
+                "finished_at": data.get("finished_at"),
+            }.items()
+            if v is not None
+        }
+
+        return Trajectory(
+            agent=Agent(
+                name=self.name(),
+                version=self._version or "unknown",
+                model_name=model_name,
+            ),
+            steps=steps,
+            final_metrics=FinalMetrics(
+                total_prompt_tokens=total_in or None,
+                total_completion_tokens=total_out or None,
+                total_cached_tokens=total_cache or None,
+                total_cost_usd=None,
+                total_steps=len(steps),
+            ),
+            extra=extra or None,
+        )
+
+    @override
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        native_path = self.logs_dir / _NATIVE_TRAJECTORY_FILENAME
+        if not native_path.is_file():
+            return
+
+        try:
+            data = json.loads(native_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            self.logger.debug(f"Failed to read agav native trajectory: {exc}")
+            return
+
+        try:
+            trajectory = self._convert_native_to_atif(data)
+        except Exception:
+            self.logger.debug(
+                "Failed to convert agav trajectory to ATIF", exc_info=True
+            )
+            return
+
+        if trajectory is None:
+            return
+
+        atif_path = self.logs_dir / "trajectory.json"
+        try:
+            atif_path.write_text(format_trajectory_json(trajectory.to_json_dict()))
+        except OSError as exc:
+            self.logger.debug(f"Failed to write ATIF trajectory {atif_path}: {exc}")
+            return
+
+        if trajectory.final_metrics:
+            fm = trajectory.final_metrics
+            context.cost_usd = fm.total_cost_usd
+            context.n_input_tokens = fm.total_prompt_tokens or 0
+            context.n_output_tokens = fm.total_completion_tokens or 0
+            context.n_cache_tokens = fm.total_cached_tokens or 0

--- a/benchmarks/egress-proxy.py
+++ b/benchmarks/egress-proxy.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Denylist/allowlist egress proxy for agav benchmark re-runs (anti reward-hacking).
+
+Why this exists
+---------------
+On plain re-runs the agent fetches the benchmark repo / leaked solutions, which
+turns real failures into fake passes. Disabling agav's fetch tools is NOT
+airtight (shell curl/git bypass) and AGAV_PERMISSION deny flips agav into global
+"deny-writes" (breaks legit tasks). The only side-effect-free layer is network
+egress control.
+
+Observed adversarial behavior (mteb-leaderboard__FsybnJg, 2026-08-11): with a
+plain hostname denylist the agent DEFEATED it via
+  * reader-proxies (r.jina.ai) that fetch a blocked URL server-side, and
+  * leaked mirrors on shared allowed hosts (huggingface.co/HKasar1239, and a new
+    github mirror mintoriakamoto/AI-Bench-MoeX).
+So this version (a) always blocks reader-proxies/caches + all known mirrors
+FIRST, and (b) offers an optional strict allowlist mode (--strict) that blocks
+everything not explicitly allowed.
+
+Design constraints
+------------------
+* NO TLS interception (no CA -> would change the task image / break model calls).
+  Filtering is on the CONNECT hostname (and Host header for plain HTTP) only.
+* Because HTTPS hides the URL path, two vectors CANNOT be stopped by hostname and
+  remain residual even in --strict: (1) a leak hosted on a shared allowed host
+  (huggingface.co/HKasar1239), (2) a mirror cloned from github.com. The
+  full-channel canary/benchmark-host GREP over each finished trajectory stays the
+  MANDATORY authoritative gate.
+
+Usage
+-----
+    python3 benchmarks/egress-proxy.py                 # denylist-only (default)
+    python3 benchmarks/egress-proxy.py --strict        # default-deny allowlist
+    python3 benchmarks/egress-proxy.py --log /tmp/egress-blocks.log
+
+Then, before re-running:
+    export AGAV_EGRESS_PROXY=http://host.docker.internal:8080
+    EXTRA="-n 1" JOB_NAME=tb21-agav-full ./benchmarks/run-tasks.sh --all
+"""
+
+import argparse
+import select
+import socket
+import sys
+import threading
+from datetime import datetime, timezone
+
+# --------------------------------------------------------------------------
+# ALWAYS-DENIED host suffixes (checked FIRST, in both modes). Suffix match:
+# "spylab.ai" blocks "spylab.ai" and "x.spylab.ai".
+# --------------------------------------------------------------------------
+DENY_SUFFIXES = [
+    # --- search engines (mirror/leak DISCOVERY channel; 0 legit fetches to
+    # these hosts observed among clean reward=1 trials, so denylist them even in
+    # default-allow mode). Note: these suffixes do NOT match googleapis.com /
+    # gstatic.com / google.dev, which stay allowed. ---
+    "duckduckgo.com",               # agav web_search backend (html.duckduckgo.com)
+    "bing.com",
+    "google.com",                   # www.google.com/search (NOT *.googleapis.com)
+    "search.brave.com",
+    "search.marginalia.nu",
+    # --- benchmark repo browse/raw APIs (dominant vector) ---
+    "api.github.com",
+    "raw.githubusercontent.com",
+    "gist.githubusercontent.com",
+    # --- known leak / mirror hosts ---
+    "hub.harborframework.com",
+    "harborframework.com",
+    "tbench.ai",
+    "spylab.ai",
+    "solutions-spylab.github.io",
+    "marginlab.ai",
+    "deepwiki.com",
+    "hkasar1239.github.io",
+    "moogician.github.io",
+    # --- reader-proxies / URL-fetch relays / caches (the bypass class) ---
+    # These fetch an arbitrary (blocked) URL server-side and return its body,
+    # defeating hostname filtering. Block the relay itself.
+    "jina.ai",                      # r.jina.ai, s.jina.ai, ...
+    "corsproxy.io",
+    "allorigins.win",               # api.allorigins.win
+    "12ft.io",
+    "1ft.io",
+    "cors-anywhere.herokuapp.com",
+    "thingproxy.freeboard.io",
+    "codetabs.com",                 # api.codetabs.com/v1/proxy
+    "cors.sh",                      # proxy.cors.sh
+    "whateverorigin.org",
+    "crossorigin.me",
+    "yacdn.org",
+    "textance.herokuapp.com",
+    "urlreq.appspot.com",
+    # --- web caches / archives / translators (also fetch blocked URLs) ---
+    "webcache.googleusercontent.com",
+    "web.archive.org",
+    "archive.org",
+    "archive.ph",
+    "archive.today",
+    "cachedview.nl",
+    "translate.goog",               # *.translate.goog (Google Translate relay)
+    "translate.google.com",
+    "translate.yandex.com",
+]
+
+# Substrings that, if present ANYWHERE in the CONNECT host, force a block. Used
+# for mirror *accounts* that live on otherwise-allowed hosts is impossible by
+# hostname (HTTPS hides the path) -- but standalone mirror domains go here.
+DENY_CONTAINS = [
+    "harborframework",
+    "terminalbench",
+]
+
+# --------------------------------------------------------------------------
+# ALLOWLIST (only consulted with --strict). Everything not matching (and not in
+# DENY above) is refused. Curated to cover legit needs of the re-run tasks +
+# hosts actually observed in clean traffic (datawrapper, kennethenevoldsen).
+# Extend freely: watch the log for "DENY not-allowlisted <host>" and add it.
+# NOTE: github.com and huggingface.co are allowed (legit clones / model pulls) ->
+# their leaked-mirror sub-paths are the residual gap the GREP gate must catch.
+# --------------------------------------------------------------------------
+ALLOW_SUFFIXES = [
+    # model / agent APIs
+    "api.openai.com", "openai.com", "api.anthropic.com", "anthropic.com",
+    # python / pip
+    "pypi.org", "pythonhosted.org", "pypi.python.org",
+    # conda
+    "anaconda.org", "anaconda.com",
+    # OS packages
+    "debian.org", "ubuntu.com", "archive.ubuntu.com", "security.ubuntu.com",
+    # other language package registries
+    "registry.npmjs.org", "npmjs.org", "crates.io", "proxy.golang.org",
+    "sum.golang.org", "rubygems.org",
+    # huggingface (models/datasets/spaces) -- REQUIRED by mteb/hf tasks
+    "huggingface.co", "hf.co", "hf.space", "cdn-lfs.huggingface.co",
+    "cdn-lfs-us-1.hf.co", "cdn-lfs-eu-1.hf.co", "datasets-server.huggingface.co",
+    "hf-mirror.com",
+    # github legit clones / assets (NOT raw/api -- those are denied above)
+    "github.com", "codeload.github.com", "objects.githubusercontent.com",
+    # common CDNs
+    "jsdelivr.net", "cdnjs.cloudflare.com", "unpkg.com", "fastly.net",
+    # legit hosts observed in clean mteb traffic
+    "dwcdn.net", "datawrapper.de", "kennethenevoldsen.com",
+    # Scandinavian Embedding Benchmark author's own site (the primary legit
+    # source for this task) -- NOT a benchmark grader/mirror. Safe to allow:
+    # the denied *.github.io mirror hosts (hkasar1239/moogician/solutions-spylab)
+    # are exact suffixes checked FIRST, so this cannot shadow them.
+    "kennethenevoldsen.github.io",
+    # official POV-Ray project distribution site -- REQUIRED by build-pov-ray to
+    # download the legit 2.2 source archive. Upstream project, not a mirror.
+    "povray.org",
+    # legit POV-Ray distribution MIRRORS the agent falls back to (reputable
+    # academic / OS software mirrors carrying Old-Versions/Official-2.2) -- also
+    # needed for a clean build-pov-ray solve; none are benchmark/grader hosts.
+    "ftp.nluug.nl", "mirrors.dotsrc.org", "ftp.icm.edu.pl", "ftp.fau.de",
+    "ftp.uni-erlangen.de",
+]
+
+_lock = threading.Lock()
+_log_fh = None
+_strict = False
+
+
+def log(msg: str) -> None:
+    line = f"{datetime.now(timezone.utc).isoformat()} {msg}"
+    with _lock:
+        sys.stderr.write(line + "\n")
+        sys.stderr.flush()
+        if _log_fh is not None:
+            _log_fh.write(line + "\n")
+            _log_fh.flush()
+
+
+def _norm(host: str) -> str:
+    h = host.strip().lower().rstrip(".")
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+    return h
+
+
+def _suffix_match(host: str, suffixes) -> bool:
+    for suf in suffixes:
+        if host == suf or host.endswith("." + suf):
+            return True
+    return False
+
+
+def verdict(host: str) -> tuple[bool, str]:
+    """Return (blocked, reason)."""
+    h = _norm(host)
+    if _suffix_match(h, DENY_SUFFIXES):
+        return True, "denylist"
+    if any(tok in h for tok in DENY_CONTAINS):
+        return True, "denylist(contains)"
+    if _strict and not _suffix_match(h, ALLOW_SUFFIXES):
+        return True, "not-allowlisted"
+    return False, "allow"
+
+
+def pipe(a: socket.socket, b: socket.socket) -> None:
+    socks = [a, b]
+    try:
+        while True:
+            r, _, x = select.select(socks, [], socks, 60)
+            if x or not r:
+                break
+            for s in r:
+                other = b if s is a else a
+                try:
+                    data = s.recv(65536)
+                except OSError:
+                    return
+                if not data:
+                    return
+                try:
+                    other.sendall(data)
+                except OSError:
+                    return
+    finally:
+        for s in socks:
+            try:
+                s.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
+def read_headers(sock: socket.socket) -> bytes:
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        buf += chunk
+        if len(buf) > 65536:
+            break
+    return buf
+
+
+def _refuse(client: socket.socket) -> None:
+    try:
+        client.sendall(b"HTTP/1.1 403 Forbidden\r\n"
+                       b"Content-Length: 0\r\nConnection: close\r\n\r\n")
+    except OSError:
+        pass
+    client.close()
+
+
+def handle_connect(client: socket.socket, target: str) -> None:
+    host, _, port_s = target.partition(":")
+    port = int(port_s) if port_s else 443
+    blocked, reason = verdict(host)
+    if blocked:
+        log(f"BLOCK CONNECT {host}:{port} [{reason}]")
+        _refuse(client)
+        return
+    try:
+        upstream = socket.create_connection((host, port), timeout=30)
+    except OSError as exc:
+        log(f"FAIL  CONNECT {host}:{port} ({exc})")
+        try:
+            client.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+        except OSError:
+            pass
+        client.close()
+        return
+    client.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+    pipe(client, upstream)
+
+
+def handle_plain_http(client: socket.socket, first_line: str, raw: bytes) -> None:
+    try:
+        _, url, _ = first_line.split(" ", 2)
+    except ValueError:
+        client.close()
+        return
+    hostport = url.split("//", 1)[-1].split("/", 1)[0]
+    host, _, port_s = hostport.partition(":")
+    port = int(port_s) if port_s else 80
+    blocked, reason = verdict(host)
+    if blocked:
+        log(f"BLOCK HTTP    {host}:{port} {url} [{reason}]")
+        _refuse(client)
+        return
+    try:
+        upstream = socket.create_connection((host, port), timeout=30)
+    except OSError as exc:
+        log(f"FAIL  HTTP    {host}:{port} ({exc})")
+        try:
+            client.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+        except OSError:
+            pass
+        client.close()
+        return
+    upstream.sendall(raw)
+    pipe(client, upstream)
+
+
+def handle_client(client: socket.socket, addr) -> None:
+    try:
+        client.settimeout(30)
+        raw = read_headers(client)
+        if not raw:
+            client.close()
+            return
+        first_line = raw.split(b"\r\n", 1)[0].decode("latin-1", "replace")
+        method = first_line.split(" ", 1)[0].upper()
+        client.settimeout(None)
+        if method == "CONNECT":
+            handle_connect(client, first_line.split(" ", 2)[1])
+        else:
+            handle_plain_http(client, first_line, raw)
+    except Exception as exc:  # noqa: BLE001
+        log(f"ERROR client {addr}: {exc}")
+        try:
+            client.close()
+        except OSError:
+            pass
+
+
+def main() -> int:
+    global _log_fh, _strict
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="0.0.0.0")
+    ap.add_argument("--port", type=int, default=8080)
+    ap.add_argument("--strict", action="store_true",
+                    help="default-deny: block everything not on ALLOW_SUFFIXES "
+                         "(may block legit hosts -- watch the log and extend)")
+    ap.add_argument("--log", help="also append events to this file")
+    args = ap.parse_args()
+
+    _strict = args.strict
+    if args.log:
+        _log_fh = open(args.log, "a", buffering=1)
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind((args.host, args.port))
+    srv.listen(128)
+    mode = "STRICT allowlist" if _strict else "denylist-only"
+    log(f"egress-proxy on {args.host}:{args.port} mode={mode}; "
+        f"deny={len(DENY_SUFFIXES)} suffixes"
+        + (f", allow={len(ALLOW_SUFFIXES)} suffixes" if _strict else ""))
+    log("residual gaps (hostname-only): github.com mirror clones + "
+        "huggingface.co/HKasar1239 -> canary/benchmark-host GREP stays mandatory")
+    try:
+        while True:
+            client, addr = srv.accept()
+            threading.Thread(target=handle_client, args=(client, addr),
+                             daemon=True).start()
+    except KeyboardInterrupt:
+        log("shutting down")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/package-for-vm.sh
+++ b/benchmarks/package-for-vm.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Package everything needed to run the agav benchmark on a native amd64 VM into a
+# single tarball, so the (private) agav source never has to leave this machine.
+#
+# The bundle contains benchmarks/ (adapter package, run/verify/upload scripts,
+# tasks.txt) plus the PREBUILT agav binaries in agav-agent/bin/. It deliberately
+# excludes the local .venv (rebuilt on the VM) and any jobs/ output.
+#
+# On the VM you only need Docker + uv; build-binary.sh will detect the prebuilt
+# binary and skip building (the agav source is not shipped).
+#
+# Usage:
+#   benchmarks/package-for-vm.sh              # -> ./agav-benchmarks-vm.tgz
+#   OUT=/tmp/foo.tgz benchmarks/package-for-vm.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUT="${OUT:-${REPO_ROOT}/agav-benchmarks-vm.tgz}"
+
+# The amd64 VM runs amd64 containers, so the x64 binary is mandatory. Build it
+# first if we have the source (no-op if already up to date); otherwise require it.
+BIN_X64="${SCRIPT_DIR}/agav-agent/bin/agav-linux-x64"
+if [[ ! -f "${BIN_X64}" ]]; then
+  if [[ -d "${REPO_ROOT}/source" ]]; then
+    echo "Prebuilt x64 binary missing; building it from local source..."
+    ARCHES="x64" "${SCRIPT_DIR}/agav-agent/build-binary.sh"
+  else
+    echo "error: ${BIN_X64} not found and no agav source to build it from." >&2
+    echo "       Run this on a machine with the agav checkout (or build-binary.sh) first." >&2
+    exit 1
+  fi
+fi
+
+echo "Packaging benchmarks/ -> ${OUT}"
+# Bundle benchmarks/ (with a top-level 'benchmarks/' path on extraction),
+# excluding the venv, job output, and python build cruft.
+tar \
+  --exclude='benchmarks/.venv' \
+  --exclude='benchmarks/jobs' \
+  --exclude='benchmarks/**/__pycache__' \
+  --exclude='benchmarks/**/*.egg-info' \
+  --exclude='benchmarks/**/.pytest_cache' \
+  --exclude='benchmarks/agav-benchmarks-vm.tgz' \
+  -C "${REPO_ROOT}" -czf "${OUT}" benchmarks
+
+size="$(du -sh "${OUT}" | cut -f1)"
+echo "-------------------------------------------------------------"
+echo "Bundle : ${OUT} (${size})"
+echo
+echo "Next (on an amd64 Linux VM with Docker + uv installed):"
+echo "  scp ${OUT} user@<vm>:~/"
+echo "  ssh user@<vm>"
+echo "  tar -xzf agav-benchmarks-vm.tgz && cd benchmarks"
+echo "  uv venv .venv && source .venv/bin/activate && uv pip install -e agav-agent"
+echo "  export OPENAI_API_KEY=sk-...            # gpt-5.5 key"
+echo "  cd .. && EXTRA='-k 1' ./benchmarks/run-tasks.sh --all   # smoke test first"
+echo "  ./benchmarks/verify-run.sh"
+echo "  ./benchmarks/run-tasks.sh --all         # real -k 5 run"
+echo "  harbor auth login && PUBLIC=1 ./benchmarks/upload.sh"

--- a/benchmarks/run-tasks.sh
+++ b/benchmarks/run-tasks.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Run Terminal-Bench 2.1 tasks (by name, or the whole board with --all) via Harbor.
+#
+# This script is self-contained in the benchmarks/ folder and does not touch
+# anything else in the repo. It only shells out to `harbor`.
+#
+# Usage:
+#   ./run-tasks.sh                        # runs every task listed in tasks.txt
+#   ./run-tasks.sh task-a task-b          # runs the task names you pass as args
+#   ./run-tasks.sh --all                  # runs the WHOLE dataset (all 89 tasks)
+#   ./run-tasks.sh -m gpt-5.5 task-a      # -m/--model and -a/--agent are flags
+#   AGENT=oracle ./run-tasks.sh task-a    # env vars also work (flags win)
+#
+# --all is the leaderboard-submission mode: it drops the per-task filter and runs
+# every task in the dataset with 5 trials each (-k 5, the Terminal-Bench 2.1
+# minimum). Override the trial count via EXTRA, e.g. EXTRA="-k 1" for a cheap
+# full-board smoke test. --all cannot be combined with explicit task names.
+#
+# RESUMABLE runs: set JOB_NAME to pin the output dir (jobs/<JOB_NAME>). If the run
+# is interrupted, re-run the IDENTICAL command and harbor skips completed trials
+# and finishes the rest. Example:
+#   JOB_NAME=tb21-agav-full ./run-tasks.sh --all      # resume-safe -k 5 run
+# Use a DIFFERENT JOB_NAME for the -k 1 smoke test (configs must match to resume).
+#
+# A --model without a provider prefix defaults to openai/ (e.g. gpt-5.5 ->
+# openai/gpt-5.5). Task names may be bare (auto-matched as */name).
+#
+# Environment overrides:
+#   AGENT    Harbor agent to use            (default: agav)
+#            AGENT=agav benchmarks the agav CLI (a locally-built binary is
+#            uploaded into each container; built automatically via build-binary.sh).
+#            Set AGENT=oracle to sanity-check a task with its known-good solution.
+#   MODEL    Model identifier for the agent (default: openai/gpt-5.5)
+#   DATASET  Dataset identifier             (default: terminal-bench/terminal-bench-2-1)
+#   EXTRA    Extra flags passed to harbor   (default: empty), e.g. EXTRA="-n 2"
+#
+# Prerequisites:
+#   - Docker running
+#   - Harbor installed:  uv tool install harbor   (or: pipx install harbor)
+#   - To benchmark agav (AGENT=agav): install the adapter into Harbor's env first:
+#       uv pip install -e benchmarks/agav-agent
+#     and export the provider key, e.g. ANTHROPIC_API_KEY. See benchmarks/README.md.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASKS_FILE="${SCRIPT_DIR}/tasks.txt"
+
+AGENT="${AGENT:-agav}"
+MODEL="${MODEL:-openai/gpt-5.5}"
+DATASET="${DATASET:-terminal-bench/terminal-bench-2-1}"
+EXTRA="${EXTRA:-}"
+ALL="${ALL:-}"
+# Pin a job name to make a run RESUMABLE: harbor stores it at jobs/<JOB_NAME> and,
+# if interrupted, re-running the IDENTICAL command skips completed trials and only
+# runs the rest. Unset -> harbor uses a fresh timestamp each run (not resumable).
+JOB_NAME="${JOB_NAME:-}"
+
+# --- parse args: -m/--model, -a/--agent are flags; the rest are task names --
+# Any non-flag args override tasks.txt. Flags override the MODEL/AGENT env vars.
+tasks=()
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -m|--model)
+      MODEL="${2:-}"; shift 2 ;;
+    --model=*)
+      MODEL="${1#*=}"; shift ;;
+    -a|--agent)
+      AGENT="${2:-}"; shift 2 ;;
+    --agent=*)
+      AGENT="${1#*=}"; shift ;;
+    --all)
+      ALL=1; shift ;;
+    --)
+      shift; while [[ "$#" -gt 0 ]]; do tasks+=("$1"); shift; done ;;
+    -*)
+      echo "error: unknown flag '$1'. Supported: -m/--model, -a/--agent, --all." >&2
+      exit 2 ;;
+    *)
+      tasks+=("$1"); shift ;;
+  esac
+done
+
+# --all runs the whole dataset (no per-task filter). It's mutually exclusive with
+# naming tasks, so a stray arg can't silently narrow a "full board" submission.
+if [[ -n "${ALL}" && "${#tasks[@]}" -gt 0 ]]; then
+  echo "error: --all runs the whole dataset and cannot be combined with task names (${tasks[*]})." >&2
+  exit 2
+fi
+
+# A model without a provider prefix defaults to the openai provider.
+if [[ -n "${MODEL}" && "${MODEL}" != */* ]]; then
+  MODEL="openai/${MODEL}"
+fi
+
+# No task args given -> fall back to tasks.txt (unless --all runs everything).
+if [[ -z "${ALL}" && "${#tasks[@]}" -eq 0 ]]; then
+  if [[ ! -f "${TASKS_FILE}" ]]; then
+    echo "error: no tasks given and ${TASKS_FILE} not found" >&2
+    exit 1
+  fi
+  while IFS= read -r line; do
+    line="${line%%#*}"                 # strip inline/full-line comments
+    line="$(echo "${line}" | xargs)"   # trim surrounding whitespace
+    [[ -z "${line}" ]] && continue
+    tasks+=("${line}")
+  done < "${TASKS_FILE}"
+fi
+
+if [[ -z "${ALL}" && "${#tasks[@]}" -eq 0 ]]; then
+  echo "error: no task names to run. Add names to tasks.txt, pass them as arguments," >&2
+  echo "       or use --all to run the whole dataset." >&2
+  echo "example: ./run-tasks.sh some-task-name" >&2
+  exit 1
+fi
+
+# --- preflight checks ------------------------------------------------------
+if ! command -v harbor >/dev/null 2>&1; then
+  echo "error: 'harbor' not found. Install it with:  uv tool install harbor" >&2
+  exit 127
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "error: Docker does not appear to be running. Start Docker and retry." >&2
+  exit 1
+fi
+
+# Provider API key must be set on the host: the agav adapter only forwards a
+# key into the container if it exists here. A missing key otherwise surfaces as
+# an opaque NonZeroAgentExitCodeError for every task. The 'oracle' agent replays
+# the reference solution and needs no model key, so skip the check for it.
+if [[ "${AGENT}" != "oracle" ]]; then
+  provider="${MODEL%%/*}"
+  case "${provider}" in
+    google|google-gemini|googleai) provider="gemini" ;;
+  esac
+  case "${provider}" in
+    anthropic)      required_keys=("ANTHROPIC_API_KEY") ;;
+    openai)         required_keys=("OPENAI_API_KEY") ;;
+    gemini)         required_keys=("GEMINI_API_KEY") ;;
+    ollama)         required_keys=() ;;  # local; no API key needed
+    *)              required_keys=() ;;  # unknown provider: let the agent decide
+  esac
+  for key in "${required_keys[@]}"; do
+    if [[ -z "${!key:-}" ]]; then
+      echo "error: \$${key} is not set, but model '${MODEL}' (provider '${provider}') needs it." >&2
+      echo "       Export it and retry, e.g.:  export ${key}=\"sk-...\"" >&2
+      exit 1
+    fi
+  done
+fi
+
+# --- build the --include-task-name flags -----------------------------------
+# Harbor matches the FULL task name (e.g. "terminal-bench/fix-git") with fnmatch.
+# So a bare name like "fix-git" is auto-wrapped into a "*/fix-git" glob. Names
+# that already contain "/" or a glob char (* ? [) are passed through untouched.
+# In --all mode there are no task names, so include_flags stays empty and harbor
+# runs the whole dataset. (Guard the loop for set -u + bash 3.2 empty arrays.)
+include_flags=()
+for t in ${tasks[@]+"${tasks[@]}"}; do
+  if [[ "${t}" == */* || "${t}" == *[\*\?\[]* ]]; then
+    pattern="${t}"
+  else
+    pattern="*/${t}"
+  fi
+  include_flags+=(--include-task-name "${pattern}")
+done
+
+# Full-board runs need >=5 trials/task for the leaderboard; default to -k 5 unless
+# the caller already set a trial count via EXTRA (e.g. EXTRA="-k 1" for a smoke test).
+trials_flags=()
+if [[ -n "${ALL}" && " ${EXTRA} " != *" -k "* && " ${EXTRA} " != *" --n-attempts "* ]]; then
+  trials_flags=(-k 5)
+fi
+
+# Pin the job name (resumable run) when JOB_NAME is set. Don't also pass one via
+# EXTRA, or harbor gets a duplicate --job-name.
+job_name_flags=()
+if [[ -n "${JOB_NAME}" ]]; then
+  job_name_flags=(--job-name "${JOB_NAME}")
+fi
+
+# --- select built-in agent vs the agav custom-agent import path ------------
+# `--agent` (`-a`) accepts both built-in names and "module:Class" import paths.
+agent_flags=()
+if [[ "${AGENT}" == "agav" ]]; then
+  agent_flags=(-a "agav_terminal_bench:AgavAgent")
+  # agav's repo is private, so we can't clone it in-container. Build a local
+  # single-file binary (cached; rebuilt only when sources change) which the
+  # adapter uploads into each task container.
+  echo "Ensuring agav binary is built (build-binary.sh)..."
+  "${SCRIPT_DIR}/agav-agent/build-binary.sh"
+  echo "-------------------------------------------------------------"
+else
+  agent_flags=(-a "${AGENT}")
+fi
+
+echo "Dataset : ${DATASET}"
+echo "Agent   : ${AGENT}"
+echo "Model   : ${MODEL}"
+if [[ -n "${ALL}" ]]; then
+  echo "Tasks   : (all — whole dataset)${trials_flags[@]+ ${trials_flags[*]}}"
+else
+  echo "Tasks   : ${tasks[*]}"
+fi
+if [[ -n "${JOB_NAME}" ]]; then
+  echo "Job     : ${JOB_NAME} (resumable — re-run the same command to continue)"
+fi
+echo "-------------------------------------------------------------"
+
+# shellcheck disable=SC2086  # EXTRA is intentionally word-split
+harbor run \
+  -d "${DATASET}" \
+  "${agent_flags[@]}" \
+  -m "${MODEL}" \
+  ${include_flags[@]+"${include_flags[@]}"} \
+  ${trials_flags[@]+"${trials_flags[@]}"} \
+  ${job_name_flags[@]+"${job_name_flags[@]}"} \
+  ${EXTRA}

--- a/benchmarks/tasks.txt
+++ b/benchmarks/tasks.txt
@@ -1,0 +1,24 @@
+# Terminal-Bench 2.1 tasks to run — one task name per line.
+# Lines starting with '#' and blank lines are ignored.
+# (To run the WHOLE board instead of this list, use: ./run-tasks.sh --all)
+#
+# Put the exact task NAMES here (the harness filters with --include-task-name).
+# Find available task names by listing the dataset (see README.md), e.g.:
+#   harbor run -d terminal-bench/terminal-bench-2-1 -a oracle --dry-run
+#
+# Replace the examples below with the tasks you actually want:
+
+# example-task-one
+# example-task-two
+
+cobol-modernization
+fix-git
+overfull-hbox
+prove-plus-comm
+adaptive-rejection-sampler
+break-filter-js-from-html
+build-cython-ext
+build-pmars
+sanitize-git-repo
+rstan-to-pystan
+portfolio-optimization

--- a/benchmarks/upload.sh
+++ b/benchmarks/upload.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Upload a Harbor job's results to the Harbor Hub, attributed to our org by
+# default. Harbor has no persistent "default org" setting and `harbor run` takes
+# no org at all — the org is only ever attached at UPLOAD time via --share-org.
+# So this wrapper bakes that default in: every upload is shared with `prapaa`
+# unless overridden.
+#
+# Usage:
+#   ./upload.sh                       # upload the most recent job dir (jobs/*)
+#   ./upload.sh jobs/2026-08-03__...  # upload a specific job dir
+#   PUBLIC=1 ./upload.sh <job_dir>    # publish to the public leaderboard
+#   ORG="teamA teamB" ./upload.sh ... # share with other/multiple orgs
+#   ORG="" ./upload.sh <job_dir>      # upload with no org share (owner only)
+#
+# Visibility defaults to PRIVATE so nothing lands on the public leaderboard by
+# accident. Set PUBLIC=1 for a real leaderboard submission.
+#
+# Environment overrides:
+#   ORG      Org(s) to share with (space-separated)  (default: prapaa)
+#   PUBLIC   1 -> --public, else --private           (default: unset -> private)
+#   HARBOR   harbor executable                        (default: auto-detected)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ORG="${ORG-prapaa}"          # default org; ORG="" disables sharing
+PUBLIC="${PUBLIC:-}"
+
+# Resolve the harbor executable: prefer one on PATH, else the repo venv.
+HARBOR="${HARBOR:-}"
+if [[ -z "${HARBOR}" ]]; then
+  if command -v harbor >/dev/null 2>&1; then
+    HARBOR="harbor"
+  elif [[ -x "${REPO_ROOT}/.venv/bin/harbor" ]]; then
+    HARBOR="${REPO_ROOT}/.venv/bin/harbor"
+  else
+    echo "error: 'harbor' not found on PATH or in ${REPO_ROOT}/.venv/bin." >&2
+    echo "       Install it with:  uv tool install harbor" >&2
+    exit 127
+  fi
+fi
+
+# Job dir: first non-flag arg, else the most recent under jobs/.
+JOB_DIR="${1:-}"
+if [[ -z "${JOB_DIR}" ]]; then
+  JOB_DIR="$(ls -dt "${REPO_ROOT}"/jobs/*/ 2>/dev/null | head -1 || true)"
+  if [[ -z "${JOB_DIR}" ]]; then
+    echo "error: no job dir given and none found under ${REPO_ROOT}/jobs/." >&2
+    echo "       Run a benchmark first (./run-tasks.sh) or pass a job dir." >&2
+    exit 1
+  fi
+  JOB_DIR="${JOB_DIR%/}"
+  echo "No job dir given; using most recent: ${JOB_DIR}"
+fi
+if [[ ! -d "${JOB_DIR}" ]]; then
+  echo "error: job dir not found: ${JOB_DIR}" >&2
+  exit 1
+fi
+
+# Must be authenticated to upload.
+if ! "${HARBOR}" auth status >/dev/null 2>&1; then
+  echo "error: not authenticated. Run:  ${HARBOR} auth login" >&2
+  exit 1
+fi
+
+# Assemble flags.
+upload_flags=()
+if [[ -n "${PUBLIC}" ]]; then
+  upload_flags+=(--public)
+else
+  upload_flags+=(--private)
+fi
+for org in ${ORG}; do
+  upload_flags+=(--share-org "${org}")
+done
+
+echo "Harbor     : ${HARBOR}"
+echo "Job dir    : ${JOB_DIR}"
+echo "Visibility : $([[ -n "${PUBLIC}" ]] && echo public || echo private)"
+echo "Share orgs : ${ORG:-<none>}"
+echo "-------------------------------------------------------------"
+
+exec "${HARBOR}" upload "${JOB_DIR}" "${upload_flags[@]}"

--- a/benchmarks/verify-run.sh
+++ b/benchmarks/verify-run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Verify a Harbor job produced valid ATIF trajectories (and a reward) for every
+# trial. Use this after ./run-tasks.sh to confirm the agav adapter emitted a
+# leaderboard-eligible trajectory.json per trial BEFORE uploading.
+#
+# For each trial dir it checks:
+#   - agent/agav.txt              (raw agav log)
+#   - agent/agav-trajectory.json  (agav's native transcript)
+#   - agent/trajectory.json       (Harbor ATIF — the one CI/judge audits)
+# and validates the ATIF file against Harbor's own Trajectory model (strict).
+# It also prints each trial's reward from result.json, and totals up token usage
+# + estimated $ cost across the whole job (with a projection to a full 89x5 run).
+#
+# Usage:
+#   ./verify-run.sh                 # verify the most recent job under jobs/
+#   ./verify-run.sh jobs/<job-dir>  # verify a specific job dir
+#
+# Cost rates default to gpt-5.5 ($/1M tokens); override any via env vars, e.g.
+# P_OUT=45 for long-context output. Short-context: P_IN/P_CACHED/P_OUT; the
+# long-context tier is shown too via P_IN_LONG/P_CACHED_LONG/P_OUT_LONG.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Resolve a python that can import harbor (prefer the repo venv).
+PY="${REPO_ROOT}/.venv/bin/python"
+if [[ ! -x "${PY}" ]]; then PY="python3"; fi
+
+# gpt-5.5 pricing ($ per 1M tokens). Cached input is a subset of input billed at
+# the cached rate; gpt-5.5 has no separate cache-write charge. Override via env.
+P_IN="${P_IN:-5.00}";        P_CACHED="${P_CACHED:-0.50}";        P_OUT="${P_OUT:-30.00}"
+P_IN_LONG="${P_IN_LONG:-10.00}"; P_CACHED_LONG="${P_CACHED_LONG:-1.00}"; P_OUT_LONG="${P_OUT_LONG:-45.00}"
+
+# Full-board size for the cost projection (Terminal-Bench 2.1: 89 tasks x 5 trials).
+FULL_RUN_TRIALS="${FULL_RUN_TRIALS:-445}"
+
+JOB_DIR="${1:-}"
+if [[ -z "${JOB_DIR}" ]]; then
+  JOB_DIR="$(ls -dt "${REPO_ROOT}"/jobs/*/ 2>/dev/null | head -1 || true)"
+  [[ -z "${JOB_DIR}" ]] && { echo "error: no job dir found under ${REPO_ROOT}/jobs/. Run ./run-tasks.sh first." >&2; exit 1; }
+  JOB_DIR="${JOB_DIR%/}"
+  echo "No job dir given; using most recent: ${JOB_DIR}"
+fi
+[[ -d "${JOB_DIR}" ]] || { echo "error: job dir not found: ${JOB_DIR}" >&2; exit 1; }
+
+echo "Job dir : ${JOB_DIR}"
+echo "-------------------------------------------------------------"
+
+fail=0
+trials=0
+sum_p=0   # total input (prompt) tokens, includes cached
+sum_c=0   # total cached input tokens (subset of sum_p)
+sum_o=0   # total output (completion) tokens
+for trial in "${JOB_DIR}"/*/; do
+  [[ -f "${trial}result.json" ]] || continue   # only real trial dirs
+  trials=$((trials + 1))
+  name="$(basename "${trial}")"
+  agent_dir="${trial}agent"
+
+  # Reward (from result.json) + token totals (from the ATIF trajectory.json),
+  # emitted as one tab-separated line: reward<TAB>prompt<TAB>cached<TAB>completion.
+  stats="$("${PY}" - "${trial}result.json" "${agent_dir}/trajectory.json" <<'PY' 2>/dev/null || printf '?\t0\t0\t0\n'
+import json, sys
+
+def load(path):
+    try:
+        return json.load(open(path))
+    except Exception:
+        return {}
+
+res = load(sys.argv[1])
+# Harbor stores reward at verifier_result.rewards.reward; fall back to older shapes.
+r = (res.get("verifier_result") or {}).get("rewards", {}).get("reward")
+if r is None:
+    r = res.get("reward", (res.get("metrics") or {}).get("reward"))
+
+fm = (load(sys.argv[2]).get("final_metrics")) or {}
+p = fm.get("total_prompt_tokens") or 0
+c = fm.get("total_cached_tokens") or 0
+o = fm.get("total_completion_tokens") or 0
+print(f"{r if r is not None else '?'}\t{p}\t{c}\t{o}")
+PY
+)"
+  IFS=$'\t' read -r reward p_tok c_tok o_tok <<<"${stats}"
+  # Coerce token fields to integers (guard blanks / non-numeric / missing file).
+  [[ "${p_tok:-}" =~ ^[0-9]+$ ]] || p_tok=0
+  [[ "${c_tok:-}" =~ ^[0-9]+$ ]] || c_tok=0
+  [[ "${o_tok:-}" =~ ^[0-9]+$ ]] || o_tok=0
+  reward="${reward:-?}"
+  sum_p=$(( sum_p + p_tok ))
+  sum_c=$(( sum_c + c_tok ))
+  sum_o=$(( sum_o + o_tok ))
+  tok="tok in=${p_tok}/out=${o_tok}/cached=${c_tok}"
+
+  miss=()
+  [[ -f "${agent_dir}/agav.txt" ]]             || miss+=("agav.txt")
+  [[ -f "${agent_dir}/agav-trajectory.json" ]] || miss+=("agav-trajectory.json")
+  [[ -f "${agent_dir}/trajectory.json" ]]      || miss+=("trajectory.json")
+
+  atif_ok="—"
+  if [[ -f "${agent_dir}/trajectory.json" ]]; then
+    if "${PY}" - "${agent_dir}/trajectory.json" <<'PY' >/dev/null 2>&1
+import sys
+from harbor.models.trajectories import Trajectory
+Trajectory.model_validate_json(open(sys.argv[1]).read())
+PY
+    then atif_ok="valid"; else atif_ok="INVALID"; fail=1; fi
+  fi
+
+  if [[ ${#miss[@]} -gt 0 || "${atif_ok}" == "INVALID" ]]; then
+    fail=1
+    echo "  ✗ ${name}  reward=${reward}  ATIF=${atif_ok}  ${tok}  missing: ${miss[*]:-none}"
+  else
+    echo "  ✓ ${name}  reward=${reward}  ATIF=${atif_ok}  ${tok}"
+  fi
+done
+
+echo "-------------------------------------------------------------"
+[[ ${trials} -eq 0 ]] && { echo "error: no trials with result.json under ${JOB_DIR}" >&2; exit 1; }
+
+# --- token + cost summary ---------------------------------------------------
+# fresh (uncached) input = total prompt tokens minus the cached subset.
+fresh=$(( sum_p - sum_c )); (( fresh < 0 )) && fresh=0
+awk -v prompt="${sum_p}" -v fresh="${fresh}" -v cached="${sum_c}" -v out="${sum_o}" \
+    -v trials="${trials}" -v full="${FULL_RUN_TRIALS}" \
+    -v pin="${P_IN}"   -v pc="${P_CACHED}"   -v pout="${P_OUT}" \
+    -v pinL="${P_IN_LONG}" -v pcL="${P_CACHED_LONG}" -v poutL="${P_OUT_LONG}" 'BEGIN {
+  short = fresh/1e6*pin  + cached/1e6*pc  + out/1e6*pout;
+  long  = fresh/1e6*pinL + cached/1e6*pcL + out/1e6*poutL;
+  per   = (trials > 0) ? short/trials : 0;
+  perL  = (trials > 0) ? long/trials  : 0;
+  printf "Tokens  : input=%d (fresh=%d + cached=%d)  output=%d  total=%d\n", prompt, fresh, cached, out, prompt+out;
+  printf "Cost    : short-ctx $%.2f   |   long-ctx $%.2f   (gpt-5.5 rates, %d trial(s))\n", short, long, trials;
+  printf "Per-tr. : short-ctx $%.4f  |   long-ctx $%.4f\n", per, perL;
+  printf "Project : full %d-trial run -> short-ctx $%.2f   |   long-ctx $%.2f\n", full, per*full, perL*full;
+}'
+echo "-------------------------------------------------------------"
+
+if [[ ${fail} -ne 0 ]]; then
+  echo "RESULT: problems found (see ✗ above). Do NOT submit until every trial has a valid ATIF trajectory."
+  exit 1
+fi
+echo "RESULT: all ${trials} trial(s) have a valid ATIF trajectory.json ✅"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A terminal-native environment for running local AI systems",
   "type": "module",
   "bin": {

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -5,7 +5,6 @@ import { isEffortLevel, loadConfig, type AgavConfig } from "./config/config.js";
 import { createProvider } from "./providers/registry.js";
 import type { LLMProvider } from "./providers/types.js";
 import { buildSystemPrompt } from "./utils/system-prompt.js";
-import { expandFileMentions } from "./utils/file-mentions.js";
 import { loadSessionState, markCleanExit } from "./config/session-state.js";
 import { loadTheme } from "./config/theme.js";
 import { ConversationState } from "./agent/conversation.js";
@@ -21,12 +20,14 @@ import {
   validateOutput,
   type OutputSchema,
 } from "./utils/output-schema.js";
+import { writeAgavTrajectory, type AgavRunUsage } from "./utils/trajectory.js";
 
 const KNOWN_FLAGS = [
   "--help", "-h", "--version", "-v", "--provider", "-p", "--model", "-m",
   "--effort", "--auto-accept", "-y", "--stream", "--output-schema", "--deny-writes",
   "--resume", "-r", "--ollama-host", "--ollama-port", "--ollama-endpoint",
   "--ollama-api-key", "--print", "-P", "--permission", "--openai-api", "--max-turns",
+  "--trajectory",
 ];
 
 function levenshtein(a: string, b: string): number {
@@ -126,6 +127,10 @@ export function parseArgs(argv: string[]) {
       flags.maxTurns = argv[++i] ?? "";
     } else if (arg.startsWith("--max-turns=")) {
       flags.maxTurns = arg.slice("--max-turns=".length);
+    } else if (arg === "--trajectory") {
+      flags.trajectory = argv[++i] ?? "";
+    } else if (arg.startsWith("--trajectory=")) {
+      flags.trajectory = arg.slice("--trajectory=".length);
     } else if (arg === "update" && i === 0) {
       flags.update = true;
       if (argv[i + 1] && !argv[i + 1]!.startsWith("-")) {
@@ -133,7 +138,11 @@ export function parseArgs(argv: string[]) {
       }
     } else if (arg === "run" && i === 0) {
       flags.run = true;
-    } else if (flags.run && !arg.startsWith("-") && !flags.runPrompt) {
+    } else if (flags.run && !flags.runPrompt) {
+      // First positional after `run` is the prompt, even if it starts with
+      // "-" (e.g. an instruction beginning with a markdown bullet). Known
+      // flags are matched by the earlier branches, so anything reaching here
+      // in run mode before a prompt is captured is the prompt itself.
       flags.runPrompt = arg;
     } else if (arg.startsWith("-")) {
       const suggestion = findClosestFlag(arg);
@@ -160,24 +169,22 @@ export async function runPipeMode(
   prompt: string,
   config: AgavConfig,
   provider: LLMProvider,
-  options: { stream?: boolean; outputSchema?: OutputSchema; stdinContent?: string; includeDynamicContext?: boolean; permissionOverride?: import("./config/config.js").PermissionMode; allowedToolsOverride?: string[]; maxTurns?: number } = {},
+  options: { stream?: boolean; outputSchema?: OutputSchema; stdinContent?: string; includeDynamicContext?: boolean; permissionOverride?: import("./config/config.js").PermissionMode; allowedToolsOverride?: string[]; maxTurns?: number; trajectoryPath?: string } = {},
 ): Promise<number> {
   const { stream = false, outputSchema } = options;
   const stdinContent = options.stdinContent ?? await readStdin();
 
-  let expansion;
-  try {
-    expansion = await expandFileMentions(prompt, { cwd: process.cwd() });
-  } catch (err) {
-    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    return 1;
-  }
-  for (const warning of expansion.warnings) process.stderr.write(`Warning: ${warning}\n`);
-
-  let fullPrompt = expansion.expanded;
+  // File @-mention expansion is intentionally disabled in non-interactive
+  // (pipe / `agav run` / `-P`) mode. Here the prompt is a complete instruction
+  // supplied by the caller, so a bare "@word" — e.g. a Vim register (`@a`), a
+  // Python decorator, or an email handle — must pass through literally rather
+  // than being treated as a file attachment (which would abort the run with
+  // "File not found" when no such file exists). Callers that want file contents
+  // in the prompt can pipe them via stdin, which is wrapped below.
+  let fullPrompt = prompt;
   if (stdinContent) {
     const prefix = `<stdin>\n${stdinContent}\n</stdin>\n\n`;
-    fullPrompt = prefix + (expansion.expanded || "Respond to the above input.");
+    fullPrompt = prefix + (prompt || "Respond to the above input.");
   }
 
   if (!fullPrompt) {
@@ -188,7 +195,7 @@ export async function runPipeMode(
   const toolRegistry = createToolRegistry();
   const conversation = new ConversationState();
   conversation.setModel(config.model);
-  conversation.addUserMessage(fullPrompt, expansion.contentBlocks, undefined, prompt);
+  conversation.addUserMessage(fullPrompt, undefined, undefined, prompt);
 
   let effectiveSystemPrompt = config.systemPrompt ?? "";
   if (options.includeDynamicContext) {
@@ -203,6 +210,34 @@ export async function runPipeMode(
     : `${effectiveSystemPrompt}\n\nYour final response MUST be valid JSON matching this schema: ${schemaJson}. Return only the JSON value, with no markdown fences or commentary.`;
 
   const permissionMode = options.permissionOverride ?? "auto-accept";
+
+  // Trajectory capture: accumulate token usage (the loop's `usage` events are
+  // otherwise dropped in pipe mode) and record run timing, so we can emit a
+  // faithful native trajectory after the run regardless of how it exits.
+  const usage: AgavRunUsage = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+  };
+  const startedAt = new Date().toISOString();
+  const flushTrajectory = async (): Promise<void> => {
+    if (!options.trajectoryPath) return;
+    try {
+      await writeAgavTrajectory(options.trajectoryPath, {
+        model: config.model,
+        provider: config.provider,
+        startedAt,
+        finishedAt: new Date().toISOString(),
+        usage,
+        messages: conversation.getMessages(),
+      });
+    } catch (err) {
+      process.stderr.write(
+        `Warning: failed to write trajectory: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  };
 
   const runTurn = async (streamText: boolean): Promise<{ finalText: string; exitCode: number; wroteStreamText: boolean }> => {
     let finalText = "";
@@ -250,6 +285,12 @@ export async function runPipeMode(
           case "compacted":
             process.stderr.write(`  ${icons.warning} Auto-compacted: ${event.droppedCount} messages summarized\n`);
             break;
+          case "usage":
+            usage.input_tokens += event.inputTokens ?? 0;
+            usage.output_tokens += event.outputTokens ?? 0;
+            usage.cache_read_tokens += event.cacheReadTokens ?? 0;
+            usage.cache_write_tokens += event.cacheWriteTokens ?? 0;
+            break;
           case "assistant_message_complete":
             finalText = event.text;
             break;
@@ -281,43 +322,49 @@ export async function runPipeMode(
 
   // Schema output must stay buffered so an invalid first attempt never contaminates stdout.
   let result = await runTurn(stream && outputSchema === undefined);
-  if (result.exitCode !== 0) return result.exitCode;
+  // A trajectory is written on every post-loop exit path (including errors) via
+  // the finally block, so the adapter always has a transcript to convert.
+  try {
+    if (result.exitCode !== 0) return result.exitCode;
 
-  if (outputSchema !== undefined) {
-    let validate;
-    try {
-      validate = createOutputValidator(outputSchema);
-    } catch (error) {
-      process.stderr.write(`Error: Invalid JSON Schema: ${error instanceof Error ? error.message : String(error)}\n`);
-      return 1;
+    if (outputSchema !== undefined) {
+      let validate;
+      try {
+        validate = createOutputValidator(outputSchema);
+      } catch (error) {
+        process.stderr.write(`Error: Invalid JSON Schema: ${error instanceof Error ? error.message : String(error)}\n`);
+        return 1;
+      }
+
+      let validation = validateOutput(result.finalText, validate);
+      if (!validation.valid) {
+        const details = formatValidationErrors(validation);
+        process.stderr.write(`Schema validation failed; retrying once: ${details}\n`);
+        conversation.addUserMessage(
+          `Your previous response was invalid. ${details}\nCorrect it and return ONLY valid JSON matching the required schema, with no markdown fences or commentary.`,
+        );
+        result = await runTurn(false);
+        if (result.exitCode !== 0) return result.exitCode;
+        validation = validateOutput(result.finalText, validate);
+      }
+
+      if (!validation.valid) {
+        process.stderr.write(`Error: Response failed JSON Schema validation after retry: ${formatValidationErrors(validation)}\n`);
+        return 1;
+      }
+      process.stdout.write(`${JSON.stringify(validation.value)}\n`);
+      return 0;
     }
 
-    let validation = validateOutput(result.finalText, validate);
-    if (!validation.valid) {
-      const details = formatValidationErrors(validation);
-      process.stderr.write(`Schema validation failed; retrying once: ${details}\n`);
-      conversation.addUserMessage(
-        `Your previous response was invalid. ${details}\nCorrect it and return ONLY valid JSON matching the required schema, with no markdown fences or commentary.`,
-      );
-      result = await runTurn(false);
-      if (result.exitCode !== 0) return result.exitCode;
-      validation = validateOutput(result.finalText, validate);
+    if (stream && result.wroteStreamText) {
+      process.stdout.write("\n");
+    } else if (result.finalText) {
+      process.stdout.write(result.finalText + "\n");
     }
-
-    if (!validation.valid) {
-      process.stderr.write(`Error: Response failed JSON Schema validation after retry: ${formatValidationErrors(validation)}\n`);
-      return 1;
-    }
-    process.stdout.write(`${JSON.stringify(validation.value)}\n`);
-    return 0;
+    return result.exitCode;
+  } finally {
+    await flushTrajectory();
   }
-
-  if (stream && result.wroteStreamText) {
-    process.stdout.write("\n");
-  } else if (result.finalText) {
-    process.stdout.write(result.finalText + "\n");
-  }
-  return result.exitCode;
 }
 
 export async function main() {
@@ -347,6 +394,7 @@ export async function main() {
     --output-schema      Require pipe-mode output to match an inline JSON Schema or @file
     --openai-api         OpenAI API mode: responses or chat (default: responses)
     --permission         JSON tool permissions for run mode (or set AGAV_PERMISSION env var)
+    --trajectory         Write a native JSON trajectory of the run to the given path
     --resume, -r [id]    Resume a session (list if no id, prefix match if given)
     --auto-accept, -y    Skip tool confirmations
     --deny-writes        Block all write operations
@@ -596,6 +644,7 @@ export async function main() {
     const exitCode = await runPipeMode(String(flags.printPrompt ?? ""), config, provider, {
       stream: flags.stream === true,
       outputSchema,
+      trajectoryPath: typeof flags.trajectory === "string" && flags.trajectory ? flags.trajectory : undefined,
     });
     process.exit(exitCode);
     return;
@@ -607,6 +656,9 @@ export async function main() {
       stream: true,
       includeDynamicContext: true,
     };
+    if (typeof flags.trajectory === "string" && flags.trajectory) {
+      runOptions.trajectoryPath = flags.trajectory;
+    }
 
     // Parse permission from --permission flag or AGAV_PERMISSION env var
     const permissionJson = (typeof flags.permission === "string" && flags.permission)

--- a/source/utils/trajectory.ts
+++ b/source/utils/trajectory.ts
@@ -1,0 +1,68 @@
+import { writeFile } from "node:fs/promises";
+import type { Message, ContentBlock } from "../providers/types.js";
+
+/**
+ * Native "agav trajectory" export used by non-interactive run/print modes.
+ *
+ * This is agav's own on-disk representation of a single run: the ordered
+ * conversation (with tool_use / tool_result content blocks correlated by
+ * toolCallId), aggregate token usage, and run timing. It is intentionally a
+ * faithful dump of agav's internal structures — downstream consumers (e.g. the
+ * Harbor/Terminal-Bench adapter) convert it into whatever interchange format
+ * they need (ATIF, etc.), so we keep the schema here simple and stable.
+ */
+
+export interface AgavRunUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+}
+
+export interface AgavTrajectoryInput {
+  model: string;
+  provider: string;
+  startedAt: string;
+  finishedAt: string;
+  usage: AgavRunUsage;
+  messages: Message[];
+}
+
+/** Copy a content block, dropping large binary image payloads. */
+function sanitizeBlock(block: ContentBlock): ContentBlock {
+  const out: ContentBlock = { type: block.type };
+  if (block.text !== undefined) out.text = block.text;
+  if (block.toolCallId !== undefined) out.toolCallId = block.toolCallId;
+  if (block.toolName !== undefined) out.toolName = block.toolName;
+  if (block.toolInput !== undefined) out.toolInput = block.toolInput;
+  if (block.toolResult !== undefined) out.toolResult = block.toolResult;
+  if (block.isError !== undefined) out.isError = block.isError;
+  if (block.toolResultContent) {
+    out.toolResultContent = block.toolResultContent.map(sanitizeBlock);
+  }
+  // Never serialize base64 image bytes — they bloat the trajectory and add no
+  // value to an auditable transcript. Leave a placeholder instead.
+  if (block.type === "image") {
+    out.text = block.text ?? "[image omitted]";
+  }
+  return out;
+}
+
+/** Serialize a completed run to a native agav trajectory JSON file. */
+export async function writeAgavTrajectory(path: string, data: AgavTrajectoryInput): Promise<void> {
+  const trajectory = {
+    agav_trajectory_version: 1 as const,
+    model: data.model,
+    provider: data.provider,
+    started_at: data.startedAt,
+    finished_at: data.finishedAt,
+    usage: data.usage,
+    messages: data.messages.map((m) => ({
+      role: m.role,
+      ...(m.sourceText ? { sourceText: m.sourceText } : {}),
+      ...(m.displayText ? { displayText: m.displayText } : {}),
+      content: m.content.map(sanitizeBlock),
+    })),
+  };
+  await writeFile(path, JSON.stringify(trajectory, null, 2), "utf-8");
+}


### PR DESCRIPTION
- Updated version in package.json to 0.1.1.
- Added new benchmark scripts: run-tasks.sh, verify-run.sh, upload.sh, and package-for-vm.sh.
- Introduced egress-proxy.py for network control during benchmark runs.
- Created agav-agent for Harbor integration, including build scripts and configuration.
- Added README.md and tasks.txt for benchmark usage instructions.
- Updated .gitignore to include new benchmark-related files and directories.

## Type

<!-- Check one -->

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] Chore

## Testing

<!-- How was this tested? -->

- [ ] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal
- [x] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

## Screenshots / Terminal Output

<!-- If applicable, paste terminal output showing the feature working -->
