### PR TITLE
fix: account for nested skill token usage in display totals

### DIFF
--- a/source/__tests__/skills.commands.test.ts
+++ b/source/__tests__/skills.commands.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConversationState } from "../agent/conversation.js";
+import type { SkillDefinition } from "../skills/types.js";
+
+vi.mock("../skills/executor.js", () => ({
+  executeSkill: vi.fn(async () => ({
+    output: "user skill output",
+    tokenUsage: { inputTokens: 1, outputTokens: 2, cacheReadTokens: 3, cacheWriteTokens: 4 },
+  })),
+}));
+
+import { executeSkill } from "../skills/executor.js";
+import { createSkillSlashCommand } from "../skills/commands.js";
+
+const skill: SkillDefinition = {
+  name: "User Skill",
+  slug: "user-skill",
+  description: "Invoked manually",
+  body: "do things",
+  frontmatter: { name: "User Skill", description: "Invoked manually", invocation: "user" },
+  filePath: "/tmp/skills/user/SKILL.md",
+  origin: "project",
+};
+
+describe("skills/commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // executeSkill reports usage two mutually exclusive ways: the onTokenUsage
+  // callback (activate_skill) or the returned tokenUsage (here, forwarded as
+  // _tokenUsage and merged by saveNow). Wiring up both would count every
+  // /skill-name run twice, so this path must leave the callback unset.
+  it("keeps the slash-command skill path on returned token usage instead of the callback", async () => {
+    const command = createSkillSlashCommand(skill);
+
+    const result = await command.execute("  trim me  ", {
+      conversation: new ConversationState(),
+      provider: { name: "mock", stream: vi.fn() } as any,
+      toolRegistry: {} as any,
+      config: {
+        model: "test-model",
+        systemPrompt: "",
+        permissionMode: "ask",
+        effort: "medium",
+        maxIterations: 1,
+      } as any,
+      setModel: vi.fn(),
+      setProvider: vi.fn(),
+      setEffort: vi.fn(),
+      clearMessages: vi.fn(),
+      showStatus: vi.fn(),
+      saveSession: vi.fn(),
+      refreshDisplay: vi.fn(),
+      loadSession: vi.fn(),
+      activateSession: vi.fn(),
+      renameSession: vi.fn(),
+      exit: vi.fn(),
+      getDebugState: vi.fn(),
+      submit: vi.fn(),
+      handleSubmit: vi.fn(),
+      addTokenUsage: vi.fn(),
+      setRunningSkill: vi.fn(),
+      setPickerActive: vi.fn(),
+    });
+
+    const [, passedArgs, deps] = vi.mocked(executeSkill).mock.calls[0]!;
+    expect(passedArgs).toBe("trim me");
+    expect(deps.onTokenUsage).toBeUndefined();
+
+    // The other half of the invariant: usage still has to reach the caller.
+    expect(result).toMatchObject({
+      type: "message",
+      text: "user skill output",
+      _isSkill: true,
+      _tokenUsage: { inputTokens: 1, outputTokens: 2, cacheReadTokens: 3, cacheWriteTokens: 4 },
+    });
+  });
+});

