### PR TITLE
feat(windows): publish agav-windows-x64.exe and document uninstall

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
             os: ubuntu-latest
           - target: linux-arm64
             os: ubuntu-latest
+          # Bun cross-compiles, so no Windows runner is needed. `ext` is empty
+          # for every other target. No windows-arm64: Bun has no such target.
+          - target: windows-x64
+            os: ubuntu-latest
+            ext: .exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -68,9 +73,9 @@ jobs:
         run: |
           mkdir -p dist
           if [ "${{ matrix.target }}" = "$(uname -s | tr A-Z a-z)-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')" ]; then
-            bun build source/cli.tsx --compile --outfile dist/agav-${{ matrix.target }}
+            bun build source/cli.tsx --compile --outfile dist/agav-${{ matrix.target }}${{ matrix.ext }}
           else
-            bun build source/cli.tsx --compile --target=bun-${{ matrix.target }} --outfile dist/agav-${{ matrix.target }}
+            bun build source/cli.tsx --compile --target=bun-${{ matrix.target }} --outfile dist/agav-${{ matrix.target }}${{ matrix.ext }}
           fi
       - name: Sign binary (macOS)
         if: startsWith(matrix.target, 'darwin')
@@ -92,15 +97,15 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum agav-${{ matrix.target }} > agav-${{ matrix.target }}.sha256
-          cat agav-${{ matrix.target }}.sha256
+          sha256sum agav-${{ matrix.target }}${{ matrix.ext }} > agav-${{ matrix.target }}${{ matrix.ext }}.sha256
+          cat agav-${{ matrix.target }}${{ matrix.ext }}.sha256
 
       - uses: actions/upload-artifact@v4
         with:
           name: agav-${{ matrix.target }}
           path: |
-            dist/agav-${{ matrix.target }}
-            dist/agav-${{ matrix.target }}.sha256
+            dist/agav-${{ matrix.target }}${{ matrix.ext }}
+            dist/agav-${{ matrix.target }}${{ matrix.ext }}.sha256
             dist/agav-${{ matrix.target }}.sig
 
   release:
@@ -172,16 +177,19 @@ jobs:
           mkdir -p release
           for dir in artifacts/agav-*; do
             target=$(basename "$dir")
-            # Copy binary
-            if [ -f "$dir/$target" ]; then
-              cp "$dir/$target" "release/$target"
-              chmod +x "release/$target"
-            fi
-            # Copy checksums and signatures
-            for ext in sha256 sig; do
-              if [ -f "$dir/${target}.${ext}" ]; then
-                cp "$dir/${target}.${ext}" "release/${target}.${ext}"
-              fi
+            # The artifact dir is named after the target, but the Windows
+            # binary inside it carries a .exe suffix, so try both.
+            for asset in "$target" "$target.exe"; do
+              [ -f "$dir/$asset" ] || continue
+              # Copy binary
+              cp "$dir/$asset" "release/$asset"
+              chmod +x "release/$asset"
+              # Copy checksums and signatures
+              for ext in sha256 sig; do
+                if [ -f "$dir/${asset}.${ext}" ]; then
+                  cp "$dir/${asset}.${ext}" "release/${asset}.${ext}"
+                fi
+              done
             done
           done
           # Generate combined SHA256SUMS file
@@ -237,13 +245,15 @@ jobs:
             ### Windows
 
             ```powershell
-            # Download and install
-            Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}/agav-windows-x64.exe" -OutFile "$env:LOCALAPPDATA\agav.exe"
+            # Download and install (x64; ARM64 runs this under emulation)
+            New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\agav" | Out-Null
+            Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}/agav-windows-x64.exe" -OutFile "$env:LOCALAPPDATA\agav\agav.exe"
 
             # Add to PATH (run once)
+            $dir = "$env:LOCALAPPDATA\agav"
             $path = [Environment]::GetEnvironmentVariable("Path", "User")
-            if ($path -notlike "*$env:LOCALAPPDATA*") {
-              [Environment]::SetEnvironmentVariable("Path", "$env:LOCALAPPDATA;$path", "User")
+            if ($path -notlike "*$dir*") {
+              [Environment]::SetEnvironmentVariable("Path", "$dir;$path", "User")
             }
             ```
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -63,6 +63,67 @@ For Windows Command Prompt (`cmd.exe`):
 
 Or download a specific platform binary from [Releases](../../releases).
 
