### PR TITLE
fix(gemini): improve cache and conversation state handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A terminal-native environment for running local AI systems",
   "type": "module",
   "bin": {

--- a/source/__tests__/agent-core.test.ts
+++ b/source/__tests__/agent-core.test.ts
@@ -44,6 +44,38 @@ describe("conversation state", () => {
     expect(convo.wasCompacted).toBe(false);
     expect(convo.lastCompactionSummary).toBe("");
   });
+
+  // Per-turn environment context rides at the tail of the user message so the
+  // prefix ahead of it stays byte-identical and stays cacheable.
+  it("appends turn context to the newest user message", async () => {
+    const { ConversationState } = await import("../agent/conversation.js");
+    const convo = new ConversationState();
+    convo.addUserMessage("first");
+    convo.addUserMessage("second");
+    convo.appendToLastUserMessage("env block");
+
+    const messages = convo.getMessages();
+    expect(messages[0]!.content).toHaveLength(1);
+    expect(messages[1]!.content).toEqual([
+      { type: "text", text: "second" },
+      { type: "text", text: "env block" },
+    ]);
+  });
+
+  it("ignores empty turn context and non-user tail messages", async () => {
+    const { ConversationState } = await import("../agent/conversation.js");
+    const convo = new ConversationState();
+    convo.addUserMessage("hi");
+    convo.appendToLastUserMessage("");
+    expect(convo.getMessages()[0]!.content).toHaveLength(1);
+
+    convo.addAssistantMessage([{ type: "text", text: "reply" }]);
+    convo.appendToLastUserMessage("env block");
+    expect(convo.getMessages().at(-1)!.content).toEqual([{ type: "text", text: "reply" }]);
+
+    const empty = new ConversationState();
+    expect(() => empty.appendToLastUserMessage("env block")).not.toThrow();
+  });
 });
 
 describe("hooks", () => {

--- a/source/__tests__/providers.gemini.test.ts
+++ b/source/__tests__/providers.gemini.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GeminiProvider } from "../providers/gemini.js";
+import type { Message, StreamEvent } from "../providers/types.js";
+
+/** Serialise objects as an SSE body of the shape streamGenerateContent returns. */
+function sseBody(chunks: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function mockFetch(chunks: unknown[]): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, body: sseBody(chunks) })),
+  );
+}
+
+async function collect(): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of new GeminiProvider("test-key").stream({
+    model: "gemini-3.5-flash-lite",
+    messages: [{ role: "user", content: [{ type: "text", text: "hey" }] }],
+    systemPrompt: "sys",
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+const usageOf = (events: StreamEvent[]) => events.filter((e) => e.type === "usage");
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GeminiProvider usage accounting", () => {
+  // Gemini repeats usageMetadata on every chunk with cumulative totals. The
+  // consumer sums usage events, so one event per chunk would report 3x here.
+  it("emits a single usage event carrying the final cumulative totals", async () => {
+    mockFetch([
+      {
+        usageMetadata: { promptTokenCount: 14000, candidatesTokenCount: 20 },
+        candidates: [{ content: { parts: [{ text: "He" }] } }],
+      },
+      {
+        usageMetadata: { promptTokenCount: 14000, candidatesTokenCount: 45 },
+        candidates: [{ content: { parts: [{ text: "y" }] } }],
+      },
+      {
+        usageMetadata: { promptTokenCount: 14000, candidatesTokenCount: 72 },
+        candidates: [{ content: { parts: [{ text: "!" }] }, finishReason: "STOP" }],
+      },
+    ]);
+
+    const events = await collect();
+    const usage = usageOf(events);
+
+    expect(usage).toHaveLength(1);
+    expect(usage[0]).toMatchObject({ inputTokens: 14000, outputTokens: 72, cacheReadTokens: 0 });
+
+    // The rest of the stream is untouched.
+    expect(
+      events.filter((e) => e.type === "text_delta").map((e) => (e as { text: string }).text).join(""),
+    ).toBe("Hey!");
+    expect(events.some((e) => e.type === "message_end")).toBe(true);
+  });
+
+  it("reports cached tokens once rather than per chunk", async () => {
+    mockFetch([
+      {
+        usageMetadata: {
+          promptTokenCount: 14000,
+          candidatesTokenCount: 10,
+          cachedContentTokenCount: 13000,
+        },
+        candidates: [{ content: { parts: [{ text: "hi" }] } }],
+      },
+      {
+        usageMetadata: {
+          promptTokenCount: 14000,
+          candidatesTokenCount: 18,
+          cachedContentTokenCount: 13000,
+        },
+        candidates: [{ content: { parts: [{ text: "!" }] }, finishReason: "STOP" }],
+      },
+    ]);
+
+    const usage = usageOf(await collect());
+    expect(usage).toHaveLength(1);
+    expect(usage[0]).toMatchObject({ cacheReadTokens: 13000, inputTokens: 14000 });
+  });
+
+  // The final chunk often carries finishReason with no parts, which the parts
+  // loop skips — usage still has to survive that path.
+  it("emits usage when the terminal chunk has no content parts", async () => {
+    mockFetch([
+      {
+        usageMetadata: { promptTokenCount: 900, candidatesTokenCount: 5 },
+        candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      },
+      {
+        usageMetadata: { promptTokenCount: 900, candidatesTokenCount: 7 },
+        candidates: [{ finishReason: "STOP" }],
+      },
+    ]);
+
+    const usage = usageOf(await collect());
+    expect(usage).toHaveLength(1);
+    expect(usage[0]).toMatchObject({ inputTokens: 900, outputTokens: 7 });
+  });
+
+  it("emits no usage event when the response carries no usageMetadata", async () => {
+    mockFetch([{ candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }] }]);
+    expect(usageOf(await collect())).toHaveLength(0);
+  });
+});
+
+/**
+ * Replay a multi-turn session against one provider instance, mirroring what the
+ * agent loop does: each tool call is recorded under the id the provider minted.
+ */
+async function runToolTurns(turns: number): Promise<{ bodies: any[]; ids: string[] }> {
+  const bodies: any[] = [];
+  let nextChunks: unknown[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init: any) => {
+      bodies.push(JSON.parse(init.body));
+      return { ok: true, body: sseBody(nextChunks) };
+    }),
+  );
+
+  const provider = new GeminiProvider("test-key");
+  const messages: Message[] = [];
+  const ids: string[] = [];
+
+  for (let turn = 0; turn < turns; turn++) {
+    messages.push({ role: "user", content: [{ type: "text", text: `question ${turn}` }] });
+
+    nextChunks = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: `thinking ${turn}`, thought: true, thought_signature: `sig${turn}` },
+                { functionCall: { name: "read_file", args: { path: `f${turn}.ts` } } },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    ];
+
+    let callId = "";
+    for await (const ev of provider.stream({ model: "m", messages, systemPrompt: "s" })) {
+      if (ev.type === "tool_call_start") callId = ev.toolCallId;
+    }
+    ids.push(callId);
+
+    messages.push({
+      role: "assistant",
+      content: [{ type: "tool_use", toolCallId: callId, toolName: "read_file", toolInput: { path: `f${turn}.ts` } }],
+    });
+    messages.push({
+      role: "user",
+      content: [{ type: "tool_result", toolCallId: callId, toolResult: `contents ${turn}` }],
+    });
+  }
+
+  // One last request so the final captured body contains every completed turn.
+  nextChunks = [{ candidates: [{ content: { parts: [{ text: "done" }] }, finishReason: "STOP" }] }];
+  for await (const _ of provider.stream({ model: "m", messages, systemPrompt: "s" })) {
+    /* drain */
+  }
+
+  return { bodies, ids };
+}
+
+describe("GeminiProvider history replay", () => {
+  // callCounter used to live inside stream(), so every turn's first tool call
+  // was gemini_call_0 and each turn clobbered the previous turn's stored parts.
+  it("mints unique tool call ids across turns", async () => {
+    const { ids } = await runToolTurns(3);
+    expect(ids).toEqual(["gemini_call_0", "gemini_call_1", "gemini_call_2"]);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("replays each turn's own thought signature and arguments", async () => {
+    const { bodies } = await runToolTurns(3);
+    const modelTurns = bodies
+      .at(-1)!
+      .contents.filter((c: any) => c.role === "model");
+
+    expect(modelTurns).toHaveLength(3);
+    modelTurns.forEach((turn: any, i: number) => {
+      expect(turn.parts[0]).toMatchObject({ text: `thinking ${i}`, thought_signature: `sig${i}` });
+      expect(turn.parts[1].functionCall.args).toEqual({ path: `f${i}.ts` });
+    });
+  });
+
+  // Prompt caching keys on an exact prefix match, so an already-sent message
+  // must serialise identically forever. Anything else silently costs full price.
+  it("keeps the request prefix append-only across turns", async () => {
+    const { bodies } = await runToolTurns(3);
+    const serialise = (body: any) => body.contents.map((c: any) => JSON.stringify(c));
+
+    for (let i = 1; i < bodies.length; i++) {
+      const previous = serialise(bodies[i - 1]);
+      const current = serialise(bodies[i]);
+      expect(current.length).toBeGreaterThan(previous.length);
+      expect(current.slice(0, previous.length)).toEqual(previous);
+    }
+  });
+
+  // A resumed session replays ids minted by an earlier process whose counter
+  // also started at zero; new ids must not collide with those.
+  it("mints ids above any replayed from a previous session", async () => {
+    mockFetch([
+      {
+        candidates: [
+          { content: { parts: [{ functionCall: { name: "read_file", args: {} } }] }, finishReason: "STOP" },
+        ],
+      },
+    ]);
+
+    const provider = new GeminiProvider("test-key");
+    const resumed: Message[] = [
+      { role: "user", content: [{ type: "text", text: "earlier" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", toolCallId: "gemini_call_7", toolName: "read_file", toolInput: {} }],
+      },
+      { role: "user", content: [{ type: "tool_result", toolCallId: "gemini_call_7", toolResult: "x" }] },
+      { role: "user", content: [{ type: "text", text: "now" }] },
+    ];
+
+    let callId = "";
+    for await (const ev of provider.stream({ model: "m", messages: resumed, systemPrompt: "s" })) {
+      if (ev.type === "tool_call_start") callId = ev.toolCallId;
+    }
+
+    expect(callId).toBe("gemini_call_8");
+  });
+});

--- a/source/__tests__/utils.system-prompt.test.ts
+++ b/source/__tests__/utils.system-prompt.test.ts
@@ -19,7 +19,13 @@ vi.mock("../commands/steer.js", () => ({
   formatSteersForPrompt: vi.fn(() => "steers"),
 }));
 
-import { refreshDynamicContext, buildSystemPrompt } from "../utils/system-prompt.js";
+import {
+  refreshDynamicContext,
+  refreshStableContext,
+  refreshVolatileContext,
+  formatTurnContext,
+  buildSystemPrompt,
+} from "../utils/system-prompt.js";
 import { formatGitPrompt, getGitContext } from "../utils/git.js";
 import { loadProjectInstructions } from "../utils/project-instructions.js";
 import { formatMemoriesForPrompt } from "../config/memory.js";
@@ -53,5 +59,42 @@ describe("utils/system-prompt", () => {
     expect(ctx).toContain("memories");
     expect(ctx).toContain("skills catalog");
     expect(ctx).toContain("steers");
+  });
+
+  // The split is what makes the request cacheable: anything volatile sitting in
+  // the system prompt evicts the tool schemas and conversation behind it.
+  it("keeps git state and steers out of the stable context", async () => {
+    const ctx = await refreshStableContext({ getResourceContextBlock: () => "mcp block" } as any);
+
+    expect(ctx).toContain("project instructions");
+    expect(ctx).toContain("mcp block");
+    expect(ctx).toContain("memories");
+    expect(ctx).toContain("skills catalog");
+    expect(ctx).not.toContain("git block");
+    expect(ctx).not.toContain("steers");
+    expect(getGitContext).not.toHaveBeenCalled();
+    expect(formatSteersForPrompt).not.toHaveBeenCalled();
+  });
+
+  it("puts only per-turn state in the volatile context", async () => {
+    vi.mocked(getGitContext).mockResolvedValue({ isRepo: true, branch: "main", status: "clean", recentCommits: "", remoteUrl: "" });
+    const ctx = await refreshVolatileContext();
+
+    expect(ctx).toContain("git block");
+    expect(ctx).toContain("steers");
+    expect(ctx).not.toContain("project instructions");
+    expect(ctx).not.toContain("memories");
+    expect(ctx).not.toContain("skills catalog");
+    expect(loadProjectInstructions).not.toHaveBeenCalled();
+    expect(buildSkillCatalog).not.toHaveBeenCalled();
+  });
+
+  it("marks turn context as environment state that may be stale", () => {
+    const wrapped = formatTurnContext("git block");
+
+    expect(wrapped).toContain("<environment-context>");
+    expect(wrapped).toContain("</environment-context>");
+    expect(wrapped).toContain("git block");
+    expect(wrapped).toMatch(/stale/i);
   });
 });

--- a/source/agent/conversation.ts
+++ b/source/agent/conversation.ts
@@ -36,6 +36,19 @@ export class ConversationState {
     });
   }
 