--- a/source/__tests__/skills.executor.test.ts
+++ b/source/__tests__/skills.executor.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SkillDefinition } from "../skills/types.js";
+import { ToolRegistry } from "../tools/registry.js";
+
+vi.mock("../agent/loop.js", () => ({
+  runAgentLoop: vi.fn(() => (async function* () {
+    yield { type: "usage", inputTokens: 11, outputTokens: 7, cacheReadTokens: 3, cacheWriteTokens: 2 };
+    yield { type: "assistant_message_complete", text: "skill done" };
+  })()),
+}));
+vi.mock("../commands/steer.js", () => ({
+  formatSteersForPrompt: vi.fn(() => ""),
+}));
+vi.mock("../skills/improvement.js", () => ({
+  recordSkillTrace: vi.fn(() => Promise.resolve()),
+}));
+
+import { runAgentLoop } from "../agent/loop.js";
+import { recordSkillTrace } from "../skills/improvement.js";
+import { executeSkill } from "../skills/executor.js";
+
+const baseDeps = {
+  provider: { name: "mock", stream: vi.fn() } as any,
+  parentRegistry: new ToolRegistry(),
+  model: "test-model",
+  systemPrompt: "",
+  permissionMode: "ask" as const,
+  effort: "medium" as const,
+  maxIterations: 1,
+};
+
+const skill: SkillDefinition = {
+  name: "Demo Skill",
+  slug: "demo-skill",
+  description: "Demo skill used in tests",
+  body: "Do the thing.",
+  frontmatter: { name: "Demo Skill", description: "Demo skill used in tests" },
+  filePath: "/tmp/demo/SKILL.md",
+  origin: "project",
+};
+
+describe("skills/executor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards aggregated usage to the parent token accounting callback", async () => {
+    const onTokenUsage = vi.fn();
+
+    const result = await executeSkill(skill, "", {
+      provider: { name: "mock", stream: vi.fn() } as any,
+      parentRegistry: new ToolRegistry(),
+      model: "test-model",
+      systemPrompt: "",
+      permissionMode: "ask",
+      effort: "medium",
+      maxIterations: 1,
+      onTokenUsage,
+    });
+
+    expect(result.output).toBe("skill done");
+    expect(result.tokenUsage).toEqual({
+      inputTokens: 11,
+      outputTokens: 7,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 2,
+    });
+    expect(onTokenUsage).toHaveBeenCalledTimes(1);
+    expect(onTokenUsage).toHaveBeenCalledWith(result.tokenUsage);
+  });
+
+  it("records a successful run against the skill's trace log", async () => {
+    await executeSkill(skill, "do it", baseDeps);
+
+    expect(recordSkillTrace).toHaveBeenCalledWith("Demo Skill", "do it", 18, true);
+  });
+
+  // An abort or provider error part-way through still burned tokens, so the
+  // usage callback has to fire — and the trace must not claim the run succeeded.
+  it("reports partial usage and a failed trace when the loop throws", async () => {
+    vi.mocked(runAgentLoop).mockReturnValueOnce((async function* () {
+      yield { type: "usage", inputTokens: 5, outputTokens: 4, cacheReadTokens: 0, cacheWriteTokens: 0 };
+      throw new Error("aborted");
+    })() as any);
+
+    const onTokenUsage = vi.fn();
+
+    await expect(executeSkill(skill, "do it", { ...baseDeps, onTokenUsage })).rejects.toThrow("aborted");
+
+    expect(onTokenUsage).toHaveBeenCalledTimes(1);
+    expect(onTokenUsage).toHaveBeenCalledWith({
+      inputTokens: 5,
+      outputTokens: 4,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect(recordSkillTrace).toHaveBeenCalledWith("Demo Skill", "do it", 9, false);
+  });
+});

--- a/source/__tests__/skills.tool.test.ts
+++ b/source/__tests__/skills.tool.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ToolRegistry } from "../tools/registry.js";
+
+const reportedUsage = { inputTokens: 2, outputTokens: 3, cacheReadTokens: 4, cacheWriteTokens: 5 };
+
+vi.mock("../skills/loader.js", () => ({
+  getSkill: vi.fn(() => ({
+    name: "Nested Skill",
+    slug: "nested-skill",
+    description: "Runs nested",
+    body: "",
+    frontmatter: { name: "Nested Skill", description: "Runs nested", invocation: "agav" },
+    filePath: "/tmp/skills/nested/SKILL.md",
+    origin: "project",
+  })),
+}));
+vi.mock("../skills/executor.js", () => ({
+  executeSkill: vi.fn(async (_skill: unknown, _args: string, deps: { onTokenUsage?: (usage: typeof reportedUsage) => void }) => {
+    deps.onTokenUsage?.(reportedUsage);
+    return { output: "nested output", tokenUsage: reportedUsage };
+  }),
+}));
+
+import { createSkillTool } from "../skills/tool.js";
+
+describe("skills/tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes token usage from activate_skill runs into the parent accounting callback", async () => {
+    const onTokenUsage = vi.fn();
+    const tool = createSkillTool({
+      provider: { name: "mock", stream: vi.fn() } as any,
+      parentRegistry: new ToolRegistry(),
+      getConfig: () => ({
+        model: "test-model",
+        systemPrompt: "",
+        permissionMode: "ask",
+        effort: "medium",
+        maxIterations: 1,
+      }),
+      onTokenUsage,
+      getSignal: () => undefined,
+    });
+
+    const result = await tool.execute({ name: "Nested Skill", arguments: "use this" });
+
+    expect(result).toEqual({ output: "nested output", isError: false });
+    expect(onTokenUsage).toHaveBeenCalledTimes(1);
+    expect(onTokenUsage).toHaveBeenCalledWith(reportedUsage);
+  });
+});

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -281,6 +281,12 @@ export function useAgent(
             maxIterations: configRef.current.maxIterations,
           }),
           confirmTool: skillConfirmCallback,