+### Uninstall
+
+Both installers accept `--uninstall`.
+
+**macOS / Linux:**
+
+```bash
+curl -fsSL https://agav.dev/install.sh | bash -s -- --uninstall
+```
+
+**Windows PowerShell:**
+
+```powershell
+& ([scriptblock]::Create((irm https://agav.dev/install.ps1))) --uninstall
+```
+
+**Windows Command Prompt (`cmd.exe`):**
+
+```bat
+curl -fsSL https://agav.dev/install.cmd -o install.cmd
+install.cmd --uninstall
+del install.cmd
+```
+
+If you installed via a package manager instead, remove it the same way:
+
+```bash
+npm uninstall -g agav-cli    # or: bun remove -g agav-cli
+```
+
+#### What `--uninstall` leaves behind
+
+It removes the binary, but deliberately keeps your settings and does not edit your shell profile:
+
+| | Removed | Left behind |
+| --- | --- | --- |
+| macOS / Linux | `~/.local/bin/agav`, `~/.agav/packages/standalone/` | `~/.agav/` config, `PATH` line in your shell profile |
+| Windows | `%LOCALAPPDATA%\agav\agav.exe` | `%USERPROFILE%\.agav\` config, `PATH` entry in your user environment |
+
+To remove your configuration as well — this deletes `config.json` (which holds your **encrypted API keys**), `prompt-history.json`, `keybindings.json`, and any installed `plugins/` and `skills/`:
+
+```bash
+rm -rf ~/.agav                       # macOS / Linux
+```
+
+```powershell
+Remove-Item -Recurse -Force "$HOME\.agav"    # Windows
+```
+
+To remove the `PATH` entry, delete this block from your shell profile — `~/.zprofile` (macOS + zsh), `~/.bash_profile` (macOS + bash), `~/.zshrc` or `~/.bashrc` (Linux), or `~/.profile`:
+
+```bash
+# >>> Agav installer >>>
+export PATH="$HOME/.local/bin:$PATH"
+# <<< Agav installer <<<
+```
+
+On Windows, remove the Agav entry from your user `PATH` under **Settings → Edit environment variables for your account**.
+
+Agav also writes per-project directories inside repositories you've worked in — `.agav/` (cached images) and `.agav-worktrees/`. Delete those individually if you want them gone.
+
 ### Run from source
 
 #### macOS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A terminal-native environment for running local AI systems",
   "type": "module",
   "bin": {

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -40,6 +40,9 @@ case "$TARGETS" in
     build_target "darwin-x64" "agav-darwin-x64"
     build_target "linux-x64" "agav-linux-x64"
     build_target "linux-arm64" "agav-linux-arm64"
+    # No windows-arm64: Bun has no such compile target. ARM64 Windows runs
+    # the x64 build under emulation.
+    build_target "windows-x64" "agav-windows-x64.exe"
     ;;
   *)
     build_target "$TARGETS" "agav-$TARGETS"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -37,14 +37,19 @@ foreach ($arg in $args) {
 }
 
 # --- Detect architecture ---
-$Arch = if ([Environment]::Is64BitOperatingSystem) {
-    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" }
-} else {
-    Write-Error "Unsupported: 32-bit systems are not supported."
+if (-not [Environment]::Is64BitOperatingSystem) {
+    Write-Host "Unsupported: 32-bit systems are not supported." -ForegroundColor Red
     exit 1
 }
 
-$Target = "win32-$Arch"
+# Bun has no windows-arm64 compile target, and Windows on ARM runs x64
+# binaries under emulation, so every 64-bit machine gets the x64 build.
+$Arch = "x64"
+if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq "ARM64") {
+    Write-Host "agav -> ARM64 detected; installing the x64 build (runs under emulation)." -ForegroundColor Cyan
+}
+
+$Target = "windows-$Arch"
 $AssetName = "agav-$Target.exe"
 
 # --- Check existing install ---

--- a/source/utils/auto-update.ts
+++ b/source/utils/auto-update.ts
@@ -52,6 +52,10 @@ async function saveState(state: UpdateState): Promise<void> {
 function getBinaryName(): string {
   const os = platform();
   const cpu = arch();
+  // Windows ships x64 only — Bun has no windows-arm64 target, and ARM64
+  // Windows runs the x64 build under emulation. It is also the one asset
+  // that carries a file extension.
+  if (os === "win32") return "agav-windows-x64.exe";
   const osName = os === "darwin" ? "darwin" : "linux";
   const archName = cpu === "arm64" ? "arm64" : "x64";
   return `agav-${osName}-${archName}`;


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR does and why -->

- Windows installs fail with `Download failed - release not found for win32-x64` because no Windows binary has ever been built or published — releases ship macOS and Linux only. This adds `agav-windows-x64.exe` to the release pipeline.
- Reconciles the three different names previously used for that asset (`agav-win32-x64.exe` in the installer, `agav-windows-x64.exe` in the release notes, `bun-windows-x64` in Bun) onto `agav-windows-x64.exe`.
- Documents uninstall steps, which the README didn't cover.

## Changes

<!-- List the key changes made -->

- `release.yml` — added a `windows-x64` matrix target (Bun cross-compiles, so it runs on `ubuntu-latest`) with a new `ext: .exe` key, empty for all other targets. Threaded `ext` through the build, checksum, and upload steps, and taught the asset-assembly loop to find `agav-windows-x64.exe` inside the `agav-windows-x64` artifact directory — without that it would have silently dropped the binary.
- `build-binary.sh` — `all` now builds `agav-windows-x64.exe` too.
- `install.ps1` — requests `agav-windows-$Arch.exe`; ARM64 falls back to the x64 build (Bun has no `windows-arm64` target; Windows on ARM emulates x64).
- `auto-update.ts` — `getBinaryName()` returned `agav-linux-x64` on Windows, so `agav update` would have overwritten `agav.exe` with a Linux ELF. Now returns `agav-windows-x64.exe`.
- `README.md` — added an Uninstall section covering all three installers, plus what `--uninstall` leaves behind (config in `~/.agav`, the `PATH` entry).
- `package.json` — version bumped to 0.1.5, which is what triggers the release that publishes the new asset.

## Related Issues

<!-- Link related issues: Closes #N, Fixes #N, or Relates to #N -->

Follows #35, which fixed the PowerShell parse error that masked this failure.

## Type

<!-- Check one -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

<!-- How was this tested? -->

- [x] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal — **not verified on Windows; see below**
- [ ] Tested with `--provider openai` — _N/A_
- [ ] Tested with `--provider anthropic` — _N/A_
- [ ] Tested with `--provider ollama` — _N/A_
- [ ] Tested pipe mode (`-P`) — _N/A_

Also verified locally:

- `npx vitest run` — 106 tests pass
- `release.yml` parses as YAML and resolves to 5 matrix targets; all three embedded shell scripts pass `bash -n`
- `bash -n scripts/build-binary.sh`
- `scripts/install.ps1` is pure ASCII with even quote parity per line (the #35 invariant holds)

**Not verified:** the `bun-windows-x64` cross-compile has never run in this repo's CI, and the resulting `.exe` has not been booted on Windows. The first release after merge is the real test — worth watching the `Build windows-x64` job and then running `install.cmd` on a Windows machine.

## Screenshots / Terminal Output

<!-- If applicable, paste terminal output showing the feature working -->

The failure this fixes:

```
C:\Users\...\Temp\agav-install-6347-6737.ps1 : Download failed - release not found for win32-x64
At C:\Users\...\Temp\agav-install-6347-6737.ps1:78 char:5
+     Write-Error "Download failed - release not found for $Target"
```

Confirming the asset genuinely doesn't exist today:

```
$ gh release view v0.1.4 --json assets
  agav-darwin-arm64   agav-darwin-x64   agav-linux-arm64   agav-linux-x64

$ curl -sSI -L -o /dev/null -w '%{http_code}\n' \
    https://github.com/prapaa-ai/agav/releases/latest/download/agav-win32-x64.exe
404
```