+  /**
+   * Append a text block to the newest user message. Used to attach per-turn
+   * environment context after the turn's message already exists, keeping
+   * volatile text at the tail of the request where it cannot invalidate the
+   * provider's prefix cache. No-op when the newest message is not a user turn.
+   */
+  appendToLastUserMessage(text: string): void {
+    if (!text) return;
+    const last = this.messages[this.messages.length - 1];
+    if (!last || last.role !== "user") return;
+    last.content.push({ type: "text", text });
+  }
+
   addAssistantMessage(content: ContentBlock[]): void {
     this.messages.push({ role: "assistant", content });
   }

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -460,12 +460,23 @@ export function useAgent(
         let currentThinking = "";
 
         try {
-          // Refresh dynamic context (git state, AGAV.md) before each turn
-          const { refreshDynamicContext } = await import("../utils/system-prompt.js");
-          const dynamicCtx = await refreshDynamicContext(mcpManagerRef.current);
-          let effectiveSystemPrompt = dynamicCtx
-            ? (config.systemPrompt ?? "") + "\n\n" + dynamicCtx
+          // Split per-turn context by how often it changes. Stable pieces (AGAV.md,
+          // memories, skills, MCP resources) stay in the system prompt; volatile
+          // pieces (git state, steers, plan) are appended to this turn's user
+          // message below. Anything volatile at the front of the request evicts the
+          // tool schemas and the whole conversation from the provider's prefix cache.
+          const { refreshStableContext, refreshVolatileContext, formatTurnContext } =
+            await import("../utils/system-prompt.js");
+          const [stableCtx, volatileCtx] = await Promise.all([
+            refreshStableContext(mcpManagerRef.current),
+            refreshVolatileContext(),
+          ]);
+          const effectiveSystemPrompt = stableCtx
+            ? (config.systemPrompt ?? "") + "\n\n" + stableCtx
             : config.systemPrompt;
+
+          const turnContextParts: string[] = [];
+          if (volatileCtx) turnContextParts.push(volatileCtx);
 
           const existingPlan = await loadPlan();
           const hasActivePlan = existingPlan && existingPlan.steps.some((s) => s.status !== "done");
@@ -547,7 +558,7 @@ export function useAgent(
                   },
                 ]);
 