+          onTokenUsage: (usage) => setTokenUsage((prev) => ({
+            inputTokens: prev.inputTokens + usage.inputTokens,
+            outputTokens: prev.outputTokens + usage.outputTokens,
+            cacheReadTokens: prev.cacheReadTokens + usage.cacheReadTokens,
+            cacheWriteTokens: prev.cacheWriteTokens + usage.cacheWriteTokens,
+          })),
           getSignal: () => abortRef.current?.signal,
         });
         toolRegistryRef.current.register(skillTool);

--- a/source/skills/executor.ts
+++ b/source/skills/executor.ts
@@ -19,6 +19,9 @@ interface SkillExecDeps {
   effort: EffortLevel;
   maxIterations: number;
   confirmTool?: (toolName: string, input: Record<string, unknown>) => Promise<ConfirmResult>;
+  // Optional nested-skill accounting callback: /skill-name continues to use _tokenUsage on the
+  // returned command result, while activate_skill uses this to merge usage into the parent turn.
+  onTokenUsage?: (usage: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }) => void;
   signal?: AbortSignal;
 }
 
@@ -106,25 +109,35 @@ export async function executeSkill(
   });
 
   let result = "";
+  let failed = false;
   const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
-  for await (const event of loop) {
-    switch (event.type) {
-      case "streaming_text":
-        result += event.text;
-        break;
-      case "assistant_message_complete":
-        result = event.text;
-        break;
-      case "usage":
-        usage.inputTokens += event.inputTokens;
-        usage.outputTokens += event.outputTokens;
-        usage.cacheReadTokens += event.cacheReadTokens ?? 0;
-        usage.cacheWriteTokens += event.cacheWriteTokens ?? 0;
-        break;
-    }
-  }
 
-  recordSkillTrace(skill.name, args, usage.inputTokens + usage.outputTokens).catch(() => {});
+  // Report usage and record the trace from a finally so an abort or provider
+  // error part-way through still accounts for the tokens already spent.
+  try {
+    for await (const event of loop) {
+      switch (event.type) {
+        case "streaming_text":
+          result += event.text;
+          break;
+        case "assistant_message_complete":
+          result = event.text;
+          break;
+        case "usage":
+          usage.inputTokens += event.inputTokens;
+          usage.outputTokens += event.outputTokens;
+          usage.cacheReadTokens += event.cacheReadTokens ?? 0;
+          usage.cacheWriteTokens += event.cacheWriteTokens ?? 0;
+          break;
+      }
+    }
+  } catch (err) {
+    failed = true;
+    throw err;
+  } finally {
+    deps.onTokenUsage?.(usage);
+    recordSkillTrace(skill.name, args, usage.inputTokens + usage.outputTokens, !failed).catch(() => {});
+  }
 
   return {
     output: result || "(skill produced no output)",

--- a/source/skills/tool.ts
+++ b/source/skills/tool.ts
@@ -17,6 +17,7 @@ interface SkillToolDeps {
     maxIterations: number;
   };
   confirmTool?: (toolName: string, input: Record<string, unknown>) => Promise<ConfirmResult>;
+  onTokenUsage?: (usage: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }) => void;
   getSignal: () => AbortSignal | undefined;
 }
 
@@ -67,6 +68,7 @@ export function createSkillTool(deps: SkillToolDeps): ToolDefinition {
           effort: config.effort,
           maxIterations: config.maxIterations,
           confirmTool: deps.confirmTool,
+          onTokenUsage: deps.onTokenUsage,
           signal: deps.getSignal(),
         });
         return { output: result.output, isError: false };


### PR DESCRIPTION
## Summary

- Account for token usage from nested `activate_skill` runs so displayed totals include skills across providers.
- Keep `/skill` slash-command accounting on the existing return-value path to avoid double counting.
- Harden skill execution so partial usage is still recorded on errors/aborts.

## Changes

- Added an optional nested-skill token usage callback through `executeSkill()` and `createSkillTool()`.
- Wired `use-agent.ts` to merge nested skill usage into the live session token totals.
- Kept slash-command skill execution on the existing `_tokenUsage` path.
- Added regression tests for the executor, tool wrapper, and slash-command path.

## Related Issues

- None

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

## Screenshots / Terminal Output

- `npm run build`
- `vitest run source` → 28 passed, 0 failed
