### PR TITLE
fix: improve terminal handling for Agav launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A terminal-native environment for running local AI systems",
   "type": "module",
   "bin": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -527,5 +527,14 @@ printf '\nAgav %s installed successfully.\n' "$installed_ver"
 
 if prompt_yes_no "Start Agav now?"; then
   step "Launching Agav"
-  "$BIN_PATH"
+  # Under `curl … | bash` our stdin is the curl pipe, not the terminal. Agav's
+  # UI needs a real TTY, so reattach one — otherwise it dies on raw-mode setup.
+  # `exec` hands the terminal over cleanly instead of nesting under the pipe.
+  if [ -e /dev/tty ] && ( : </dev/tty ) 2>/dev/null; then
+    exec "$BIN_PATH" </dev/tty
+  elif [ -t 0 ]; then
+    exec "$BIN_PATH"
+  else
+    warn "No terminal available to launch Agav. Run: $BIN_PATH"
+  fi
 fi

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -642,6 +642,21 @@ export async function main() {
     return;
   }
 
+  // Every non-interactive path has returned by now, so the Ink UI is next.
+  // Ink needs raw mode, which requires a TTY — without this guard a piped
+  // stdin (e.g. the installer launching us from `curl … | bash`) surfaces as
+  // an unreadable React stack trace instead of an actionable message.
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      "\n  Agav's interactive UI needs a terminal, but stdin is not a TTY.\n\n" +
+        "    • Run `agav` directly from your shell.\n" +
+        "    • For piped or scripted use:  agav -P \"your prompt\"\n" +
+        "    • Just installed via `curl … | bash`? That pipe is still attached —\n" +
+        "      open your terminal and run `agav`.\n\n",
+    );
+    process.exit(1);
+  }
+
   /** Print a subtle reminder pointing at the most recent resumable session. */
   async function showResumeHint() {
     try {


### PR DESCRIPTION
- Added checks to ensure Agav's UI can run in a proper TTY environment when launched from a pipe.
- Enhanced error messaging for non-interactive scenarios, guiding users on how to run Agav directly or with prompts.

## Type

<!-- Check one -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

<!-- How was this tested? -->

- [ ] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)