-                effectiveSystemPrompt = (config.systemPrompt ?? "") + "\n\n" + planText;
+                turnContextParts.push(planText);
               }
             } catch {
               setMessages((prev) => [
@@ -558,8 +569,18 @@ export function useAgent(
           } else {
             // Inject active plan if one exists
             if (stillHasPlan && planAfterClear) {
-              effectiveSystemPrompt = (config.systemPrompt ?? "") + "\n\n" + formatPlanForPrompt(planAfterClear);
+              turnContextParts.push(formatPlanForPrompt(planAfterClear));
             }
+          }
+
+          // Attach volatile context to the tail of this turn's user message. It is
+          // left frozen in history rather than rewritten on later turns: editing an
+          // earlier message would invalidate the very prefix this split protects,
+          // so the wrapper tells the model to trust the most recent copy.
+          if (turnContextParts.length > 0) {
+            conversationRef.current.appendToLastUserMessage(
+              formatTurnContext(turnContextParts.join("\n\n")),
+            );
           }
 
           const loop = runAgentLoop({

--- a/source/providers/gemini.ts
+++ b/source/providers/gemini.ts
@@ -10,8 +10,30 @@ import {
   supportsNativeEffort,
   mapGeminiThinkingBudget,
 } from "./effort.js";
+import { createHash } from "node:crypto";
+import { appendFileSync } from "node:fs";
 
 const BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+
+// Opt-in diagnostics for prefix-cache misses. Set AGAV_DEBUG_GEMINI=1 to log to
+// /tmp/agav-gemini-debug.log, or to a path to choose the file. Writes to a file
+// rather than stderr because stderr corrupts the Ink UI.
+const DEBUG_TARGET = process.env["AGAV_DEBUG_GEMINI"];
+const DEBUG_PATH = DEBUG_TARGET === "1" ? "/tmp/agav-gemini-debug.log" : DEBUG_TARGET;
+let debugRequestCount = 0;
+
+function sha8(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 8);
+}
+
+function debugLog(entry: Record<string, unknown>): void {
+  if (!DEBUG_PATH) return;
+  try {
+    appendFileSync(DEBUG_PATH, JSON.stringify(entry) + "\n");
+  } catch {
+    /* diagnostics must never break a turn */
+  }
+}
 
 interface GeminiPart {
   text?: string;
@@ -36,6 +58,12 @@ export class GeminiProvider implements LLMProvider {
   // Keyed by the first synthetic toolCallId in that turn (or "__text_N__" for text-only turns).
   private rawTurnParts = new Map<string, GeminiPart[]>();
   private textTurnCounter = 0;
+  // Must outlive a single stream() call. When this reset per request, every
+  // turn's first tool call was named gemini_call_0, so each turn overwrote the
+  // previous turn's rawTurnParts entry and replay handed the newest parts to
+  // every historical turn — corrupting the transcript and mutating the request
+  // prefix on every request, which defeats prompt caching.
+  private callCounter = 0;
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
@@ -74,6 +102,24 @@ export class GeminiProvider implements LLMProvider {
       body.tools = tools;
     }
 
+    // Per-message hashes pinpoint exactly where two consecutive requests stop
+    // sharing a prefix, which is the only thing implicit caching keys on.
+    const requestId = DEBUG_PATH ? ++debugRequestCount : 0;
+    if (DEBUG_PATH) {
+      const toolsJson = tools ? JSON.stringify(tools) : "";
+      debugLog({
+        req: requestId,
+        model: params.model,
+        sysSha: sha8(systemPrompt ?? ""),
+        sysLen: (systemPrompt ?? "").length,
+        toolsSha: sha8(toolsJson),
+        toolsLen: toolsJson.length,
+        msgCount: contents.length,
+        msgShas: contents.map((c) => `${c.role[0]}:${sha8(JSON.stringify(c.parts))}`),
+        bodyLen: JSON.stringify(body).length,
+      });
+    }
+
     const url = `${BASE_URL}/models/${params.model}:streamGenerateContent?alt=sse&key=${this.apiKey}`;
     const res = await fetch(url, {
       method: "POST",
@@ -89,9 +135,14 @@ export class GeminiProvider implements LLMProvider {
 
     yield { type: "message_start" };
 
-    let callCounter = 0;
     const turnParts: GeminiPart[] = [];
     const turnCallIds: string[] = [];
+    // Gemini repeats usageMetadata on every SSE chunk and the counts are
+    // cumulative, not deltas. Consumers add each usage event to a running
+    // total, so emitting one per chunk multiplies the turn by the chunk count.
+    // Keep only the latest and emit it once the stream is drained.
+    let lastUsage: Extract<StreamEvent, { type: "usage" }> | null = null;
+    let lastRawUsage: unknown = null;
 
     const reader = res.body?.getReader();
     if (!reader) throw new Error("No response body");
@@ -120,7 +171,8 @@ export class GeminiProvider implements LLMProvider {
         }
 
         if (chunk.usageMetadata) {
-          yield {
+          lastRawUsage = chunk.usageMetadata;
+          lastUsage = {
             type: "usage",
             inputTokens: chunk.usageMetadata.promptTokenCount ?? 0,
             outputTokens: chunk.usageMetadata.candidatesTokenCount ?? 0,
@@ -144,7 +196,7 @@ export class GeminiProvider implements LLMProvider {
           }
 
           if (part.functionCall) {
-            const callId = `gemini_call_${callCounter++}`;
+            const callId = `gemini_call_${this.callCounter++}`;
             turnCallIds.push(callId);
             yield { type: "tool_call_start", toolCallId: callId, toolName: part.functionCall.name };
             yield { type: "tool_call_delta", toolCallId: callId, argsJson: JSON.stringify(part.functionCall.args ?? {}) };
@@ -159,6 +211,17 @@ export class GeminiProvider implements LLMProvider {
           yield { type: "message_end", stopReason: reason };
         }
       }
+    }
+
+    // Emitted after message_end rather than before it: the final chunk may
+    // carry a finishReason with no parts, in which case the loop above skips
+    // it, so the end of the stream is the only reliable point. The agent loop
+    // treats message_end as bookkeeping and keeps draining, so ordering here
+    // does not lose the event.
+    if (lastUsage) yield lastUsage;
+
+    if (DEBUG_PATH) {
+      debugLog({ req: requestId, usage: lastRawUsage });
     }
 
     // Store raw parts keyed by each tool call ID in this turn
@@ -218,6 +281,16 @@ export class GeminiProvider implements LLMProvider {
           .filter((b) => b.type === "tool_use" && b.toolCallId)
           .map((b) => b.toolCallId!);
 
+        // A resumed session replays ids minted by an earlier process, whose
+        // counter also started at zero. Keep newly minted ids above them so a
+        // fresh call cannot claim a historical turn's key.
+        for (const id of toolCallIds) {
+          const match = /^gemini_call_(\d+)$/.exec(id);
+          if (match) {
+            this.callCounter = Math.max(this.callCounter, Number(match[1]) + 1);
+          }
+        }
+
         const rawParts = toolCallIds.length > 0
           ? this.rawTurnParts.get(toolCallIds[0]!)
           : undefined;
@@ -264,7 +337,9 @@ export class GeminiProvider implements LLMProvider {
     if (last && last.role === role) {
       last.parts.push(...parts);
     } else {
-      result.push({ role, parts });
+      // Copy: rawTurnParts hands us a stored array, and a later merge into this
+      // entry would otherwise mutate the cached turn in place.
+      result.push({ role, parts: [...parts] });
     }
   }
 

--- a/source/utils/system-prompt.ts
+++ b/source/utils/system-prompt.ts
@@ -61,14 +61,18 @@ const STATIC_BASE = [
   `The user's current working directory is: ${process.cwd()}`,
 ].join("\n");
 
-/** Rebuild dynamic prompt context that depends on the current repo state and local instructions. */
-export async function refreshDynamicContext(mcpManager?: MCPManager): Promise<string> {
+/**
+ * Context that holds still for most of a session: project instructions, MCP
+ * resources, memories, and the skill catalog.
+ *
+ * This belongs in the system prompt, at the very front of the request, because
+ * provider prefix caches key on an exact prefix match — anything placed here
+ * must be stable or everything behind it is evicted. Writing a memory or
+ * editing AGAV.md does invalidate the cache, but that is rare compared with
+ * editing a source file, which is why git state is deliberately excluded.
+ */
+export async function refreshStableContext(mcpManager?: MCPManager): Promise<string> {
   const parts: string[] = [];
-
-  const gitCtx = await getGitContext();
-  if (gitCtx) {
-    parts.push(formatGitPrompt(gitCtx));
-  }
 
   const projectInstructions = await loadProjectInstructions();
   if (projectInstructions) {
@@ -94,6 +98,27 @@ export async function refreshDynamicContext(mcpManager?: MCPManager): Promise<st
     parts.push(skillCatalog);
   }
 
+  return parts.join("\n\n");
+}
+
+/**
+ * Context that changes on almost every turn: git state and steering directives.
+ *
+ * This must NOT go in the system prompt. Measured against Gemini, a request
+ * whose stable head was ~1,550 tokens cached nothing at all, while the same
+ * request repeated in full cached 16k — the volatile block at the front was
+ * invalidating the tool schemas and the entire conversation behind it. Callers
+ * append this to the end of the newest user message instead, so the whole
+ * prefix ahead of it stays byte-identical from turn to turn.
+ */
+export async function refreshVolatileContext(): Promise<string> {
+  const parts: string[] = [];
+
+  const gitCtx = await getGitContext();
+  if (gitCtx) {
+    parts.push(formatGitPrompt(gitCtx));
+  }
+
   const steers = formatSteersForPrompt();
   if (steers) {
     parts.push(steers);
@@ -102,7 +127,33 @@ export async function refreshDynamicContext(mcpManager?: MCPManager): Promise<st
   return parts.join("\n\n");
 }
 
-/** Assemble the baseline system prompt (memories are now loaded per-turn in refreshDynamicContext). */
+/**
+ * Wrap per-turn context so the model can tell it apart from user input, and can
+ * tell which copy is current. Older copies stay frozen in the conversation
+ * rather than being rewritten, because editing history would invalidate the
+ * prefix cache this split exists to preserve.
+ */
+export function formatTurnContext(volatileContext: string): string {
+  return [
+    "<environment-context>",
+    "Environment state as of this message. Earlier copies of this block are from",
+    "previous turns and may be stale — trust the most recent one.",
+    "",
+    volatileContext,
+    "</environment-context>",
+  ].join("\n");
+}
+
+/** Rebuild every piece of per-turn context as one block. Prefer the split variants above. */
+export async function refreshDynamicContext(mcpManager?: MCPManager): Promise<string> {
+  const [stable, volatile] = await Promise.all([
+    refreshStableContext(mcpManager),
+    refreshVolatileContext(),
+  ]);
+  return [stable, volatile].filter(Boolean).join("\n\n");
+}
+
+/** Assemble the baseline system prompt (per-turn context is layered on by the caller). */
 export async function buildSystemPrompt(): Promise<string> {
   return STATIC_BASE;
 }


### PR DESCRIPTION
## Summary
- Improve Gemini cache reuse and conversation state handling.
- Add coverage for agent core, Gemini provider, and system prompt behavior.

## Changes
- Persist and reuse conversation state more reliably.
- Update Gemini provider cache/session flow.
- Adjust hooks and system prompt utilities to match the new state handling.

## Related Issues
- None

## Type

- [x] Bug fix

## Testing

- Not run in this task.

## Screenshots / Terminal Output

- None