### PR TITLE
fix(install): keep install.ps1 pure ASCII so PowerShell 5.1 can parse it

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,3 +1,8 @@
+# Keep this file pure ASCII. install.cmd fetches it with Invoke-WebRequest,
+# which writes raw bytes, and Windows PowerShell 5.1 decodes a BOM-less -File
+# script as Windows-1252. A UTF-8 char whose trailing byte is 0x93/0x94 then
+# becomes a smart quote, which the parser accepts as a string delimiter and
+# the whole script fails to parse.
 $ErrorActionPreference = "Stop"
 
 $Repo = "prapaa-ai/agav"
@@ -70,7 +75,7 @@ $TmpFile = Join-Path $InstallDir "$BinaryName.tmp"
 try {
     Invoke-WebRequest -Uri $DownloadUrl -OutFile $TmpFile -UseBasicParsing
 } catch {
-    Write-Error "Download failed — release not found for $Target"
+    Write-Error "Download failed - release not found for $Target"
     Write-Error "Check available releases: https://github.com/$Repo/releases"
     if (Test-Path $TmpFile) { Remove-Item $TmpFile -Force }
     exit 1
@@ -82,9 +87,9 @@ Move-Item -Path $TmpFile -Destination $FinalPath -Force
 # --- Verify ---
 try {
     $InstalledVer = & $FinalPath --version 2>&1 | Select-String -Pattern '\d+\.\d+\.\d+' | ForEach-Object { $_.Matches[0].Value }
-    Write-Host "✓ Agav v$InstalledVer installed to $FinalPath" -ForegroundColor Green
+    Write-Host "Agav v$InstalledVer installed to $FinalPath" -ForegroundColor Green
 } catch {
-    Write-Host "✓ Agav installed to $FinalPath" -ForegroundColor Green
+    Write-Host "Agav installed to $FinalPath" -ForegroundColor Green
 }
 
 # --- PATH check ---


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR does and why -->

- Every Windows install via `install.cmd` currently fails with a PowerShell **parse error** before a single line executes, so the installer is completely broken on Windows.
- Root cause: `scripts/install.ps1` contained three non-ASCII characters. `install.cmd` downloads the script with `Invoke-WebRequest -OutFile` (raw bytes, no BOM) and runs it with `powershell.exe -File`. Windows PowerShell 5.1 decodes a BOM-less script using the **ANSI code page (CP1252)**, not UTF-8 — and the trailing bytes of those characters land on `0x93`/`0x94`, which are the curly quotes `“` / `”`. PowerShell accepts curly quotes as **string delimiters**, so quote parity flips mid-file and everything after it misparses.
- Fix: make the file pure ASCII, and record the constraint in a header comment so the next `✓` or `—` doesn't silently reintroduce it.

## Changes

<!-- List the key changes made -->

- `scripts/install.ps1` L73 — `Download failed — release not found` → `Download failed - release not found` (U+2014 em dash → ASCII hyphen)
- `scripts/install.ps1` L85, L87 — dropped the `✓` (U+2713) glyph from the two success messages; both already print in green, so the success signal is preserved
- `scripts/install.ps1` — added a 5-line header comment explaining why the file must stay ASCII

No behaviour change beyond the two cosmetic message tweaks. No other files touched.

### The offending bytes

| Line | Char | UTF-8 | Trailing byte → CP1252 |
| --- | --- | --- | --- |
| 73 | `—` U+2014 | `E2 80 94` | `0x94` → `”` |
| 85 | `✓` U+2713 | `E2 9C 93` | `0x93` → `“` |
| 87 | `✓` U+2713 | `E2 9C 93` | `0x93` → `“` |

Parity flips at L85: the straight `"` opens a string, the decoded `“` closes it immediately, and the next `"` opens a *new* string that swallows `-ForegroundColor Green` and `} catch {`.

## Related Issues

<!-- Link related issues: Closes #N, Fixes #N, or Relates to #N -->

_None filed — reported directly._

## Type

<!-- Check one -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

<!-- How was this tested? -->

- [ ] `npx tsc --noEmit` passes — _N/A, no TypeScript changed_
- [ ] Manually tested in terminal — **not yet verified on Windows; see below**
- [ ] Tested with `--provider openai` — _N/A_
- [ ] Tested with `--provider anthropic` — _N/A_
- [ ] Tested with `--provider ollama` — _N/A_
- [ ] Tested pipe mode (`-P`) — _N/A_

What **was** verified:

- `scripts/install.ps1` and `scripts/install.cmd` contain no bytes outside printable ASCII + tab
- Every line of `install.ps1` has an even number of `"` (quote-parity check)
- Confirmed the live `main` copy still serves the bad bytes, i.e. this reproduces for all users:
  ```
  curl -fsSL https://raw.githubusercontent.com/prapaa-ai/agav/main/scripts/install.ps1 \
    | LC_ALL=C grep -n '[^ -~\t]'
  73:    Write-Error "Download failed M-bM-^@M-^T release not found for $Target"
  85:    Write-Host "M-bM-^\M-^S Agav v$InstalledVer installed to $FinalPath" ...
  87:    Write-Host "M-bM-^\M-^S Agav installed to $FinalPath" ...
  ```

What still needs a human:

- **A real Windows run of `install.cmd`.** The fix was not parse-checked by PowerShell — `pwsh` isn't available on the dev machine, so verification here is byte-level only.

Post-merge check (should print nothing):

```shell
curl -fsSL https://raw.githubusercontent.com/prapaa-ai/agav/main/scripts/install.ps1 \
  | LC_ALL=C grep -n '[^ -~\t]'
```

## Screenshots / Terminal Output

<!-- If applicable, paste terminal output showing the feature working -->

Before — `install.cmd` on Windows:

```
At C:\Users\...\AppData\Local\Temp\agav-install-17644-5840.ps1:93 char:73
+ ... ent]::SetEnvironmentVariable("PATH", "$InstallDir;$UserPath", "User")
+                                                                ~~~~
Unexpected token '", "' in expression or statement.
At ...:99 char:51
+ ... Write-Host "agav -> Run 'agav' to get started." -ForegroundColor Cyan
The string is missing the terminator: ".
At ...:86 char:9
+ } catch {
Missing closing '}' in statement block or type definition.
Catch block must be the last catch block.
    + FullyQualifiedErrorId : UnexpectedToken
```

Those line numbers (86 / 93 / 99) match `main`'s 100-line `install.ps1` exactly.

---

### Notes for reviewers — out of scope, follow-ups worth filing

1. **`install.cmd` needs no republishing.** It hardcodes `raw.githubusercontent.com/.../main/scripts/install.ps1` and resolves it at run time, so merging this unblocks every Windows user immediately — including anyone with an already-downloaded `install.cmd`. No release tag required.
2. **`https://agav.dev/install.ps1` is a separate stale artifact.** It 308s to `www.agav.dev` and is served as `application/octet-stream`, not proxied from GitHub — merging will not update it. It's the route documented in `README.md:40` (`irm https://agav.dev/install.ps1 | iex`). That path likely still *works* today, since `irm | iex` executes a decoded string rather than a BOM-less file, but it should be redeployed to stay in sync.
3. **Hardening, deliberately not included here:** stamping a UTF-8 BOM onto the temp file in `install.cmd` would make the ASCII rule unnecessary rather than load-bearing, and a CI grep for non-ASCII in `scripts/install.ps1` would enforce it rather than rely on the comment.
4. **Pre-existing bug in the download-failure path** (`install.ps1` L77-82): with `$ErrorActionPreference = "Stop"`, the first `Write-Error` in the `catch` throws a terminating error, so the "Check available releases" message, the `agav.exe.tmp` cleanup, and `exit 1` never run. Untouched here — unrelated to the parse error.
