### PR TITLE
feat: agents and marketplace

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -281,7 +281,7 @@ jobs:
             FAIL=1
           fi
           if grep -rn --include='*.ts' --include='*.tsx' \
-            -E 'exec(File|Sync)?\s*\(\s*`' source/ 2>/dev/null | grep -v 'node_modules'; then
+            -E 'exec(File|Sync|Async)?\s*\(\s*`' source/ 2>/dev/null | grep -v 'node_modules'; then
             echo "::error::Shell exec with template literal — command injection risk"
             FAIL=1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,29 @@ tags: [jira, project-management]
 tool-permissions:
   jira_create_issue: destructive
   jira_view_issues: safe
+tools:                            # Declare tool schemas (avoids importing tool modules)
+  - name: jira_view_issues
+    description: View Jira issues assigned to the current user
+    inputSchema:
+      type: object
+      properties:
+        max_results:
+          type: number
+          description: Maximum number of results
+      required: []
+  - name: jira_create_issue
+    description: Create a new Jira issue
+    destructive: true
+    inputSchema:
+      type: object
+      properties:
+        project:
+          type: string
+        summary:
+          type: string
+        description:
+          type: string
+      required: [project, summary]
 enabled: true
 ---
 
@@ -99,6 +122,12 @@ enabled: true
 
 You are a Jira assistant with access to Jira REST API...
 ```
+
+### Tool Schema Declaration
+
+Declaring `tools` in AGENT.md provides accurate schemas to the model without importing tool modules. Without this, the model sees a placeholder schema (`{ task: string }`) until the tool's first invocation — which means the first call will use the wrong arguments.
+
+Tool names in the manifest should use underscores (matching the convention for `.mjs` filenames with hyphens: `search-issues.mjs` → `name: search_issues`).
 
 ### Tool Format (.mjs)
 
@@ -164,7 +193,7 @@ Credentials are stored per-agent in encrypted `config.json`:
 }
 ```
 
-At runtime, credentials are injected into `process.env` for the agent's execution scope only.
+At runtime, credentials are injected into `process.env` for the duration of each tool call only. They are not present in the main session's environment.
 
 ### Setting Credentials (Manual)
 
@@ -206,9 +235,11 @@ Your agent must implement:
 
 Agav will:
 1. Start the process via `start-command`
-2. Poll `/health` until ready
+2. Poll `/health` until ready (loopback only — remote endpoints are not supported)
 3. Send tasks to `/execute`
 4. Kill the process on exit
+
+> **Note:** `start-command` executes a binary from the downloaded agent manifest. Review the command before installing agents from untrusted sources.
 
 ## Marketplace
 
@@ -462,8 +493,8 @@ tool-permissions:
 
 - Credentials are per-agent (no cross-contamination)
 - Encrypted at rest using agav's encrypt/decrypt
-- Injected into `process.env` only during agent execution
-- Restored after execution completes
+- Injected into `process.env` only during individual tool calls (not the entire agent run)
+- Never visible to the main session's `run_command`
 
 ### HITL (Human-in-the-Loop)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,634 @@
+# Agav Service Agents System
+
+A complete service agent system for agav with native (JS/TS) and polyglot (A2A protocol) support.
+
+## Overview
+
+Service agents are specialized assistants that integrate with external services (Jira, GitHub, Slack, etc.). The main agav agent can delegate tasks to these service agents, enabling multi-agent orchestration.
+
+## Key Features
+
+- ✅ **Multi-Agent Orchestration** - Main agent delegates to specialized service agents
+- ✅ **Pluggable Post-Build** - Install agents without recompiling agav
+- ✅ **Low-Code Creation** - Simple `.mjs` tool files + YAML manifest
+- ✅ **Security** - Per-agent encrypted credentials, HITL for destructive tools
+- ✅ **Native + Polyglot** - JS/TS in-process + HTTP for Python/Go/Rust
+- ✅ **Three-Tier Priority** - Bundled < Global < Project overrides
+- ✅ **Dynamic Discovery** - Catalog injection, LLM routing by description
+- ✅ **Marketplace** - Browse and install agents from git repositories
+- ✅ **Full CLI + TUI** - Command-line and interactive management
+
+## Quick Start
+
+### Install an Agent
+
+```bash
+# From CLI
+agav agents install https://github.com/your-org/agents/jira-agent
+
+# Or use the TUI
+agav
+/agents  # Opens interactive TUI
+[2]      # Navigate to Marketplace tab
+ENTER    # Install selected agent
+```
+
+### Use an Agent
+
+```bash
+agav run "Use the jira agent to show me my open issues"
+```
+
+The main agent will automatically route to the `jira_agent` tool when appropriate.
+
+### Manage Agents
+
+```bash
+# List all agents
+agav agents list
+
+# Enable/disable an agent
+agav agents disable jira
+agav agents enable jira
+
+# Remove an agent
+agav agents remove jira
+
+# Interactive management
+agav
+/agents
+[1]       # List tab
+ENTER/i   # Inspect selected agent
+d/e       # Disable/enable
+```
+
+## Agent Structure
+
+```
+agent-name/
+  AGENT.md          # Manifest + system prompt
+  tools/            # Tool implementations
+    tool1.mjs
+    tool2.mjs
+  config.json       # Encrypted credentials (auto-generated)
+```
+
+### AGENT.md Format
+
+```yaml
+---
+name: jira
+description: Jira agent for issue tracking
+version: 1.0.0
+type: native                    # or "a2a" for polyglot
+required-config:
+  - JIRA_URL
+  - JIRA_EMAIL
+  - JIRA_API_TOKEN
+tools-dir: ./tools
+model: claude-sonnet-4-5        # Optional override
+effort: medium                  # Optional override
+tags: [jira, project-management]
+tool-permissions:
+  jira_create_issue: destructive
+  jira_view_issues: safe
+enabled: true
+---
+
+# System Prompt
+
+You are a Jira assistant with access to Jira REST API...
+```
+
+### Tool Format (.mjs)
+
+```javascript
+export default {
+  schema: {
+    name: "jira_view_issues",
+    description: "View all Jira issues assigned to me",
+    destructive: false,
+    inputSchema: {
+      type: "object",
+      properties: {
+        max_results: { type: "number", default: 50 }
+      }
+    }
+  },
+  async execute(input) {
+    const { JIRA_URL, JIRA_EMAIL, JIRA_API_TOKEN } = process.env;
+    
+    // Tool implementation using credentials
+    const response = await fetch(`${JIRA_URL}/rest/api/3/search?...`);
+    
+    return {
+      output: "Result text...",
+      isError: false
+    };
+  }
+};
+```
+
+## Agent Loading (Three-Tier)
+
+Agents are loaded from three locations, with later tiers overriding earlier ones by name:
+
+1. **Bundled** (`source/agents/bundled/`) - Shipped with agav
+2. **Global** (`~/.agav/agents/`) - User-wide installations
+3. **Project** (`.agav/agents/`) - Project-local overrides
+
+```bash
+# Example: Override bundled jira agent with custom version
+mkdir -p .agav/agents/jira
+cp -r ~/.agav/agents/my-custom-jira/* .agav/agents/jira/
+```
+
+## Credentials
+
+Agents declare required credentials in `required-config`:
+
+```yaml
+required-config:
+  - JIRA_URL
+  - JIRA_EMAIL
+  - JIRA_API_TOKEN
+```
+
+Credentials are stored per-agent in encrypted `config.json`:
+
+```json
+{
+  "JIRA_URL": "encrypted:abc123...",
+  "JIRA_EMAIL": "encrypted:def456...",
+  "JIRA_API_TOKEN": "encrypted:ghi789..."
+}
+```
+
+At runtime, credentials are injected into `process.env` for the agent's execution scope only.
+
+### Setting Credentials (Manual)
+
+```bash
+# Edit ~/.agav/agents/jira/config.json
+{
+  "JIRA_URL": "https://your-domain.atlassian.net",
+  "JIRA_EMAIL": "user@example.com",
+  "JIRA_API_TOKEN": "your-api-token"
+}
+
+# Agav will encrypt on next run
+```
+
+## Polyglot Agents (A2A Protocol)
+
+For agents in other languages (Python, Go, Rust), use the A2A protocol:
+
+### AGENT.md for A2A
+
+```yaml
+---
+name: my-python-agent
+type: a2a
+start-command: python agent.py --port 4000
+endpoint: http://localhost:4000
+description: Custom Python agent
+version: 1.0.0
+---
+```
+
+### A2A Protocol Endpoints
+
+Your agent must implement:
+
+- `GET /health` - Health check (returns 200 when ready)
+- `POST /execute` - Execute task (request: `{task, context}`, response: `{output, isError}`)
+- `POST /stream` - Stream execution (SSE format, optional)
+
+Agav will:
+1. Start the process via `start-command`
+2. Poll `/health` until ready
+3. Send tasks to `/execute`
+4. Kill the process on exit
+
+## Marketplace
+
+### Using a Marketplace
+
+Configure in `~/.agav/config.json`:
+
+```json
+{
+  "agentMarketplace": "https://raw.githubusercontent.com/your-org/agav-agents/main"
+}
+```
+
+Browse and install via TUI:
+
+```bash
+agav
+/agents
+[2]       # Marketplace tab
+↑↓        # Navigate
+ENTER     # Install
+```
+
+### Creating a Marketplace
+
+1. Create a git repository
+2. Add `index.json` in root:
+
+```json
+{
+  "version": "1.0.0",
+  "agents": [
+    {
+      "name": "jira",
+      "description": "Jira agent for issue tracking",
+      "category": "project-management",
+      "tags": ["jira", "issues"],
+      "version": "1.0.0",
+      "path": "agents/jira",
+      "tool-count": 5,
+      "has-destructive-tools": true
+    }
+  ],
+  "categories": [
+    {
+      "id": "project-management",
+      "name": "Project Management"
+    }
+  ]
+}
+```
+
+3. Create `agents/jira/` with `AGENT.md` + `tools/*.mjs`
+4. Host on GitHub or any static server
+
+Users install with:
+
+```bash
+agav agents install https://raw.githubusercontent.com/your-org/agav-agents/main/agents/jira
+```
+
+## Creating Your Own Agent
+
+### Quick Start
+
+1. Create directory structure:
+
+```bash
+mkdir -p my-agent/tools
+cd my-agent
+```
+
+2. Create `AGENT.md`:
+
+```yaml
+---
+name: my-agent
+description: My custom agent
+version: 1.0.0
+type: native
+tools-dir: ./tools
+enabled: true
+---
+
+# My Agent
+
+System prompt goes here...
+```
+
+3. Create tools in `tools/*.mjs`:
+
+```javascript
+// tools/my-tool.mjs
+export default {
+  schema: {
+    name: "my_tool",
+    description: "Does something useful",
+    destructive: false,
+    inputSchema: {
+      type: "object",
+      properties: {
+        input: { type: "string" }
+      },
+      required: ["input"]
+    }
+  },
+  async execute(input) {
+    return {
+      output: `Processed: ${input.input}`,
+      isError: false
+    };
+  }
+};
+```
+
+4. Install locally:
+
+```bash
+agav agents install ./my-agent
+```
+
+5. Test:
+
+```bash
+agav run "Use my agent to process 'hello world'"
+```
+
+## Multi-Agent Orchestration
+
+The main agent can call multiple service agents in sequence or parallel:
+
+### Example: Sequential
+
+```
+User: "Get details on JIRA-123 and create a GitHub issue for it"
+
+Main agent reasoning:
+1. Call jira_agent({ task: "get details of JIRA-123" })
+2. Call github_agent({ task: "create issue: ..." })
+3. Synthesize and respond
+```
+
+### Example: Parallel
+
+```
+User: "Show me all my open work across Jira and GitHub"
+
+Main agent reasoning:
+1. Call jira_agent({ task: "get my open issues" }) in parallel with
+   github_agent({ task: "get my assigned PRs and issues" })
+2. Merge results and respond
+```
+
+Service agents do NOT call each other - only the main agent orchestrates.
+
+## Bundled Agents
+
+### test (3 tools)
+
+Simple validation agent:
+- `test_echo` - Echo a message
+- `test_greet` - Greet with a name
+- `test_write` - Write to a file (destructive)
+
+### jira (5 tools)
+
+Production Jira integration:
+
+**Read-only (safe):**
+- `jira_view_my_issues` - View assigned issues
+- `jira_search_issues` - JQL search
+- `jira_get_issue` - Full issue details with comments
+
+**Mutating (destructive):**
+- `jira_create_issue` - Create new issues
+- `jira_add_comment` - Add comments
+
+Requires credentials: `JIRA_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`
+
+## CLI Reference
+
+```bash
+# List all agents
+agav agents list
+
+# Install from URL or local path
+agav agents install <url|path>
+agav agents install https://github.com/org/repo/agents/jira
+agav agents install ./my-local-agent
+agav agents install <url> --alias my-jira --destination project
+
+# Manage agents
+agav agents enable <name>
+agav agents disable <name>
+agav agents remove <name>
+```
+
+## TUI Reference
+
+```bash
+agav
+/agents
+```
+
+**Keyboard Shortcuts:**
+
+```
+1/2/3       Switch tabs (List / Marketplace / Create)
+↑↓          Navigate lists
+ENTER/i     Inspect agent (list) / Install (marketplace)
+d           Disable selected agent
+e           Enable selected agent
+r           Refresh marketplace
+b/ESC       Back (in inspect view)
+q/ESC       Exit
+```
+
+**Tab 1: List**
+- Shows all installed agents grouped by origin
+- Inspect mode shows detailed metadata and tool list
+
+**Tab 2: Marketplace**
+- Browse agents from configured marketplace
+- Install with ENTER
+- Shows tool count and destructive flag warnings
+
+**Tab 3: Create**
+- Placeholder for agent creation wizard (coming soon)
+
+## Slash Commands
+
+```
+/agents     Open interactive TUI
+/help agents    Show detailed help
+```
+
+## Security
+
+### Tool Permissions
+
+Tools are marked in AGENT.md:
+
+```yaml
+tool-permissions:
+  safe_tool: safe           # Never prompts for confirmation
+  write_tool: destructive   # Always prompts (unless --auto-accept)
+  legacy_tool: ~            # Falls back to SAFE_TOOLS list
+```
+
+### Credential Isolation
+
+- Credentials are per-agent (no cross-contamination)
+- Encrypted at rest using agav's encrypt/decrypt
+- Injected into `process.env` only during agent execution
+- Restored after execution completes
+
+### HITL (Human-in-the-Loop)
+
+Destructive tools trigger confirmation prompts showing:
+- Tool name
+- Input parameters
+- Preview of changes (for edits)
+
+User can:
+- Approve (Y)
+- Reject (N)
+- Always allow this tool (A)
+
+## Advanced
+
+### Agent Catalog (System Prompt Injection)
+
+When agents load, their catalog is injected into the system prompt:
+
+```
+Available specialized agents:
+- jira_agent: Jira agent for issue tracking and project management
+- github_agent: GitHub PRs, issues, code review
+```
+
+Token budget: ~500 tokens max, ~30 tokens per agent.
+
+### Tool Routing
+
+The LLM sees each agent as a tool:
+
+```json
+{
+  "name": "jira_agent",
+  "description": "Jira agent for issue tracking and project management via Jira REST API",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "task": {
+        "type": "string",
+        "description": "The task to delegate to this specialized agent"
+      }
+    },
+    "required": ["task"]
+  }
+}
+```
+
+No special routing logic - the LLM decides based on the description.
+
+### Nested Execution
+
+When an agent is called:
+1. Child `ToolRegistry` created with only the agent's tools
+2. Fresh `ConversationState` initialized
+3. `runAgentLoop()` called recursively
+4. Agent's system prompt prepended to base system prompt
+5. Output returned to parent as tool result
+
+### Agent Registry
+
+Persistent state in `~/.agav/agents/registry.json`:
+
+```json
+{
+  "agents": {
+    "jira": {
+      "name": "jira",
+      "alias": null,
+      "enabled": true,
+      "sourceUrl": "https://github.com/...",
+      "installedAt": "2026-08-06T10:32:56.932Z",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+Tracks:
+- Enabled/disabled state (overrides manifest)
+- Installation source (for updates)
+- Install timestamp
+- Aliases (for name conflicts)
+
+## Troubleshooting
+
+### Agent not appearing
+
+```bash
+# Check if loaded
+agav agents list
+
+# Check if enabled
+/agents
+[1]  # List tab, verify status
+
+# Reload agents
+agav  # Restart agav session
+```
+
+### Agent not being called
+
+```bash
+# Check catalog
+agav run "/debug" --auto-accept
+# Look for "Available specialized agents:" section
+
+# Check if disabled
+agav agents list
+```
+
+### Credential errors
+
+```bash
+# Verify credentials exist
+cat ~/.agav/agents/jira/config.json
+
+# Test manually
+node -e "
+const { decrypt } = require('./build/utils/encrypt.js');
+const fs = require('fs');
+const config = JSON.parse(fs.readFileSync('~/.agav/agents/jira/config.json'));
+console.log(decrypt(config.JIRA_URL));
+"
+```
+
+### A2A agent won't start
+
+```bash
+# Check start-command is correct
+cat ~/.agav/agents/my-agent/AGENT.md | grep start-command
+
+# Test manually
+cd ~/.agav/agents/my-agent
+python agent.py --port 4000  # Or whatever start-command says
+
+# Check health endpoint
+curl http://localhost:4000/health
+```
+
+## Examples
+
+See `marketplace-example/` for a sample marketplace structure.
+
+See `source/agents/bundled/` for example agent implementations:
+- `test-agent/` - Minimal example (3 tools)
+- `jira/` - Production example (5 tools, REST API, credentials)
+
+## Contributing
+
+To add a bundled agent:
+
+1. Create `source/agents/bundled/my-agent/`
+2. Add `AGENT.md` + `tools/*.mjs`
+3. Build will auto-copy to `build/agents/bundled/`
+4. Agent loads automatically on next run
+
+To create a marketplace:
+
+1. Fork the marketplace template
+2. Add agents to `agents/` directory
+3. Update `index.json`
+4. Host on GitHub
+5. Share the raw URL
+
+## License
+
+Bundled agents inherit agav's license. Marketplace agents may have different licenses - check each agent's AGENT.md.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build"
   ],
   "scripts": {
-    "build": "tsc && node -e \"require('fs').copyFileSync('source/cli.tsx','build/cli.js')\"",
+    "build": "tsc && node -e \"require('fs').copyFileSync('source/cli.tsx','build/cli.js')\" && node -e \"require('fs').cpSync('source/agents/bundled','build/agents/bundled',{recursive:true})\"",
     "dev": "tsx --watch source/cli.tsx",
     "start": "tsx source/cli.tsx",
     "typecheck": "tsc --noEmit",
@@ -38,7 +38,8 @@
     "openai": "^6.46.0",
     "pdfjs-dist": "^6.1.200",
     "react": "^19.2.0",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@sindresorhus/tsconfig": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A terminal-native environment for running local AI systems",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@22.20.1)
+      yaml:
+        specifier: ^2.3.4
+        version: 2.9.0
     devDependencies:
       '@sindresorhus/tsconfig':
         specifier: ^8.1.0
@@ -1683,6 +1686,11 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -3060,6 +3068,8 @@ snapshots:
   ws@8.21.0: {}
 
   y18n@5.0.8: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/source/__tests__/agents.credentials.test.ts
+++ b/source/__tests__/agents.credentials.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, stat as fsStat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { encrypt, decrypt } from "../utils/encrypt.js";
+import {
+  loadAgentConfig,
+  saveAgentConfig,
+  hasRequiredCredentials,
+  getMissingCredentials,
+} from "../agents/credentials.js";
+import type { AgentManifest } from "../agents/types.js";
+
+describe("agents/credentials", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "agav-cred-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  describe("encrypt/decrypt round-trip", () => {
+    it("encrypts and decrypts a value", () => {
+      const original = "my-secret-api-key-12345";
+      const encrypted = encrypt(original);
+      expect(encrypted).not.toBe(original);
+      expect(encrypted.startsWith("enc:")).toBe(true);
+      expect(decrypt(encrypted)).toBe(original);
+    });
+
+    it("handles empty string", () => {
+      expect(encrypt("")).toBe("");
+      expect(decrypt("")).toBe("");
+    });
+  });
+
+  describe("saveAgentConfig / loadAgentConfig round-trip", () => {
+    it("saves encrypted and loads decrypted", async () => {
+      const config = { API_KEY: "secret-123", API_SECRET: "secret-456" };
+      await saveAgentConfig(dir, config);
+
+      // Verify file is encrypted on disk
+      const raw = JSON.parse(await readFile(join(dir, "config.json"), "utf-8"));
+      expect(raw.API_KEY).not.toBe("secret-123");
+      expect(raw.API_KEY.startsWith("enc:")).toBe(true);
+
+      // Load should decrypt
+      const loaded = await loadAgentConfig(dir);
+      expect(loaded).toEqual(config);
+    });
+
+    it("returns empty object for missing config.json", async () => {
+      const loaded = await loadAgentConfig(join(dir, "nonexistent"));
+      expect(loaded).toEqual({});
+    });
+  });
+
+  describe("file permissions", () => {
+    it("creates config.json with restricted permissions", async () => {
+      await saveAgentConfig(dir, { KEY: "value" });
+      const stats = await fsStat(join(dir, "config.json"));
+      // On Windows, mode bits are limited; on Unix, check 0o600
+      if (process.platform !== "win32") {
+        const mode = stats.mode & 0o777;
+        expect(mode).toBe(0o600);
+      }
+    });
+  });
+
+  describe("hasRequiredCredentials and getMissingCredentials agreement", () => {
+    const manifest = {
+      name: "test",
+      description: "test",
+      version: "1.0.0",
+      "required-config": ["API_KEY", "API_SECRET"],
+    } as AgentManifest;
+
+    it("both report missing when nothing is configured", async () => {
+      const has = await hasRequiredCredentials(dir, manifest);
+      const missing = await getMissingCredentials(dir, manifest);
+      expect(has).toBe(false);
+      expect(missing).toEqual(["API_KEY", "API_SECRET"]);
+    });
+
+    it("both agree when config.json has all keys", async () => {
+      await saveAgentConfig(dir, { API_KEY: "k1", API_SECRET: "k2" });
+      const has = await hasRequiredCredentials(dir, manifest);
+      const missing = await getMissingCredentials(dir, manifest);
+      expect(has).toBe(true);
+      expect(missing).toEqual([]);
+    });
+
+    it("both agree when env vars provide missing keys", async () => {
+      const oldKey = process.env.API_KEY;
+      const oldSecret = process.env.API_SECRET;
+      try {
+        process.env.API_KEY = "from-env";
+        process.env.API_SECRET = "from-env";
+        const has = await hasRequiredCredentials(dir, manifest);
+        const missing = await getMissingCredentials(dir, manifest);
+        expect(has).toBe(true);
+        expect(missing).toEqual([]);
+      } finally {
+        if (oldKey === undefined) delete process.env.API_KEY;
+        else process.env.API_KEY = oldKey;
+        if (oldSecret === undefined) delete process.env.API_SECRET;
+        else process.env.API_SECRET = oldSecret;
+      }
+    });
+  });
+});

--- a/source/__tests__/agents.installer.test.ts
+++ b/source/__tests__/agents.installer.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readdir: vi.fn(),
+  rm: vi.fn().mockResolvedValue(undefined),
+  cp: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+vi.mock("../agents/loader.js", () => ({
+  loadAgent: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../agents/agent-registry.js", () => ({
+  registerAgent: vi.fn().mockResolvedValue(undefined),
+  isAgentRegistered: vi.fn().mockResolvedValue(false),
+  loadRegistry: vi.fn().mockResolvedValue({ agents: {} }),
+  saveRegistry: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { installAgent, uninstallAgent } from "../agents/installer.js";
+
+describe("agents/installer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("validateAgentName (via alias)", () => {
+    it("rejects path traversal in alias", async () => {
+      const result = await installAgent("/some/local/path", {
+        alias: "../../../etc/passwd",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent name");
+    });
+
+    it("rejects shell metacharacters in alias", async () => {
+      const result = await installAgent("/some/local/path", {
+        alias: "$(rm -rf /)",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent name");
+    });
+
+    it("rejects absolute path as alias", async () => {
+      const result = await installAgent("/some/local/path", {
+        alias: "/etc/passwd",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent name");
+    });
+
+    it("rejects empty alias", async () => {
+      const result = await installAgent("/some/local/path", {
+        alias: "",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent name");
+    });
+
+    it("rejects names with spaces", async () => {
+      const result = await installAgent("/some/local/path", {
+        alias: "my agent",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent name");
+    });
+  });
+
+  describe("validateGitUrl", () => {
+    it("rejects non-allowlisted hosts", async () => {
+      const result = await installAgent("https://evil.com/owner/repo");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Untrusted git host");
+    });
+
+    it("rejects command injection in URL", async () => {
+      const result = await installAgent("https://evil.com/$(whoami)/repo");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Untrusted git host");
+    });
+  });
+
+  describe("uninstallAgent", () => {
+    it("rejects path traversal names", async () => {
+      const result = await uninstallAgent("../../etc");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent name");
+    });
+
+    it("rejects shell metacharacters", async () => {
+      const result = await uninstallAgent("foo;rm -rf /");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent name");
+    });
+  });
+});

--- a/source/__tests__/agents.installer.test.ts
+++ b/source/__tests__/agents.installer.test.ts
@@ -24,11 +24,30 @@ vi.mock("../agents/agent-registry.js", () => ({
   saveRegistry: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { execFile } from "node:child_process";
 import { installAgent, uninstallAgent } from "../agents/installer.js";
 
 describe("agents/installer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("subPath traversal in sparse-checkout URLs", () => {
+    it("rejects URLs with ../ path traversal in the subdirectory portion", async () => {
+      // Mock execFile so git clone "succeeds"
+      vi.mocked(execFile).mockImplementation((...args: any[]) => {
+        const cb = args[args.length - 1];
+        if (typeof cb === "function") cb(null, "", "");
+        return undefined as any;
+      });
+
+      // URL passes host allowlist but has traversal in the path
+      const result = await installAgent(
+        "https://github.com/owner/repo/agents/../../../../etc/passwd"
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("escapes");
+    });
   });
 
   describe("validateAgentName (via alias)", () => {

--- a/source/__tests__/agents.installer.test.ts
+++ b/source/__tests__/agents.installer.test.ts
@@ -11,6 +11,7 @@ vi.mock("node:fs/promises", () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   stat: vi.fn(),
   readFile: vi.fn(),
+  realpath: vi.fn((p: string) => Promise.resolve(p)),
 }));
 
 vi.mock("../agents/loader.js", () => ({

--- a/source/__tests__/agents.lazy-load.test.ts
+++ b/source/__tests__/agents.lazy-load.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadAgent } from "../agents/loader.js";
+
+const SIDE_EFFECT_KEY = "__agavLazyLoadTestFlag";
+
+describe("agents/loader lazy loading", () => {
+  let agentDir: string;
+
+  beforeEach(async () => {
+    agentDir = await mkdtemp(join(tmpdir(), "agav-lazy-test-"));
+    delete (globalThis as any)[SIDE_EFFECT_KEY];
+  });
+
+  afterEach(async () => {
+    delete (globalThis as any)[SIDE_EFFECT_KEY];
+    await rm(agentDir, { recursive: true, force: true });
+  });
+
+  it("does not execute tool code at scan time — defers to first invocation", async () => {
+    // Create a minimal agent with a tool that sets a global flag on import
+    await writeFile(join(agentDir, "AGENT.md"), [
+      "---",
+      "name: lazy-test",
+      "description: Tests lazy loading",
+      "version: 1.0.0",
+      "---",
+      "Test agent.",
+    ].join("\n"));
+
+    const toolsDir = join(agentDir, "tools");
+    await mkdir(toolsDir, { recursive: true });
+    await writeFile(join(toolsDir, "side-effect.mjs"), [
+      `globalThis.${SIDE_EFFECT_KEY} = true;`,
+      `export default {`,
+      `  schema: { name: "side_effect", description: "test", inputSchema: { type: "object", properties: {} } },`,
+      `  async execute(input) { return { output: "ran", isError: false }; }`,
+      `};`,
+    ].join("\n"));
+
+    // loadAgent scans the tools directory but should NOT import the .mjs file
+    const agent = await loadAgent(agentDir, "global");
+    expect(agent).not.toBeNull();
+    expect(agent!.tools.length).toBe(1);
+    expect((globalThis as any)[SIDE_EFFECT_KEY]).toBeUndefined();
+
+    // First execute() call should trigger the lazy import
+    const result = await agent!.tools[0].execute({ task: "test" });
+    expect((globalThis as any)[SIDE_EFFECT_KEY]).toBe(true);
+    expect(result.output).toBe("ran");
+  });
+});

--- a/source/__tests__/agents.loader.test.ts
+++ b/source/__tests__/agents.loader.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+  readdir: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  stat: vi.fn(),
+}));
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import { loadAgent } from "../agents/loader.js";
+
+describe("agents/loader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: stat succeeds for AGENT.md, readdir fails for tools dir (no tools)
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any);
+    vi.mocked(readdir).mockRejectedValue(new Error("ENOENT"));
+  });
+
+  describe("parseAgentMarkdown (via loadAgent)", () => {
+    it("parses nested tool-permissions and mcp-servers", async () => {
+      const agentMd = [
+        "---",
+        "name: test-agent",
+        "description: A test agent",
+        "version: 1.0.0",
+        "tool-permissions:",
+        "  run_query: safe",
+        "  delete_table: destructive",
+        "mcp-servers:",
+        "  - key: db-server",
+        "    command: npx",
+        '    args: ["-y", "@db/mcp"]',
+        "---",
+        "You are a test agent.",
+      ].join("\n");
+
+      vi.mocked(readFile).mockResolvedValue(agentMd);
+
+      const agent = await loadAgent("/fake/agent-dir", "global");
+
+      expect(agent).not.toBeNull();
+      expect(agent!.manifest.name).toBe("test-agent");
+      expect(agent!.manifest["tool-permissions"]).toEqual({
+        run_query: "safe",
+        delete_table: "destructive",
+      });
+      expect(agent!.manifest["mcp-servers"]).toEqual([
+        { key: "db-server", command: "npx", args: ["-y", "@db/mcp"] },
+      ]);
+      expect(agent!.systemPrompt).toBe("You are a test agent.");
+    });
+
+    it("parses CRLF line endings", async () => {
+      const agentMd = [
+        "---",
+        "name: crlf-agent",
+        "description: CRLF test",
+        "version: 0.1.0",
+        "---",
+        "System prompt body.",
+      ].join("\r\n");
+
+      vi.mocked(readFile).mockResolvedValue(agentMd);
+
+      const agent = await loadAgent("/fake/crlf-dir", "global");
+
+      expect(agent).not.toBeNull();
+      expect(agent!.manifest.name).toBe("crlf-agent");
+      expect(agent!.systemPrompt).toBe("System prompt body.");
+    });
+
+    it("returns null on missing frontmatter", async () => {
+      vi.mocked(readFile).mockResolvedValue("No frontmatter here.");
+
+      const agent = await loadAgent("/fake/bad-dir", "global");
+      expect(agent).toBeNull();
+    });
+
+    it("returns null on missing required fields", async () => {
+      const agentMd = [
+        "---",
+        "name: incomplete",
+        "---",
+        "Body.",
+      ].join("\n");
+
+      vi.mocked(readFile).mockResolvedValue(agentMd);
+
+      const agent = await loadAgent("/fake/incomplete-dir", "global");
+      expect(agent).toBeNull();
+    });
+
+    it("parses required-config as array", async () => {
+      const agentMd = [
+        "---",
+        "name: config-agent",
+        "description: Agent with config",
+        "version: 1.0.0",
+        "required-config:",
+        "  - API_KEY",
+        "  - API_SECRET",
+        "---",
+        "Prompt.",
+      ].join("\n");
+
+      vi.mocked(readFile).mockResolvedValue(agentMd);
+
+      const agent = await loadAgent("/fake/config-dir", "global");
+
+      expect(agent).not.toBeNull();
+      expect(agent!.manifest["required-config"]).toEqual(["API_KEY", "API_SECRET"]);
+    });
+  });
+});

--- a/source/__tests__/agents.permission-gate.test.ts
+++ b/source/__tests__/agents.permission-gate.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runAgentLoop } from "../agent/loop.js";
+import { ConversationState } from "../agent/conversation.js";
+import { ToolRegistry } from "../tools/registry.js";
+import type { LLMProvider, StreamEvent, StreamParams } from "../providers/types.js";
+import type { ToolDefinition } from "../tools/types.js";
+import type { AgentEvent } from "../agent/loop.js";
+
+class MockProvider implements LLMProvider {
+  streams: StreamEvent[][];
+  name = "mock";
+  constructor(streams: StreamEvent[][]) {
+    this.streams = streams;
+  }
+  stream = vi.fn((_params: StreamParams) => {
+    const events = this.streams.shift() ?? [];
+    return (async function* () {
+      for (const event of events) yield event;
+    })();
+  });
+}
+
+function makeToolCallStream(toolName: string, args: Record<string, unknown>): StreamEvent[] {
+  return [
+    { type: "tool_call_start" as const, toolCallId: "tc_1", toolName },
+    { type: "tool_call_delta" as const, toolCallId: "tc_1", argsJson: JSON.stringify(args) },
+    { type: "tool_call_end" as const, toolCallId: "tc_1" },
+    { type: "usage" as const, inputTokens: 10, outputTokens: 5 },
+  ];
+}
+
+async function collectEvents(loop: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of loop) events.push(event);
+  return events;
+}
+
+describe("permission gate: destructive flag trust", () => {
+  let cwd: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    cwd = await mkdtemp(join(tmpdir(), "agav-perm-gate-"));
+    process.chdir(cwd);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("non-builtin tool with destructive:false still triggers confirmation in ask mode", async () => {
+    const externalTool: ToolDefinition = {
+      schema: {
+        name: "external_agent",
+        description: "An external agent tool",
+        destructive: false,
+        inputSchema: { type: "object", properties: { task: { type: "string" } } },
+      },
+      execute: vi.fn().mockResolvedValue({ output: "done", isError: false }),
+    };
+
+    const registry = new ToolRegistry();
+    registry.register(externalTool);
+
+    const confirmTool = vi.fn().mockResolvedValue("yes");
+
+    const provider = new MockProvider([
+      makeToolCallStream("external_agent", { task: "do something" }),
+      [{ type: "text_delta" as const, text: "Done" }, { type: "usage" as const, inputTokens: 5, outputTokens: 3 }],
+    ]);
+
+    const conversation = new ConversationState();
+    conversation.addUserMessage("test");
+
+    await collectEvents(
+      runAgentLoop({
+        provider,
+        conversation,
+        toolRegistry: registry,
+        model: "mock",
+        systemPrompt: "test",
+        effort: "low",
+        maxTokens: 1000,
+        confirmTool,
+        permissionMode: "ask",
+        maxIterations: 2,
+      })
+    );
+
+    // The tool is not in SAFE_TOOLS, so even with destructive:false it should prompt
+    expect(confirmTool).toHaveBeenCalled();
+  });
+
+  it("deny-writes mode blocks non-builtin tool regardless of destructive flag", async () => {
+    const agentTool: ToolDefinition = {
+      schema: {
+        name: "jira_agent",
+        description: "Jira agent",
+        destructive: false,
+        inputSchema: { type: "object", properties: { task: { type: "string" } } },
+      },
+      execute: vi.fn().mockResolvedValue({ output: "done", isError: false }),
+    };
+
+    const registry = new ToolRegistry();
+    registry.register(agentTool);
+
+    const provider = new MockProvider([
+      makeToolCallStream("jira_agent", { task: "create ticket" }),
+      [{ type: "text_delta" as const, text: "Blocked" }, { type: "usage" as const, inputTokens: 5, outputTokens: 3 }],
+    ]);
+
+    const conversation = new ConversationState();
+    conversation.addUserMessage("test");
+
+    const events = await collectEvents(
+      runAgentLoop({
+        provider,
+        conversation,
+        toolRegistry: registry,
+        model: "mock",
+        systemPrompt: "test",
+        effort: "low",
+        maxTokens: 1000,
+        permissionMode: "deny-writes",
+        maxIterations: 2,
+      })
+    );
+
+    // Tool should NOT have been executed
+    expect(agentTool.execute).not.toHaveBeenCalled();
+
+    // Should see an error result about denied/confirmation
+    const toolResults = events.filter((e) => e.type === "tool_result");
+    expect(toolResults.length).toBeGreaterThan(0);
+    const result = toolResults[0] as any;
+    expect(result.isError).toBe(true);
+  });
+});

--- a/source/__tests__/agents.registry.test.ts
+++ b/source/__tests__/agents.registry.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("agents/agent-registry", () => {
+  let fakeHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    fakeHome = await mkdtemp(join(tmpdir(), "agav-reg-test-"));
+    originalHome = process.env.HOME;
+    // Override HOME so homedir() returns our fake dir
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    await mkdir(join(fakeHome, ".agav", "agents"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    await rm(fakeHome, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it("returns empty registry when no file exists", async () => {
+    const { loadRegistry } = await import("../agents/agent-registry.js");
+    const reg = await loadRegistry();
+    expect(reg).toEqual({ agents: {} });
+  });
+
+  it("round-trips an agent through register and load", async () => {
+    const { registerAgent, loadRegistry } = await import("../agents/agent-registry.js");
+    await registerAgent({
+      name: "test-agent",
+      enabled: true,
+      installedAt: "2026-01-01T00:00:00Z",
+      version: "1.0.0",
+    });
+
+    const reg = await loadRegistry();
+    expect(reg.agents["test-agent"]).toBeDefined();
+    expect(reg.agents["test-agent"].enabled).toBe(true);
+  });
+
+  it("unregisters an agent", async () => {
+    const { registerAgent, unregisterAgent, loadRegistry } = await import("../agents/agent-registry.js");
+    await registerAgent({
+      name: "to-remove",
+      enabled: true,
+      installedAt: "2026-01-01T00:00:00Z",
+      version: "1.0.0",
+    });
+
+    await unregisterAgent("to-remove");
+    const reg = await loadRegistry();
+    expect(reg.agents["to-remove"]).toBeUndefined();
+  });
+
+  it("recovers from corrupt registry.json with warning", async () => {
+    const regPath = join(fakeHome, ".agav", "agents", "registry.json");
+    await writeFile(regPath, "this is not valid json{{{", "utf-8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { loadRegistry } = await import("../agents/agent-registry.js");
+    const reg = await loadRegistry();
+
+    expect(reg).toEqual({ agents: {} });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("saves valid JSON to registry file", async () => {
+    const { registerAgent } = await import("../agents/agent-registry.js");
+    await registerAgent({
+      name: "atomic-test",
+      enabled: true,
+      installedAt: "2026-01-01T00:00:00Z",
+      version: "1.0.0",
+    });
+
+    const regPath = join(fakeHome, ".agav", "agents", "registry.json");
+    const content = await readFile(regPath, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.agents["atomic-test"]).toBeDefined();
+  });
+});

--- a/source/__tests__/agents.registry.test.ts
+++ b/source/__tests__/agents.registry.test.ts
@@ -73,6 +73,31 @@ describe("agents/agent-registry", () => {
     warnSpy.mockRestore();
   });
 
+  it("concurrent writes don't corrupt the registry file", async () => {
+    const { registerAgent, loadRegistry } = await import("../agents/agent-registry.js");
+    await Promise.all([
+      registerAgent({
+        name: "agent-a",
+        enabled: true,
+        installedAt: "2026-01-01T00:00:00Z",
+        version: "1.0.0",
+      }),
+      registerAgent({
+        name: "agent-b",
+        enabled: true,
+        installedAt: "2026-01-01T00:00:00Z",
+        version: "1.0.0",
+      }),
+    ]);
+
+    // File should be valid JSON (not corrupted by concurrent writes)
+    const regPath = join(fakeHome, ".agav", "agents", "registry.json");
+    const content = await readFile(regPath, "utf-8");
+    const parsed = JSON.parse(content);
+    // Note: last-writer-wins means one entry may be missing, but file is valid JSON
+    expect(typeof parsed.agents).toBe("object");
+  });
+
   it("saves valid JSON to registry file", async () => {
     const { registerAgent } = await import("../agents/agent-registry.js");
     await registerAgent({

--- a/source/__tests__/commands.model-routing.test.ts
+++ b/source/__tests__/commands.model-routing.test.ts
@@ -26,6 +26,7 @@ const createContext = (provider: AgavConfig["provider"]): CommandContext => ({
   addTokenUsage: vi.fn(),
   setRunningSkill: vi.fn(),
   setPickerActive: vi.fn(),
+  showAgentsTUI: vi.fn(),
 });
 
 const route = async (command: typeof fastCommand, provider: AgavConfig["provider"]) => {

--- a/source/__tests__/commands.model.test.ts
+++ b/source/__tests__/commands.model.test.ts
@@ -57,6 +57,7 @@ function createContext(config: Partial<AgavConfig>): CommandContext {
     addTokenUsage: vi.fn(),
     setRunningSkill: vi.fn(),
     setPickerActive: vi.fn(),
+    showAgentsTUI: vi.fn(),
   };
 }
 

--- a/source/__tests__/commands.registry.test.ts
+++ b/source/__tests__/commands.registry.test.ts
@@ -24,6 +24,7 @@ const createContext = (): CommandContext => ({
   addTokenUsage: vi.fn(),
   setRunningSkill: vi.fn(),
   setPickerActive: vi.fn(),
+  showAgentsTUI: vi.fn(),
 });
 
 describe("commands/registry", () => {

--- a/source/__tests__/skills.commands.test.ts
+++ b/source/__tests__/skills.commands.test.ts
@@ -63,6 +63,7 @@ describe("skills/commands", () => {
       addTokenUsage: vi.fn(),
       setRunningSkill: vi.fn(),
       setPickerActive: vi.fn(),
+      showAgentsTUI: vi.fn(),
     });
 
     const [, passedArgs, deps] = vi.mocked(executeSkill).mock.calls[0]!;

--- a/source/__tests__/utils.system-prompt.test.ts
+++ b/source/__tests__/utils.system-prompt.test.ts
@@ -78,7 +78,7 @@ describe("utils/system-prompt", () => {
 
   it("puts only per-turn state in the volatile context", async () => {
     vi.mocked(getGitContext).mockResolvedValue({ isRepo: true, branch: "main", status: "clean", recentCommits: "", remoteUrl: "" });
-    const ctx = await refreshVolatileContext();
+    const { context: ctx } = await refreshVolatileContext();
 
     expect(ctx).toContain("git block");
     expect(ctx).toContain("steers");

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -347,10 +347,12 @@ export async function* runAgentLoop(
       const tool = params.toolRegistry.list().find((t) => t.schema.name === call.name);
       const toolDestructiveFlag = tool?.schema.destructive;
 
+      // Only trust destructive:false from builtin tools (SAFE_TOOLS).
+      // Non-builtin tools (agents, MCP) cannot lower their own destructive status.
       let isDestructive: boolean;
       if (toolDestructiveFlag === true) {
         isDestructive = true;
-      } else if (toolDestructiveFlag === false) {
+      } else if (toolDestructiveFlag === false && SAFE_TOOLS.has(call.name)) {
         isDestructive = false;
       } else {
         isDestructive = call.name === "run_command" && isDestructiveCommand(String(input.command ?? ""));
@@ -359,9 +361,10 @@ export async function* runAgentLoop(
       const destructiveApproved = isDestructive
         && isAllowed(call.name, input, params.allowedTools, { requirePattern: true });
       const denyWrites = permissionMode === "deny-writes";
+      const trustedSafe = toolDestructiveFlag === false && SAFE_TOOLS.has(call.name);
       const needsConfirm = (isDestructive && !destructiveApproved)
         || (!SAFE_TOOLS.has(call.name)
-          && toolDestructiveFlag !== false
+          && !trustedSafe
           && permissionMode !== "auto-accept"
           && !isAllowed(call.name, input, params.allowedTools));
       if ((denyWrites && isDestructive) || (needsConfirm && (denyWrites || !confirmTool))) {

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -317,9 +317,27 @@ export async function* runAgentLoop(
         continue;
       }
 
-      const isDestructive = call.name === "run_command" && isDestructiveCommand(String(input.command ?? ""));
+      // Check tool's destructive flag from schema
+      const tool = params.toolRegistry.list().find((t) => t.schema.name === call.name);
+      const toolDestructiveFlag = tool?.schema.destructive;
+
+      // Determine if destructive:
+      // - destructive === true → always destructive
+      // - destructive === false → never destructive (safe)
+      // - destructive === undefined → fallback to legacy logic
+      let isDestructive: boolean;
+      if (toolDestructiveFlag === true) {
+        isDestructive = true;
+      } else if (toolDestructiveFlag === false) {
+        isDestructive = false;
+      } else {
+        // Legacy logic: check if run_command with destructive command
+        isDestructive = call.name === "run_command" && isDestructiveCommand(String(input.command ?? ""));
+      }
+
       const needsConfirm = isDestructive
         || (!SAFE_TOOLS.has(call.name)
+          && toolDestructiveFlag !== false // explicit safe tools skip confirmation
           && permissionMode !== "auto-accept"
           && !isAllowed(call.name, input, params.allowedTools));
       if (needsConfirm && permissionMode === "deny-writes") {

--- a/source/agent/subagent-progress.ts
+++ b/source/agent/subagent-progress.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared helper for tracking named-agent and subagent progress in the UI.
+ * Used by both the built-in `subagent` tool and named agents registered via agentToTool().
+ */
+
+import type { SubagentProgress } from "./subagent-types.js";
+import type { AgentEvent } from "./loop.js";
+
+/**
+ * Creates a progress tracker for a single agent invocation.
+ *
+ * Returns an `onEvent` function that should be called for every AgentEvent
+ * emitted by the child runAgentLoop. It maintains a SubagentProgress entry
+ * in the provided state setter, creating it on first call.
+ *
+ * @param id       Unique ID for this agent invocation
+ * @param title    Display name (agent manifest name or subagent title)
+ * @param task     Task description (shown in detail view)
+ * @param setState React state setter for the SubagentProgress[] array
+ */
+export function makeAgentProgressTracker(
+  id: string,
+  title: string,
+  task: string,
+  setState: (updater: (prev: SubagentProgress[]) => SubagentProgress[]) => void,
+): (event: AgentEvent) => void {
+  let seeded = false;
+
+  function seed() {
+    if (seeded) return;
+    seeded = true;
+    const entry: SubagentProgress = {
+      id,
+      title,
+      task,
+      status: "running",
+      toolCalls: [],
+      streamingText: "",
+      startedAt: Date.now(),
+      totalToolCalls: 0,
+      tokenUsage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0 },
+    };
+    setState((prev) => [...prev, entry]);
+  }
+
+  function update(updater: (entry: SubagentProgress) => SubagentProgress) {
+    setState((prev) =>
+      prev.map((e) => (e.id === id ? updater(e) : e))
+    );
+  }
+
+  return (event: AgentEvent) => {
+    seed();
+
+    switch (event.type) {
+      case "streaming_text":
+        update((e) => ({ ...e, streamingText: e.streamingText + event.text }));
+        break;
+
+      case "tool_call_start":
+        update((e) => ({
+          ...e,
+          totalToolCalls: e.totalToolCalls + 1,
+          toolCalls: [...e.toolCalls, { toolName: event.toolName, input: {}, status: "running" }],
+        }));
+        break;
+
+      case "tool_result":
+        update((e) => ({
+          ...e,
+          toolCalls: e.toolCalls.map((tc) =>
+            tc.toolName === event.toolName && tc.status === "running"
+              ? { ...tc, status: event.isError ? "error" : "done" }
+              : tc
+          ),
+        }));
+        break;
+
+      case "assistant_message_complete":
+        update((e) => ({ ...e, streamingText: "", toolCalls: [] }));
+        break;
+
+      case "turn_complete":
+        // Mark done but keep visible — the next turn's setSubagentStates([]) handles cleanup.
+        // This lets the user see which sub-tools were called after the agent finishes.
+        update((e) => ({ ...e, status: "done", streamingText: "" }));
+        break;
+
+      case "error":
+        update((e) => ({ ...e, status: "error", error: event.error.message, streamingText: "" }));
+        break;
+
+      case "usage":
+        update((e) => ({
+          ...e,
+          tokenUsage: {
+            inputTokens: e.tokenUsage.inputTokens + event.inputTokens,
+            outputTokens: e.tokenUsage.outputTokens + event.outputTokens,
+            cacheReadTokens: e.tokenUsage.cacheReadTokens + (event.cacheReadTokens ?? 0),
+          },
+        }));
+        break;
+    }
+  };
+}

--- a/source/agent/subagent-progress.ts
+++ b/source/agent/subagent-progress.ts
@@ -36,6 +36,7 @@ export function makeAgentProgressTracker(
       status: "running",
       toolCalls: [],
       streamingText: "",
+      thinkingText: "",
       startedAt: Date.now(),
       totalToolCalls: 0,
       tokenUsage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0 },

--- a/source/agents/a2a-client.ts
+++ b/source/agents/a2a-client.ts
@@ -8,12 +8,11 @@ import type { AgentDefinition } from "./types.js";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
 
-function assertLoopbackEndpoint(endpoint: string, allowRemote?: boolean): void {
-  if (allowRemote) return;
+function assertLoopbackEndpoint(endpoint: string): void {
   const parsed = new URL(endpoint);
   if (!LOOPBACK_HOSTS.has(parsed.hostname)) {
     throw new Error(
-      `A2A endpoint "${endpoint}" is not loopback. Set "allow-remote-endpoint: true" in the manifest to allow remote endpoints.`
+      `A2A endpoint "${endpoint}" is not loopback. A2A endpoints must be loopback (127.0.0.1/localhost/::1). Remote endpoints are not supported.`
     );
   }
 }
@@ -102,7 +101,7 @@ export async function startA2AAgent(agent: AgentDefinition): Promise<{ success: 
   }
 
   try {
-    assertLoopbackEndpoint(endpoint, (agent.manifest as any)["allow-remote-endpoint"]);
+    assertLoopbackEndpoint(endpoint);
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : String(e) };
   }

--- a/source/agents/a2a-client.ts
+++ b/source/agents/a2a-client.ts
@@ -1,0 +1,310 @@
+/**
+ * A2A (Agent-to-Agent) protocol client
+ * Implements Google's A2A protocol for communicating with external agents via HTTP
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import type { AgentDefinition } from "./types.js";
+
+/**
+ * A2A request format
+ */
+interface A2ARequest {
+  task: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * A2A response format
+ */
+interface A2AResponse {
+  output: string;
+  isError: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * A2A event types for streaming
+ */
+type A2AEvent =
+  | { type: "text"; text: string }
+  | { type: "tool_call"; name: string; input: unknown }
+  | { type: "tool_result"; name: string; output: string; isError: boolean }
+  | { type: "error"; error: string }
+  | { type: "done"; output: string };
+
+/**
+ * Managed A2A agent process
+ */
+interface ManagedA2AAgent {
+  agent: AgentDefinition;
+  process: ChildProcess;
+  endpoint: string;
+  ready: boolean;
+}
+
+/**
+ * Registry of managed A2A agent processes
+ */
+const managedAgents = new Map<string, ManagedA2AAgent>();
+
+/**
+ * Start an A2A agent process if it has a start-command
+ */
+export async function startA2AAgent(agent: AgentDefinition): Promise<{ success: boolean; error?: string }> {
+  const key = agent.alias || agent.manifest.name;
+
+  // Already running
+  if (managedAgents.has(key)) {
+    return { success: true };
+  }
+
+  const startCommand = agent.manifest["start-command"];
+  if (!startCommand) {
+    return { success: false, error: "No start-command defined for A2A agent" };
+  }
+
+  const endpoint = agent.manifest.endpoint;
+  if (!endpoint) {
+    return { success: false, error: "No endpoint defined for A2A agent" };
+  }
+
+  // Parse command and args
+  const parts = startCommand.split(/\s+/);
+  const command = parts[0]!;
+  const args = parts.slice(1);
+
+  try {
+    const proc = spawn(command, args, {
+      cwd: agent.path,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    proc.stdout?.on("data", (data) => {
+      // Log stdout for debugging
+      console.error(`[A2A ${key}] ${data.toString()}`);
+    });
+
+    proc.stderr?.on("data", (data) => {
+      console.error(`[A2A ${key}] ERROR: ${data.toString()}`);
+    });
+
+    proc.on("exit", (code) => {
+      console.error(`[A2A ${key}] Process exited with code ${code}`);
+      managedAgents.delete(key);
+    });
+
+    managedAgents.set(key, {
+      agent,
+      process: proc,
+      endpoint,
+      ready: false,
+    });
+
+    // Wait for agent to be ready (health check)
+    const ready = await waitForAgent(endpoint, 10000);
+    if (!ready) {
+      proc.kill();
+      managedAgents.delete(key);
+      return { success: false, error: "Agent failed to start (health check timeout)" };
+    }
+
+    const managed = managedAgents.get(key);
+    if (managed) {
+      managed.ready = true;
+    }
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to start A2A agent: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Wait for an A2A agent to become ready by polling its health endpoint
+ */
+async function waitForAgent(endpoint: string, timeoutMs: number): Promise<boolean> {
+  const startTime = Date.now();
+  const healthUrl = `${endpoint}/health`;
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const response = await fetch(healthUrl, { method: "GET" });
+      if (response.ok) {
+        return true;
+      }
+    } catch {
+      // Agent not ready yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return false;
+}
+
+/**
+ * Stop an A2A agent process
+ */
+export function stopA2AAgent(nameOrAlias: string): void {
+  const managed = managedAgents.get(nameOrAlias);
+  if (managed) {
+    managed.process.kill();
+    managedAgents.delete(nameOrAlias);
+  }
+}
+
+/**
+ * Stop all managed A2A agent processes
+ */
+export function stopAllA2AAgents(): void {
+  for (const [key, managed] of managedAgents.entries()) {
+    managed.process.kill();
+  }
+  managedAgents.clear();
+}
+
+/**
+ * Execute a task on an A2A agent
+ */
+export async function executeA2AAgent(
+  agent: AgentDefinition,
+  task: string,
+  context?: Record<string, unknown>
+): Promise<string> {
+  const key = agent.alias || agent.manifest.name;
+
+  // Ensure agent is started
+  let managed = managedAgents.get(key);
+  if (!managed || !managed.ready) {
+    const startResult = await startA2AAgent(agent);
+    if (!startResult.success) {
+      throw new Error(startResult.error || "Failed to start A2A agent");
+    }
+    managed = managedAgents.get(key);
+    if (!managed) {
+      throw new Error("Agent started but not found in registry");
+    }
+  }
+
+  const endpoint = managed.endpoint;
+
+  // Make A2A request
+  const request: A2ARequest = { task, context };
+
+  try {
+    const response = await fetch(`${endpoint}/execute`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw new Error(`A2A agent returned ${response.status}: ${response.statusText}`);
+    }
+
+    const result = await response.json() as A2AResponse;
+
+    if (result.isError) {
+      throw new Error(result.output);
+    }
+
+    return result.output;
+  } catch (error) {
+    throw new Error(
+      `A2A execution failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
+ * Execute a task on an A2A agent with streaming support
+ */
+export async function* executeA2AAgentStreaming(
+  agent: AgentDefinition,
+  task: string,
+  context?: Record<string, unknown>
+): AsyncGenerator<A2AEvent> {
+  const key = agent.alias || agent.manifest.name;
+
+  // Ensure agent is started
+  let managed = managedAgents.get(key);
+  if (!managed || !managed.ready) {
+    const startResult = await startA2AAgent(agent);
+    if (!startResult.success) {
+      yield { type: "error", error: startResult.error || "Failed to start A2A agent" };
+      return;
+    }
+    managed = managedAgents.get(key);
+    if (!managed) {
+      yield { type: "error", error: "Agent started but not found in registry" };
+      return;
+    }
+  }
+
+  const endpoint = managed.endpoint;
+  const request: A2ARequest = { task, context };
+
+  try {
+    const response = await fetch(`${endpoint}/stream`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      yield {
+        type: "error",
+        error: `A2A agent returned ${response.status}: ${response.statusText}`,
+      };
+      return;
+    }
+
+    if (!response.body) {
+      yield { type: "error", error: "No response body from A2A agent" };
+      return;
+    }
+
+    // Parse SSE stream
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (line.startsWith("data: ")) {
+          const data = line.slice(6);
+          if (data === "[DONE]") {
+            return;
+          }
+
+          try {
+            const event: A2AEvent = JSON.parse(data);
+            yield event;
+          } catch {
+            // Invalid JSON, skip
+          }
+        }
+      }
+    }
+  } catch (error) {
+    yield {
+      type: "error",
+      error: `A2A streaming failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/source/agents/a2a-client.ts
+++ b/source/agents/a2a-client.ts
@@ -112,6 +112,8 @@ export async function startA2AAgent(agent: AgentDefinition): Promise<{ success: 
   const args = parts.slice(1);
 
   try {
+    // TODO: start-command is unreviewed execution from a downloaded manifest.
+    // Add user confirmation at install or first run.
     const proc = spawn(command, args, {
       cwd: agent.path,
       stdio: ["ignore", "pipe", "pipe"],

--- a/source/agents/a2a-client.ts
+++ b/source/agents/a2a-client.ts
@@ -6,6 +6,38 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import type { AgentDefinition } from "./types.js";
 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+function assertLoopbackEndpoint(endpoint: string, allowRemote?: boolean): void {
+  if (allowRemote) return;
+  const parsed = new URL(endpoint);
+  if (!LOOPBACK_HOSTS.has(parsed.hostname)) {
+    throw new Error(
+      `A2A endpoint "${endpoint}" is not loopback. Set "allow-remote-endpoint: true" in the manifest to allow remote endpoints.`
+    );
+  }
+}
+
+function parseCommandString(cmd: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let inQuote: string | null = null;
+  for (const ch of cmd) {
+    if (inQuote) {
+      if (ch === inQuote) { inQuote = null; continue; }
+      current += ch;
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+    } else if (/\s/.test(ch)) {
+      if (current) { parts.push(current); current = ""; }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) parts.push(current);
+  return parts;
+}
+
 /**
  * A2A request format
  */
@@ -69,8 +101,14 @@ export async function startA2AAgent(agent: AgentDefinition): Promise<{ success: 
     return { success: false, error: "No endpoint defined for A2A agent" };
   }
 
-  // Parse command and args
-  const parts = startCommand.split(/\s+/);
+  try {
+    assertLoopbackEndpoint(endpoint, (agent.manifest as any)["allow-remote-endpoint"]);
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+
+  // Parse command and args (handles simple quoting)
+  const parts = parseCommandString(startCommand);
   const command = parts[0]!;
   const args = parts.slice(1);
 
@@ -132,7 +170,7 @@ async function waitForAgent(endpoint: string, timeoutMs: number): Promise<boolea
 
   while (Date.now() - startTime < timeoutMs) {
     try {
-      const response = await fetch(healthUrl, { method: "GET" });
+      const response = await fetch(healthUrl, { method: "GET", signal: AbortSignal.timeout(2_000) });
       if (response.ok) {
         return true;
       }
@@ -160,7 +198,7 @@ export function stopA2AAgent(nameOrAlias: string): void {
  * Stop all managed A2A agent processes
  */
 export function stopAllA2AAgents(): void {
-  for (const [key, managed] of managedAgents.entries()) {
+  for (const [, managed] of managedAgents.entries()) {
     managed.process.kill();
   }
   managedAgents.clear();
@@ -197,10 +235,9 @@ export async function executeA2AAgent(
   try {
     const response = await fetch(`${endpoint}/execute`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(request),
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (!response.ok) {
@@ -252,11 +289,9 @@ export async function* executeA2AAgentStreaming(
   try {
     const response = await fetch(`${endpoint}/stream`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-      },
+      headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
       body: JSON.stringify(request),
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (!response.ok) {
@@ -282,7 +317,7 @@ export async function* executeA2AAgentStreaming(
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
+      const lines = buffer.split(/\r?\n/);
       buffer = lines.pop() || "";
 
       for (const line of lines) {

--- a/source/agents/agent-registry.ts
+++ b/source/agents/agent-registry.ts
@@ -10,7 +10,9 @@ import type { AgentRegistry, AgentRegistryEntry } from "./types.js";
 
 const REGISTRY_PATH = join(homedir(), ".agav", "agents", "registry.json");
 
-// Mutex to serialize read-modify-write operations on the registry
+// In-process mutex only — does not protect against concurrent CLI processes.
+// The atomic temp-file-then-rename in saveRegistry prevents file corruption,
+// but two processes can still race on read-modify-write (last writer wins).
 let registryLockQueue: Promise<void> = Promise.resolve();
 function acquireRegistryLock(): Promise<() => void> {
   let release!: () => void;

--- a/source/agents/agent-registry.ts
+++ b/source/agents/agent-registry.ts
@@ -2,9 +2,10 @@
  * Agent registry - manages ~/.agav/agents/registry.json
  */
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
 import type { AgentRegistry, AgentRegistryEntry } from "./types.js";
 
 const REGISTRY_PATH = join(homedir(), ".agav", "agents", "registry.json");
@@ -15,9 +16,13 @@ const REGISTRY_PATH = join(homedir(), ".agav", "agents", "registry.json");
 export async function loadRegistry(): Promise<AgentRegistry> {
   try {
     const content = await readFile(REGISTRY_PATH, "utf-8");
-    return JSON.parse(content);
+    try {
+      return JSON.parse(content);
+    } catch (parseErr) {
+      console.warn(`[agent-registry] Failed to parse ${REGISTRY_PATH}, starting fresh:`, parseErr);
+      return { agents: {} };
+    }
   } catch {
-    // Registry doesn't exist yet
     return { agents: {} };
   }
 }
@@ -27,7 +32,9 @@ export async function loadRegistry(): Promise<AgentRegistry> {
  */
 export async function saveRegistry(registry: AgentRegistry): Promise<void> {
   await mkdir(join(homedir(), ".agav", "agents"), { recursive: true });
-  await writeFile(REGISTRY_PATH, JSON.stringify(registry, null, 2), "utf-8");
+  const tmpPath = REGISTRY_PATH + "." + randomBytes(4).toString("hex") + ".tmp";
+  await writeFile(tmpPath, JSON.stringify(registry, null, 2), "utf-8");
+  await rename(tmpPath, REGISTRY_PATH);
 }
 
 /**

--- a/source/agents/agent-registry.ts
+++ b/source/agents/agent-registry.ts
@@ -10,6 +10,15 @@ import type { AgentRegistry, AgentRegistryEntry } from "./types.js";
 
 const REGISTRY_PATH = join(homedir(), ".agav", "agents", "registry.json");
 
+// Mutex to serialize read-modify-write operations on the registry
+let registryLockQueue: Promise<void> = Promise.resolve();
+function acquireRegistryLock(): Promise<() => void> {
+  let release!: () => void;
+  const prev = registryLockQueue;
+  registryLockQueue = new Promise<void>((resolve) => { release = resolve; });
+  return prev.then(() => release);
+}
+
 /**
  * Load agent registry
  */
@@ -41,19 +50,29 @@ export async function saveRegistry(registry: AgentRegistry): Promise<void> {
  * Add or update an agent in the registry
  */
 export async function registerAgent(entry: AgentRegistryEntry): Promise<void> {
-  const registry = await loadRegistry();
-  const key = entry.alias || entry.name;
-  registry.agents[key] = entry;
-  await saveRegistry(registry);
+  const release = await acquireRegistryLock();
+  try {
+    const registry = await loadRegistry();
+    const key = entry.alias || entry.name;
+    registry.agents[key] = entry;
+    await saveRegistry(registry);
+  } finally {
+    release();
+  }
 }
 
 /**
  * Remove an agent from the registry
  */
 export async function unregisterAgent(nameOrAlias: string): Promise<void> {
-  const registry = await loadRegistry();
-  delete registry.agents[nameOrAlias];
-  await saveRegistry(registry);
+  const release = await acquireRegistryLock();
+  try {
+    const registry = await loadRegistry();
+    delete registry.agents[nameOrAlias];
+    await saveRegistry(registry);
+  } finally {
+    release();
+  }
 }
 
 /**
@@ -76,21 +95,25 @@ export async function getRegistryEntry(nameOrAlias: string): Promise<AgentRegist
  * Update agent enabled status
  */
 export async function setAgentEnabled(nameOrAlias: string, enabled: boolean): Promise<void> {
-  const registry = await loadRegistry();
-  let entry = registry.agents[nameOrAlias];
+  const release = await acquireRegistryLock();
+  try {
+    const registry = await loadRegistry();
+    let entry = registry.agents[nameOrAlias];
 
-  if (!entry) {
-    // Create a minimal registry entry if it doesn't exist (for bundled agents)
-    entry = {
-      name: nameOrAlias,
-      enabled,
-      installedAt: new Date().toISOString(),
-      version: "unknown",
-    };
-    registry.agents[nameOrAlias] = entry;
-  } else {
-    entry.enabled = enabled;
+    if (!entry) {
+      entry = {
+        name: nameOrAlias,
+        enabled,
+        installedAt: new Date().toISOString(),
+        version: "unknown",
+      };
+      registry.agents[nameOrAlias] = entry;
+    } else {
+      entry.enabled = enabled;
+    }
+
+    await saveRegistry(registry);
+  } finally {
+    release();
   }
-
-  await saveRegistry(registry);
 }

--- a/source/agents/agent-registry.ts
+++ b/source/agents/agent-registry.ts
@@ -1,0 +1,89 @@
+/**
+ * Agent registry - manages ~/.agav/agents/registry.json
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { AgentRegistry, AgentRegistryEntry } from "./types.js";
+
+const REGISTRY_PATH = join(homedir(), ".agav", "agents", "registry.json");
+
+/**
+ * Load agent registry
+ */
+export async function loadRegistry(): Promise<AgentRegistry> {
+  try {
+    const content = await readFile(REGISTRY_PATH, "utf-8");
+    return JSON.parse(content);
+  } catch {
+    // Registry doesn't exist yet
+    return { agents: {} };
+  }
+}
+
+/**
+ * Save agent registry
+ */
+export async function saveRegistry(registry: AgentRegistry): Promise<void> {
+  await mkdir(join(homedir(), ".agav", "agents"), { recursive: true });
+  await writeFile(REGISTRY_PATH, JSON.stringify(registry, null, 2), "utf-8");
+}
+
+/**
+ * Add or update an agent in the registry
+ */
+export async function registerAgent(entry: AgentRegistryEntry): Promise<void> {
+  const registry = await loadRegistry();
+  const key = entry.alias || entry.name;
+  registry.agents[key] = entry;
+  await saveRegistry(registry);
+}
+
+/**
+ * Remove an agent from the registry
+ */
+export async function unregisterAgent(nameOrAlias: string): Promise<void> {
+  const registry = await loadRegistry();
+  delete registry.agents[nameOrAlias];
+  await saveRegistry(registry);
+}
+
+/**
+ * Check if an agent name or alias is already registered
+ */
+export async function isAgentRegistered(nameOrAlias: string): Promise<boolean> {
+  const registry = await loadRegistry();
+  return nameOrAlias in registry.agents;
+}
+
+/**
+ * Get an agent registry entry
+ */
+export async function getRegistryEntry(nameOrAlias: string): Promise<AgentRegistryEntry | undefined> {
+  const registry = await loadRegistry();
+  return registry.agents[nameOrAlias];
+}
+
+/**
+ * Update agent enabled status
+ */
+export async function setAgentEnabled(nameOrAlias: string, enabled: boolean): Promise<void> {
+  const registry = await loadRegistry();
+  let entry = registry.agents[nameOrAlias];
+
+  if (!entry) {
+    // Create a minimal registry entry if it doesn't exist (for bundled agents)
+    entry = {
+      name: nameOrAlias,
+      enabled,
+      installedAt: new Date().toISOString(),
+      version: "unknown",
+    };
+    registry.agents[nameOrAlias] = entry;
+  } else {
+    entry.enabled = enabled;
+  }
+
+  await saveRegistry(registry);
+}

--- a/source/agents/catalog.ts
+++ b/source/agents/catalog.ts
@@ -27,7 +27,9 @@ export function buildAgentCatalog(agents: AgentDefinition[]): string {
 
   for (const agent of agentsToShow) {
     const toolName = `${agent.alias || agent.manifest.name}_agent`;
-    const description = agent.manifest.description;
+    const description = agent.manifest.description.length > 120
+      ? agent.manifest.description.slice(0, 117) + "..."
+      : agent.manifest.description;
     lines.push(`- ${toolName}: ${description}`);
   }
 

--- a/source/agents/catalog.ts
+++ b/source/agents/catalog.ts
@@ -1,0 +1,39 @@
+/**
+ * Agent catalog builder - generates token-capped system prompt injection
+ */
+
+import type { AgentDefinition } from "./types.js";
+
+const MAX_CATALOG_TOKENS = 500; // rough token budget for the entire catalog
+const TOKENS_PER_AGENT = 30; // rough tokens per agent entry (name + description)
+
+/**
+ * Build agent catalog string for system prompt injection
+ */
+export function buildAgentCatalog(agents: AgentDefinition[]): string {
+  // Filter to enabled agents only
+  const enabledAgents = agents.filter((a) => a.manifest.enabled !== false);
+
+  if (enabledAgents.length === 0) {
+    return "";
+  }
+
+  // Cap the number of agents shown to stay within token budget
+  const maxAgents = Math.floor(MAX_CATALOG_TOKENS / TOKENS_PER_AGENT);
+  const agentsToShow = enabledAgents.slice(0, maxAgents);
+  const remainingCount = enabledAgents.length - agentsToShow.length;
+
+  const lines = ["Available specialized agents:"];
+
+  for (const agent of agentsToShow) {
+    const toolName = `${agent.alias || agent.manifest.name}_agent`;
+    const description = agent.manifest.description;
+    lines.push(`- ${toolName}: ${description}`);
+  }
+
+  if (remainingCount > 0) {
+    lines.push(`...and ${remainingCount} more agent(s)`);
+  }
+
+  return lines.join("\n");
+}

--- a/source/agents/credentials.ts
+++ b/source/agents/credentials.ts
@@ -23,7 +23,7 @@ export async function loadAgentConfig(agentPath: string): Promise<Record<string,
         try {
           decrypted[key] = decrypt(value);
         } catch {
-          // Not encrypted, use as-is
+          console.warn(`[credentials] Decryption failed for "${key}" in ${configPath}, using as plaintext`);
           decrypted[key] = value;
         }
       }
@@ -50,7 +50,8 @@ export async function saveAgentConfig(
   }
 
   const configPath = join(agentPath, "config.json");
-  await writeFile(configPath, JSON.stringify(encrypted, null, 2), "utf-8");
+  await mkdir(agentPath, { recursive: true });
+  await writeFile(configPath, JSON.stringify(encrypted, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 /**
@@ -64,7 +65,7 @@ export async function hasRequiredCredentials(
   if (requiredConfig.length === 0) return true;
 
   const config = await loadAgentConfig(agentPath);
-  return requiredConfig.every((key) => key in config && config[key]);
+  return requiredConfig.every((key) => (key in config && config[key]) || process.env[key]);
 }
 
 /**

--- a/source/agents/credentials.ts
+++ b/source/agents/credentials.ts
@@ -1,0 +1,102 @@
+/**
+ * Agent credentials management - per-agent config.json with encryption
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { encrypt, decrypt } from "../utils/encrypt.js";
+import type { AgentManifest } from "./types.js";
+
+/**
+ * Load agent credentials from config.json
+ */
+export async function loadAgentConfig(agentPath: string): Promise<Record<string, string>> {
+  const configPath = join(agentPath, "config.json");
+  try {
+    const content = await readFile(configPath, "utf-8");
+    const config = JSON.parse(content);
+
+    // Decrypt values
+    const decrypted: Record<string, string> = {};
+    for (const [key, value] of Object.entries(config)) {
+      if (typeof value === "string") {
+        try {
+          decrypted[key] = decrypt(value);
+        } catch {
+          // Not encrypted, use as-is
+          decrypted[key] = value;
+        }
+      }
+    }
+
+    return decrypted;
+  } catch {
+    // No config.json
+    return {};
+  }
+}
+
+/**
+ * Save agent credentials to config.json (encrypted)
+ */
+export async function saveAgentConfig(
+  agentPath: string,
+  config: Record<string, string>
+): Promise<void> {
+  // Encrypt values
+  const encrypted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(config)) {
+    encrypted[key] = encrypt(value);
+  }
+
+  const configPath = join(agentPath, "config.json");
+  await writeFile(configPath, JSON.stringify(encrypted, null, 2), "utf-8");
+}
+
+/**
+ * Check if agent has all required credentials
+ */
+export async function hasRequiredCredentials(
+  agentPath: string,
+  manifest: AgentManifest
+): Promise<boolean> {
+  const requiredConfig = manifest["required-config"] || [];
+  if (requiredConfig.length === 0) return true;
+
+  const config = await loadAgentConfig(agentPath);
+  return requiredConfig.every((key) => key in config && config[key]);
+}
+
+/**
+ * Get missing credential keys - checks config.json first, then process.env
+ */
+export async function getMissingCredentials(
+  agentPath: string,
+  manifest: AgentManifest
+): Promise<string[]> {
+  const requiredConfig = manifest["required-config"] || [];
+  if (requiredConfig.length === 0) return [];
+
+  const config = await loadAgentConfig(agentPath);
+  return requiredConfig.filter((key) => {
+    const fromFile = config[key];
+    const fromEnv = process.env[key];
+    return !fromFile && !fromEnv;
+  });
+}
+
+/**
+ * Prompt user for credentials (to be called from TUI)
+ * Returns the credentials that should be saved
+ */
+export function buildCredentialPrompts(
+  manifest: AgentManifest,
+  existingConfig: Record<string, string> = {}
+): Array<{ key: string; label: string; defaultValue?: string }> {
+  const requiredConfig = manifest["required-config"] || [];
+  return requiredConfig.map((key) => ({
+    key,
+    label: key,
+    defaultValue: existingConfig[key],
+  }));
+}

--- a/source/agents/executor.ts
+++ b/source/agents/executor.ts
@@ -13,15 +13,6 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { decrypt } from "../utils/encrypt.js";
 
-// Mutex to serialize process.env mutations across concurrent agent calls
-let envLockQueue: Promise<void> = Promise.resolve();
-function acquireEnvLock(): Promise<() => void> {
-  let release: () => void;
-  const prev = envLockQueue;
-  envLockQueue = new Promise<void>((resolve) => { release = resolve; });
-  return prev.then(() => release!);
-}
-
 // AgavHooks type - defined locally since it's not exported from hooks.js
 interface AgavHooks {
   afterEdit?: string;
@@ -97,54 +88,35 @@ export async function executeNativeAgent(
   const model  = runtimeConfig["model"]  || agent.manifest.model  || deps.config.model;
   const effort = (runtimeConfig["effort"] || agent.manifest.effort || deps.config.effort) as import("../config/config.js").EffortLevel;
 
-  // Narrow lock scope: hold the env lock only during MCP server startup,
-  // then restore env and release before running the agent loop.
+  // Start per-agent MCP servers (credentials passed via subprocess env, not process.env)
   let agentMCPManager: import("../mcp/manager.js").MCPManager | null = null;
-  const releaseEnvLock = await acquireEnvLock();
-  try {
-    const originalEnv: Record<string, string | undefined> = {};
-    for (const [key, value] of Object.entries(runtimeConfig)) {
-      originalEnv[key] = process.env[key];
-      process.env[key] = value;
-    }
-
-    try {
-      const mcpServersDecl = agent.manifest["mcp-servers"] ?? [];
-      if (mcpServersDecl.length > 0) {
-        const { MCPManager } = await import("../mcp/manager.js");
-        agentMCPManager = new MCPManager();
-        for (const srv of mcpServersDecl) {
-          const serverConfig = {
-            command: srv.command,
-            args: srv.args ?? [],
-            env: { ...Object.fromEntries(Object.entries(process.env).filter(([, v]) => v !== undefined)) as Record<string, string>, ...runtimeConfig },
-          };
-          try {
-            await agentMCPManager.startServer(srv.key, serverConfig);
-          } catch (err) {
-            console.warn(`[agent:${agent.manifest.name}] Failed to start MCP server "${srv.key}":`, err);
-          }
-        }
-      }
-    } finally {
-      // Restore env vars as soon as MCP servers have spawned (they inherit env at spawn time)
-      for (const [key, value] of Object.entries(originalEnv)) {
-        if (value === undefined) {
-          delete process.env[key];
-        } else {
-          process.env[key] = value;
-        }
+  const mcpServersDecl = agent.manifest["mcp-servers"] ?? [];
+  if (mcpServersDecl.length > 0) {
+    const { MCPManager } = await import("../mcp/manager.js");
+    agentMCPManager = new MCPManager();
+    for (const srv of mcpServersDecl) {
+      const serverConfig = {
+        command: srv.command,
+        args: srv.args ?? [],
+        env: { ...Object.fromEntries(Object.entries(process.env).filter(([, v]) => v !== undefined)) as Record<string, string>, ...runtimeConfig },
+      };
+      try {
+        await agentMCPManager.startServer(srv.key, serverConfig);
+      } catch (err) {
+        console.warn(`[agent:${agent.manifest.name}] Failed to start MCP server "${srv.key}":`, err);
       }
     }
-  } finally {
-    releaseEnvLock();
   }
 
-  // Agent loop runs without holding the env lock
   try {
+    // Wrap each tool's execute to inject credentials via context, not process.env.
+    // Tools access credentials via process.env during their execute() call only.
     const childRegistry = new ToolRegistry();
     for (const tool of agent.tools) {
-      childRegistry.register(tool);
+      childRegistry.register({
+        schema: tool.schema,
+        execute: (input) => tool.execute(input, { env: runtimeConfig }),
+      });
     }
 
     if (agentMCPManager) {

--- a/source/agents/executor.ts
+++ b/source/agents/executor.ts
@@ -10,7 +10,17 @@ import type { AgavConfig } from "../config/config.js";
 import { runAgentLoop } from "../agent/loop.js";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import { decrypt } from "../utils/encrypt.js";
+
+// Mutex to serialize process.env mutations across concurrent agent calls
+let envLockQueue: Promise<void> = Promise.resolve();
+function acquireEnvLock(): Promise<() => void> {
+  let release: () => void;
+  const prev = envLockQueue;
+  envLockQueue = new Promise<void>((resolve) => { release = resolve; });
+  return prev.then(() => release!);
+}
 
 // AgavHooks type - defined locally since it's not exported from hooks.js
 interface AgavHooks {
@@ -78,21 +88,22 @@ export async function executeNativeAgent(
     confirmTool?: (toolName: string, input: Record<string, unknown>, diff?: any[]) => Promise<import("../agent/loop.js").ConfirmResult>;
   }
 ): Promise<string> {
-  // Unique ID for this invocation — used to correlate progress events in the UI
-  const callId = `${agent.manifest.name}-${Math.random().toString(36).slice(2, 7)}`;
+  const callId = `${agent.manifest.name}-${randomUUID().slice(0, 8)}`;
 
   // Load per-agent runtime config: credentials + optional model/effort overrides.
   // Priority: config.json > AGENT.md manifest > session config.
   const runtimeConfig = await loadAgentCredentials(agent.path, agent.manifest.name);
-  const originalEnv: Record<string, string | undefined> = {};
 
+  const model  = runtimeConfig["model"]  || agent.manifest.model  || deps.config.model;
+  const effort = (runtimeConfig["effort"] || agent.manifest.effort || deps.config.effort) as import("../config/config.js").EffortLevel;
+
+  // Serialize env mutations to prevent concurrent agents from interleaving
+  const releaseEnvLock = await acquireEnvLock();
+  const originalEnv: Record<string, string | undefined> = {};
   for (const [key, value] of Object.entries(runtimeConfig)) {
     originalEnv[key] = process.env[key];
     process.env[key] = value;
   }
-
-  const model  = runtimeConfig["model"]  || agent.manifest.model  || deps.config.model;
-  const effort = (runtimeConfig["effort"] || agent.manifest.effort || deps.config.effort) as import("../config/config.js").EffortLevel;
 
   // Start per-agent MCP servers declared in the manifest
   let agentMCPManager: import("../mcp/manager.js").MCPManager | null = null;
@@ -104,7 +115,7 @@ export async function executeNativeAgent(
       const serverConfig = {
         command: srv.command,
         args: srv.args ?? [],
-        env: runtimeConfig, // inject agent credentials as subprocess env vars
+        env: { ...Object.fromEntries(Object.entries(process.env).filter(([, v]) => v !== undefined)) as Record<string, string>, ...runtimeConfig },
       };
       try {
         await agentMCPManager.startServer(srv.key, serverConfig);
@@ -152,7 +163,7 @@ export async function executeNativeAgent(
       // If the parent provided a confirmTool callback, use it so that tools
       // marked as destructive inside the agent get proper HITL approval.
       confirmTool: deps.confirmTool,
-      permissionMode: deps.confirmTool ? "ask" : "auto-accept",
+      permissionMode: deps.confirmTool ? "ask" : "deny-writes",
       maxIterations: 50,
       hooks: deps.hooks,
     });
@@ -161,14 +172,10 @@ export async function executeNativeAgent(
       // Forward every event to the UI progress tracker keyed by this invocation's callId
       deps.onProgressUpdate?.(callId, event);
 
-      // Collect text output
       if (event.type === "streaming_text") {
         output += event.text;
       } else if (event.type === "assistant_message_complete") {
-        // Use the accumulated streaming text as output
-        if (output) {
-          // Already have streaming text
-        } else if (event.text) {
+        if (!output && event.text) {
           output = event.text;
         }
       } else if (event.type === "error") {
@@ -183,15 +190,13 @@ export async function executeNativeAgent(
 
     return output || "Agent completed with no output.";
   } finally {
-    // Signal the UI that this agent invocation is complete (success or failure)
     deps.onProgressUpdate?.(callId, { type: "turn_complete" });
 
-    // Stop per-agent MCP servers
     if (agentMCPManager) {
-      agentMCPManager.stopAll();
+      await agentMCPManager.stopAll();
     }
 
-    // Restore original env vars
+    // Restore original env vars, then release the lock
     for (const [key, value] of Object.entries(originalEnv)) {
       if (value === undefined) {
         delete process.env[key];
@@ -199,6 +204,7 @@ export async function executeNativeAgent(
         process.env[key] = value;
       }
     }
+    releaseEnvLock();
   }
 }
 
@@ -211,10 +217,6 @@ export async function executeA2AAgent(
 ): Promise<string> {
   const { executeA2AAgent: a2aExecute } = await import("./a2a-client.js");
 
-  try {
-    const output = await a2aExecute(agent, task);
-    return output;
-  } catch (error) {
-    return `A2A agent error: ${error instanceof Error ? error.message : String(error)}`;
-  }
+  const output = await a2aExecute(agent, task);
+  return output;
 }

--- a/source/agents/executor.ts
+++ b/source/agents/executor.ts
@@ -97,58 +97,68 @@ export async function executeNativeAgent(
   const model  = runtimeConfig["model"]  || agent.manifest.model  || deps.config.model;
   const effort = (runtimeConfig["effort"] || agent.manifest.effort || deps.config.effort) as import("../config/config.js").EffortLevel;
 
-  // Serialize env mutations to prevent concurrent agents from interleaving
-  const releaseEnvLock = await acquireEnvLock();
-  const originalEnv: Record<string, string | undefined> = {};
-  for (const [key, value] of Object.entries(runtimeConfig)) {
-    originalEnv[key] = process.env[key];
-    process.env[key] = value;
-  }
-
-  // Start per-agent MCP servers declared in the manifest
+  // Narrow lock scope: hold the env lock only during MCP server startup,
+  // then restore env and release before running the agent loop.
   let agentMCPManager: import("../mcp/manager.js").MCPManager | null = null;
-  const mcpServersDecl = agent.manifest["mcp-servers"] ?? [];
-  if (mcpServersDecl.length > 0) {
-    const { MCPManager } = await import("../mcp/manager.js");
-    agentMCPManager = new MCPManager();
-    for (const srv of mcpServersDecl) {
-      const serverConfig = {
-        command: srv.command,
-        args: srv.args ?? [],
-        env: { ...Object.fromEntries(Object.entries(process.env).filter(([, v]) => v !== undefined)) as Record<string, string>, ...runtimeConfig },
-      };
-      try {
-        await agentMCPManager.startServer(srv.key, serverConfig);
-      } catch (err) {
-        // Non-fatal: log but continue without this MCP server
-        console.warn(`[agent:${agent.manifest.name}] Failed to start MCP server "${srv.key}":`, err);
+  const releaseEnvLock = await acquireEnvLock();
+  try {
+    const originalEnv: Record<string, string | undefined> = {};
+    for (const [key, value] of Object.entries(runtimeConfig)) {
+      originalEnv[key] = process.env[key];
+      process.env[key] = value;
+    }
+
+    try {
+      const mcpServersDecl = agent.manifest["mcp-servers"] ?? [];
+      if (mcpServersDecl.length > 0) {
+        const { MCPManager } = await import("../mcp/manager.js");
+        agentMCPManager = new MCPManager();
+        for (const srv of mcpServersDecl) {
+          const serverConfig = {
+            command: srv.command,
+            args: srv.args ?? [],
+            env: { ...Object.fromEntries(Object.entries(process.env).filter(([, v]) => v !== undefined)) as Record<string, string>, ...runtimeConfig },
+          };
+          try {
+            await agentMCPManager.startServer(srv.key, serverConfig);
+          } catch (err) {
+            console.warn(`[agent:${agent.manifest.name}] Failed to start MCP server "${srv.key}":`, err);
+          }
+        }
+      }
+    } finally {
+      // Restore env vars as soon as MCP servers have spawned (they inherit env at spawn time)
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
       }
     }
+  } finally {
+    releaseEnvLock();
   }
 
+  // Agent loop runs without holding the env lock
   try {
-    // Create child tool registry with only the agent's tools
     const childRegistry = new ToolRegistry();
     for (const tool of agent.tools) {
       childRegistry.register(tool);
     }
 
-    // Register MCP tools from per-agent MCP servers
     if (agentMCPManager) {
       for (const tool of agentMCPManager.getToolDefinitions()) {
         childRegistry.register(tool);
       }
     }
 
-    // Create fresh conversation state
     const conversation = new ConversationState();
     conversation.addUserMessage(task);
 
-    // Build system prompt — avoid "undefined\n\n" if config has no custom prompt
     const base = deps.config.systemPrompt ?? "";
     const systemPrompt = base ? `${base}\n\n${agent.systemPrompt}` : agent.systemPrompt;
 
-    // Collect output
     let output = "";
     let loopError: Error | null = null;
 
@@ -160,8 +170,6 @@ export async function executeNativeAgent(
       systemPrompt,
       effort,
       maxTokens: deps.config.maxTokens,
-      // If the parent provided a confirmTool callback, use it so that tools
-      // marked as destructive inside the agent get proper HITL approval.
       confirmTool: deps.confirmTool,
       permissionMode: deps.confirmTool ? "ask" : "deny-writes",
       maxIterations: 50,
@@ -169,7 +177,6 @@ export async function executeNativeAgent(
     });
 
     for await (const event of loopGenerator) {
-      // Forward every event to the UI progress tracker keyed by this invocation's callId
       deps.onProgressUpdate?.(callId, event);
 
       if (event.type === "streaming_text") {
@@ -183,7 +190,6 @@ export async function executeNativeAgent(
       }
     }
 
-    // Surface loop errors instead of silently returning empty output
     if (loopError && !output) {
       throw loopError;
     }
@@ -195,16 +201,6 @@ export async function executeNativeAgent(
     if (agentMCPManager) {
       await agentMCPManager.stopAll();
     }
-
-    // Restore original env vars, then release the lock
-    for (const [key, value] of Object.entries(originalEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-    releaseEnvLock();
   }
 }
 

--- a/source/agents/executor.ts
+++ b/source/agents/executor.ts
@@ -1,0 +1,220 @@
+/**
+ * Agent executor - runs native and A2A agents
+ */
+
+import type { AgentDefinition } from "./types.js";
+import { ConversationState } from "../agent/conversation.js";
+import { ToolRegistry } from "../tools/registry.js";
+import type { LLMProvider } from "../providers/types.js";
+import type { AgavConfig } from "../config/config.js";
+import { runAgentLoop } from "../agent/loop.js";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { decrypt } from "../utils/encrypt.js";
+
+// AgavHooks type - defined locally since it's not exported from hooks.js
+interface AgavHooks {
+  afterEdit?: string;
+  afterShell?: string;
+  preCommit?: string;
+}
+
+/**
+ * Load agent credentials from config.json.
+ * Tries the agent's own path first, then falls back to the global
+ * ~/.agav/agents/<name> path so bundled agents can be configured
+ * without touching the app's source directory.
+ */
+async function loadAgentCredentials(agentPath: string, agentName?: string): Promise<Record<string, string>> {
+  const paths = [agentPath];
+
+  if (agentName) {
+    const { homedir } = await import("node:os");
+    const globalPath = join(homedir(), ".agav", "agents", agentName);
+    if (globalPath !== agentPath) paths.push(globalPath);
+  }
+
+  for (const p of paths) {
+    const configPath = join(p, "config.json");
+    try {
+      const content = await readFile(configPath, "utf-8");
+      const config = JSON.parse(content);
+
+      const decrypted: Record<string, string> = {};
+      for (const [key, value] of Object.entries(config)) {
+        if (typeof value === "string") {
+          try {
+            decrypted[key] = decrypt(value);
+          } catch {
+            // Not encrypted, use as-is
+            decrypted[key] = value;
+          }
+        }
+      }
+
+      if (Object.keys(decrypted).length > 0) return decrypted;
+    } catch {
+      // No config.json at this path — try next
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Execute a native agent (JS/TS in-process)
+ */
+export async function executeNativeAgent(
+  agent: AgentDefinition,
+  task: string,
+  deps: {
+    provider: LLMProvider;
+    config: AgavConfig;
+    hooks?: AgavHooks;
+    /** Called for each AgentEvent emitted by the child loop, keyed by a per-invocation callId. */
+    onProgressUpdate?: (callId: string, event: import("../agent/loop.js").AgentEvent) => void;
+    /** Parent's confirmTool — when provided, agent sub-tools that are marked
+     *  destructive will pause and surface HITL confirmation to the user. */
+    confirmTool?: (toolName: string, input: Record<string, unknown>, diff?: any[]) => Promise<import("../agent/loop.js").ConfirmResult>;
+  }
+): Promise<string> {
+  // Unique ID for this invocation — used to correlate progress events in the UI
+  const callId = `${agent.manifest.name}-${Math.random().toString(36).slice(2, 7)}`;
+
+  // Load per-agent runtime config: credentials + optional model/effort overrides.
+  // Priority: config.json > AGENT.md manifest > session config.
+  const runtimeConfig = await loadAgentCredentials(agent.path, agent.manifest.name);
+  const originalEnv: Record<string, string | undefined> = {};
+
+  for (const [key, value] of Object.entries(runtimeConfig)) {
+    originalEnv[key] = process.env[key];
+    process.env[key] = value;
+  }
+
+  const model  = runtimeConfig["model"]  || agent.manifest.model  || deps.config.model;
+  const effort = (runtimeConfig["effort"] || agent.manifest.effort || deps.config.effort) as import("../config/config.js").EffortLevel;
+
+  // Start per-agent MCP servers declared in the manifest
+  let agentMCPManager: import("../mcp/manager.js").MCPManager | null = null;
+  const mcpServersDecl = agent.manifest["mcp-servers"] ?? [];
+  if (mcpServersDecl.length > 0) {
+    const { MCPManager } = await import("../mcp/manager.js");
+    agentMCPManager = new MCPManager();
+    for (const srv of mcpServersDecl) {
+      const serverConfig = {
+        command: srv.command,
+        args: srv.args ?? [],
+        env: runtimeConfig, // inject agent credentials as subprocess env vars
+      };
+      try {
+        await agentMCPManager.startServer(srv.key, serverConfig);
+      } catch (err) {
+        // Non-fatal: log but continue without this MCP server
+        console.warn(`[agent:${agent.manifest.name}] Failed to start MCP server "${srv.key}":`, err);
+      }
+    }
+  }
+
+  try {
+    // Create child tool registry with only the agent's tools
+    const childRegistry = new ToolRegistry();
+    for (const tool of agent.tools) {
+      childRegistry.register(tool);
+    }
+
+    // Register MCP tools from per-agent MCP servers
+    if (agentMCPManager) {
+      for (const tool of agentMCPManager.getToolDefinitions()) {
+        childRegistry.register(tool);
+      }
+    }
+
+    // Create fresh conversation state
+    const conversation = new ConversationState();
+    conversation.addUserMessage(task);
+
+    // Build system prompt — avoid "undefined\n\n" if config has no custom prompt
+    const base = deps.config.systemPrompt ?? "";
+    const systemPrompt = base ? `${base}\n\n${agent.systemPrompt}` : agent.systemPrompt;
+
+    // Collect output
+    let output = "";
+    let loopError: Error | null = null;
+
+    const loopGenerator = runAgentLoop({
+      provider: deps.provider,
+      conversation,
+      toolRegistry: childRegistry,
+      model,
+      systemPrompt,
+      effort,
+      maxTokens: deps.config.maxTokens,
+      // If the parent provided a confirmTool callback, use it so that tools
+      // marked as destructive inside the agent get proper HITL approval.
+      confirmTool: deps.confirmTool,
+      permissionMode: deps.confirmTool ? "ask" : "auto-accept",
+      maxIterations: 50,
+      hooks: deps.hooks,
+    });
+
+    for await (const event of loopGenerator) {
+      // Forward every event to the UI progress tracker keyed by this invocation's callId
+      deps.onProgressUpdate?.(callId, event);
+
+      // Collect text output
+      if (event.type === "streaming_text") {
+        output += event.text;
+      } else if (event.type === "assistant_message_complete") {
+        // Use the accumulated streaming text as output
+        if (output) {
+          // Already have streaming text
+        } else if (event.text) {
+          output = event.text;
+        }
+      } else if (event.type === "error") {
+        loopError = event.error;
+      }
+    }
+
+    // Surface loop errors instead of silently returning empty output
+    if (loopError && !output) {
+      throw loopError;
+    }
+
+    return output || "Agent completed with no output.";
+  } finally {
+    // Signal the UI that this agent invocation is complete (success or failure)
+    deps.onProgressUpdate?.(callId, { type: "turn_complete" });
+
+    // Stop per-agent MCP servers
+    if (agentMCPManager) {
+      agentMCPManager.stopAll();
+    }
+
+    // Restore original env vars
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+/**
+ * Execute an A2A agent (external process via HTTP)
+ */
+export async function executeA2AAgent(
+  agent: AgentDefinition,
+  task: string
+): Promise<string> {
+  const { executeA2AAgent: a2aExecute } = await import("./a2a-client.js");
+
+  try {
+    const output = await a2aExecute(agent, task);
+    return output;
+  } catch (error) {
+    return `A2A agent error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}

--- a/source/agents/installer.ts
+++ b/source/agents/installer.ts
@@ -67,7 +67,7 @@ export async function installAgent(
     destination?: "global" | "project";
     cwd?: string;
   } = {}
-): Promise<{ success: boolean; agent?: AgentDefinition; error?: string }> {
+): Promise<{ success: boolean; agent?: AgentDefinition; error?: string; warning?: string }> {
   const { alias, destination = "global", cwd = process.cwd() } = options;
 
   // Validate alias early (before loading agent or cloning)
@@ -177,7 +177,11 @@ export async function installAgent(
     // Reload agent from final destination
     const finalAgent = await loadAgent(destPath, destination === "global" ? "global" : "project", alias);
 
-    return { success: true, agent: finalAgent || agent };
+    const installed = finalAgent || agent;
+    const warning = installed.manifest.type === "a2a" && installed.manifest["start-command"]
+      ? `This A2A agent will execute "${installed.manifest["start-command"]}" when invoked. Review the command before use.`
+      : undefined;
+    return { success: true, agent: installed, warning };
   } catch (error) {
     if (isGitUrl) {
       await rm(agentPath, { recursive: true, force: true });

--- a/source/agents/installer.ts
+++ b/source/agents/installer.ts
@@ -215,6 +215,7 @@ async function cloneAgent(url: string): Promise<{ success: boolean; path?: strin
 
       // Copy agent out of the clone, then clean up (avoids dragging .git into the install)
       const agentSrc = join(tempDir, subPath!.slice(1));
+      assertPathContained(agentSrc, tempDir);
       const outDir = join(tmpdir(), `agav-agent-${randomBytes(8).toString("hex")}`);
       await mkdir(outDir, { recursive: true });
       await cp(agentSrc, outDir, {

--- a/source/agents/installer.ts
+++ b/source/agents/installer.ts
@@ -1,0 +1,214 @@
+/**
+ * Agent installer - sparse-clone from git repos, validate, and install
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { readdir, rm, cp, mkdir } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { loadAgent } from "./loader.js";
+import { registerAgent, isAgentRegistered } from "./agent-registry.js";
+import type { AgentDefinition } from "./types.js";
+
+const execAsync = promisify(exec);
+
+/**
+ * Install agent from a git URL or local path
+ */
+export async function installAgent(
+  source: string,
+  options: {
+    alias?: string;
+    destination?: "global" | "project";
+    cwd?: string;
+  } = {}
+): Promise<{ success: boolean; agent?: AgentDefinition; error?: string }> {
+  const { alias, destination = "global", cwd = process.cwd() } = options;
+
+  // Determine if source is a git URL or local path
+  const isGitUrl = source.startsWith("http://") || source.startsWith("https://") || source.startsWith("git@");
+
+  let agentPath: string;
+
+  if (isGitUrl) {
+    // Clone from git repo
+    const cloneResult = await cloneAgent(source);
+    if (!cloneResult.success || !cloneResult.path) {
+      return { success: false, error: cloneResult.error || "Clone failed" };
+    }
+    agentPath = cloneResult.path;
+  } else {
+    // Local path
+    agentPath = source;
+  }
+
+  // Load and validate agent
+  const agent = await loadAgent(agentPath, "global", alias);
+  if (!agent) {
+    if (isGitUrl) {
+      // Clean up temp clone
+      await rm(agentPath, { recursive: true, force: true });
+    }
+    return { success: false, error: "Invalid agent: could not load AGENT.md" };
+  }
+
+  // Check for name conflict
+  const nameToCheck = alias || agent.manifest.name;
+  if (await isAgentRegistered(nameToCheck)) {
+    // Verify the registered agent actually has valid files — it may be a stale/broken entry
+    // (e.g. only config.json exists but AGENT.md and tools/ are missing)
+    const { loadRegistry } = await import("./agent-registry.js");
+    const registry = await loadRegistry();
+    const registryEntry = registry.agents[nameToCheck];
+    const { homedir: getHome } = await import("node:os");
+    const registeredPath = join(getHome(), ".agav", "agents", nameToCheck);
+    const loadedCheck = await loadAgent(registeredPath, "global");
+    const isStale = !loadedCheck; // can't load = stale/broken entry
+
+    if (!isStale) {
+      // Agent is genuinely installed and healthy — block as before
+      if (isGitUrl) await rm(agentPath, { recursive: true, force: true });
+      return {
+        success: false,
+        error: `Agent '${nameToCheck}' is already installed. Use --alias to install with a different name.`,
+      };
+    }
+
+    // Stale entry: remove it from the registry and proceed with fresh install
+    delete registry.agents[nameToCheck];
+    const { saveRegistry } = await import("./agent-registry.js");
+    await saveRegistry(registry);
+  }
+
+  // Determine install destination
+  const destPath =
+    destination === "global"
+      ? join(homedir(), ".agav", "agents", nameToCheck)
+      : join(cwd, ".agav", "agents", nameToCheck);
+
+  // Copy agent to destination
+  try {
+    await mkdir(join(destPath, ".."), { recursive: true });
+    await cp(agentPath, destPath, { recursive: true });
+
+    // If cloned from git, clean up temp directory
+    if (isGitUrl) {
+      await rm(agentPath, { recursive: true, force: true });
+    }
+
+    // Register agent
+    await registerAgent({
+      name: agent.manifest.name,
+      alias,
+      enabled: true,
+      sourceUrl: isGitUrl ? source : undefined,
+      installedAt: new Date().toISOString(),
+      version: agent.manifest.version,
+    });
+
+    // Reload agent from final destination
+    const finalAgent = await loadAgent(destPath, destination === "global" ? "global" : "project", alias);
+
+    return { success: true, agent: finalAgent || agent };
+  } catch (error) {
+    if (isGitUrl) {
+      await rm(agentPath, { recursive: true, force: true });
+    }
+    return {
+      success: false,
+      error: `Failed to install agent: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Clone agent from git URL using sparse checkout
+ */
+async function cloneAgent(url: string): Promise<{ success: boolean; path?: string; error?: string }> {
+  // Create temp directory
+  const tempDir = join(tmpdir(), `agav-agent-${randomBytes(8).toString("hex")}`);
+
+  try {
+    await mkdir(tempDir, { recursive: true });
+
+    // Parse URL to determine if it's a subdirectory or full repo
+    const isSubdirectory = url.includes("/tree/") || url.includes("/agents/");
+
+    if (isSubdirectory) {
+      // Extract repo URL and path
+      const match = url.match(/^(https?:\/\/[^\/]+\/[^\/]+\/[^\/]+)(?:\/tree\/[^\/]+)?(\/.+)$/);
+      if (!match) {
+        return { success: false, error: "Invalid git URL format" };
+      }
+
+      const [, repoUrl, subPath] = match;
+
+      // Sparse checkout
+      await execAsync(`git clone --depth=1 --filter=blob:none --sparse "${repoUrl}" .`, { cwd: tempDir });
+      await execAsync(`git sparse-checkout set ${subPath.slice(1)}`, { cwd: tempDir });
+
+      // Find the agent directory
+      const agentPath = join(tempDir, subPath.slice(1));
+      return { success: true, path: agentPath };
+    } else {
+      // Full repo clone
+      await execAsync(`git clone --depth=1 "${url}" .`, { cwd: tempDir });
+
+      // Look for agents/ directory or assume root is the agent
+      const entries = await readdir(tempDir);
+      if (entries.includes("AGENT.md")) {
+        return { success: true, path: tempDir };
+      } else if (entries.includes("agents")) {
+        // Multiple agents - return the first one found
+        const agentsDir = join(tempDir, "agents");
+        const agentDirs = await readdir(agentsDir);
+        if (agentDirs.length > 0) {
+          return { success: true, path: join(agentsDir, agentDirs[0]) };
+        }
+      }
+
+      return { success: false, error: "No AGENT.md found in repository" };
+    }
+  } catch (error) {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    return {
+      success: false,
+      error: `Git clone failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Uninstall agent (remove from filesystem and registry)
+ */
+export async function uninstallAgent(nameOrAlias: string, destination: "global" | "project" = "global", cwd: string = process.cwd()): Promise<{ success: boolean; error?: string }> {
+  const { unregisterAgent } = await import("./agent-registry.js");
+  const { stat } = await import("node:fs/promises");
+
+  const agentPath =
+    destination === "global"
+      ? join(homedir(), ".agav", "agents", nameOrAlias)
+      : join(cwd, ".agav", "agents", nameOrAlias);
+
+  // Verify the path exists (registry entry is optional — agents can exist on disk
+  // without a registry entry if the registry was pruned or manually edited)
+  try {
+    await stat(agentPath);
+  } catch {
+    return { success: false, error: `Agent '${nameOrAlias}' not found at ${agentPath}` };
+  }
+
+  try {
+    await rm(agentPath, { recursive: true, force: true });
+    // Remove from registry if present — non-fatal if already absent
+    await unregisterAgent(nameOrAlias).catch(() => {});
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to uninstall: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/source/agents/installer.ts
+++ b/source/agents/installer.ts
@@ -2,17 +2,60 @@
  * Agent installer - sparse-clone from git repos, validate, and install
  */
 
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
-import { readdir, rm, cp, mkdir } from "node:fs/promises";
-import { join, basename } from "node:path";
+import { execFile } from "node:child_process";
+import { readdir, rm, cp, mkdir, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
 import { loadAgent } from "./loader.js";
 import { registerAgent, isAgentRegistered } from "./agent-registry.js";
 import type { AgentDefinition } from "./types.js";
 
-const execAsync = promisify(exec);
+const SAFE_NAME = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+
+const DEFAULT_ALLOWED_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+function getAllowedHosts(): Set<string> {
+  const extra = process.env.AGAV_ALLOWED_GIT_HOSTS;
+  if (!extra) return DEFAULT_ALLOWED_HOSTS;
+  const hosts = new Set(DEFAULT_ALLOWED_HOSTS);
+  for (const h of extra.split(",")) {
+    const trimmed = h.trim();
+    if (trimmed) hosts.add(trimmed);
+  }
+  return hosts;
+}
+
+function validateAgentName(name: string): void {
+  if (!SAFE_NAME.test(name)) {
+    throw new Error(`Invalid agent name "${name}": must match ${SAFE_NAME}`);
+  }
+}
+
+function validateGitUrl(url: string): void {
+  const parsed = new URL(url);
+  const allowed = getAllowedHosts();
+  if (!allowed.has(parsed.hostname)) {
+    throw new Error(`Untrusted git host: ${parsed.hostname}. Allowed: ${[...allowed].join(", ")}`);
+  }
+}
+
+function assertPathContained(child: string, parent: string): void {
+  const resolved = resolve(child);
+  const root = resolve(parent);
+  if (!resolved.startsWith(root + "/") && !resolved.startsWith(root + "\\") && resolved !== root) {
+    throw new Error("Agent path escapes the agents directory");
+  }
+}
+
+function gitExec(args: string[], cwd: string): Promise<{ stdout: string }> {
+  return new Promise((resolve, reject) => {
+    execFile("git", args, { cwd, timeout: 60_000 }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve({ stdout });
+    });
+  });
+}
 
 /**
  * Install agent from a git URL or local path
@@ -26,6 +69,15 @@ export async function installAgent(
   } = {}
 ): Promise<{ success: boolean; agent?: AgentDefinition; error?: string }> {
   const { alias, destination = "global", cwd = process.cwd() } = options;
+
+  // Validate alias early (before loading agent or cloning)
+  if (alias !== undefined) {
+    try {
+      validateAgentName(alias);
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
 
   // Determine if source is a git URL or local path
   const isGitUrl = source.startsWith("http://") || source.startsWith("https://") || source.startsWith("git@");
@@ -56,16 +108,24 @@ export async function installAgent(
 
   // Check for name conflict
   const nameToCheck = alias || agent.manifest.name;
+  try {
+    validateAgentName(nameToCheck);
+  } catch (e) {
+    if (isGitUrl) await rm(agentPath, { recursive: true, force: true });
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+
   if (await isAgentRegistered(nameToCheck)) {
     // Verify the registered agent actually has valid files — it may be a stale/broken entry
     // (e.g. only config.json exists but AGENT.md and tools/ are missing)
     const { loadRegistry } = await import("./agent-registry.js");
     const registry = await loadRegistry();
-    const registryEntry = registry.agents[nameToCheck];
-    const { homedir: getHome } = await import("node:os");
-    const registeredPath = join(getHome(), ".agav", "agents", nameToCheck);
+    const registeredPath =
+      destination === "global"
+        ? join(homedir(), ".agav", "agents", nameToCheck)
+        : join(cwd, ".agav", "agents", nameToCheck);
     const loadedCheck = await loadAgent(registeredPath, "global");
-    const isStale = !loadedCheck; // can't load = stale/broken entry
+    const isStale = !loadedCheck;
 
     if (!isStale) {
       // Agent is genuinely installed and healthy — block as before
@@ -83,10 +143,12 @@ export async function installAgent(
   }
 
   // Determine install destination
-  const destPath =
+  const agentsRoot =
     destination === "global"
-      ? join(homedir(), ".agav", "agents", nameToCheck)
-      : join(cwd, ".agav", "agents", nameToCheck);
+      ? join(homedir(), ".agav", "agents")
+      : join(cwd, ".agav", "agents");
+  const destPath = join(agentsRoot, nameToCheck);
+  assertPathContained(destPath, agentsRoot);
 
   // Copy agent to destination
   try {
@@ -127,17 +189,20 @@ export async function installAgent(
  * Clone agent from git URL using sparse checkout
  */
 async function cloneAgent(url: string): Promise<{ success: boolean; path?: string; error?: string }> {
-  // Create temp directory
+  try {
+    validateGitUrl(url);
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+
   const tempDir = join(tmpdir(), `agav-agent-${randomBytes(8).toString("hex")}`);
 
   try {
     await mkdir(tempDir, { recursive: true });
 
-    // Parse URL to determine if it's a subdirectory or full repo
     const isSubdirectory = url.includes("/tree/") || url.includes("/agents/");
 
     if (isSubdirectory) {
-      // Extract repo URL and path
       const match = url.match(/^(https?:\/\/[^\/]+\/[^\/]+\/[^\/]+)(?:\/tree\/[^\/]+)?(\/.+)$/);
       if (!match) {
         return { success: false, error: "Invalid git URL format" };
@@ -145,30 +210,48 @@ async function cloneAgent(url: string): Promise<{ success: boolean; path?: strin
 
       const [, repoUrl, subPath] = match;
 
-      // Sparse checkout
-      await execAsync(`git clone --depth=1 --filter=blob:none --sparse "${repoUrl}" .`, { cwd: tempDir });
-      await execAsync(`git sparse-checkout set ${subPath.slice(1)}`, { cwd: tempDir });
+      await gitExec(["clone", "--depth=1", "--filter=blob:none", "--sparse", repoUrl!, "."], tempDir);
+      await gitExec(["sparse-checkout", "set", subPath!.slice(1)], tempDir);
 
-      // Find the agent directory
-      const agentPath = join(tempDir, subPath.slice(1));
-      return { success: true, path: agentPath };
+      // Copy agent out of the clone, then clean up (avoids dragging .git into the install)
+      const agentSrc = join(tempDir, subPath!.slice(1));
+      const outDir = join(tmpdir(), `agav-agent-${randomBytes(8).toString("hex")}`);
+      await mkdir(outDir, { recursive: true });
+      await cp(agentSrc, outDir, {
+        recursive: true,
+        filter: (src) => !src.endsWith(".git") && !src.includes(`${join(".git")}/`) && !src.includes(`${join(".git")}\\`),
+      });
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      return { success: true, path: outDir };
     } else {
-      // Full repo clone
-      await execAsync(`git clone --depth=1 "${url}" .`, { cwd: tempDir });
+      await gitExec(["clone", "--depth=1", url, "."], tempDir);
 
-      // Look for agents/ directory or assume root is the agent
       const entries = await readdir(tempDir);
       if (entries.includes("AGENT.md")) {
+        // Remove .git from the clone before returning
+        await rm(join(tempDir, ".git"), { recursive: true, force: true }).catch(() => {});
         return { success: true, path: tempDir };
       } else if (entries.includes("agents")) {
-        // Multiple agents - return the first one found
         const agentsDir = join(tempDir, "agents");
         const agentDirs = await readdir(agentsDir);
-        if (agentDirs.length > 0) {
-          return { success: true, path: join(agentsDir, agentDirs[0]) };
+        // Find first entry that contains an AGENT.md
+        for (const dir of agentDirs) {
+          const candidate = join(agentsDir, dir);
+          const s = await stat(candidate).catch(() => null);
+          if (!s?.isDirectory()) continue;
+          const candidateEntries = await readdir(candidate);
+          if (candidateEntries.includes("AGENT.md")) {
+            // Copy out of the clone to avoid dragging .git
+            const outDir = join(tmpdir(), `agav-agent-${randomBytes(8).toString("hex")}`);
+            await mkdir(outDir, { recursive: true });
+            await cp(candidate, outDir, { recursive: true });
+            await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+            return { success: true, path: outDir };
+          }
         }
       }
 
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
       return { success: false, error: "No AGENT.md found in repository" };
     }
   } catch (error) {
@@ -184,13 +267,20 @@ async function cloneAgent(url: string): Promise<{ success: boolean; path?: strin
  * Uninstall agent (remove from filesystem and registry)
  */
 export async function uninstallAgent(nameOrAlias: string, destination: "global" | "project" = "global", cwd: string = process.cwd()): Promise<{ success: boolean; error?: string }> {
-  const { unregisterAgent } = await import("./agent-registry.js");
-  const { stat } = await import("node:fs/promises");
+  try {
+    validateAgentName(nameOrAlias);
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
 
-  const agentPath =
+  const { unregisterAgent } = await import("./agent-registry.js");
+
+  const agentsRoot =
     destination === "global"
-      ? join(homedir(), ".agav", "agents", nameOrAlias)
-      : join(cwd, ".agav", "agents", nameOrAlias);
+      ? join(homedir(), ".agav", "agents")
+      : join(cwd, ".agav", "agents");
+  const agentPath = join(agentsRoot, nameOrAlias);
+  assertPathContained(agentPath, agentsRoot);
 
   // Verify the path exists (registry entry is optional — agents can exist on disk
   // without a registry entry if the registry was pruned or manually edited)

--- a/source/agents/installer.ts
+++ b/source/agents/installer.ts
@@ -3,7 +3,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { readdir, rm, cp, mkdir, stat } from "node:fs/promises";
+import { readdir, rm, cp, mkdir, stat, realpath } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
@@ -40,9 +40,9 @@ function validateGitUrl(url: string): void {
   }
 }
 
-function assertPathContained(child: string, parent: string): void {
-  const resolved = resolve(child);
-  const root = resolve(parent);
+async function assertPathContained(child: string, parent: string): Promise<void> {
+  const resolved = await realpath(resolve(child)).catch(() => resolve(child));
+  const root = await realpath(resolve(parent)).catch(() => resolve(parent));
   if (!resolved.startsWith(root + "/") && !resolved.startsWith(root + "\\") && resolved !== root) {
     throw new Error("Agent path escapes the agents directory");
   }
@@ -80,7 +80,11 @@ export async function installAgent(
   }
 
   // Determine if source is a git URL or local path
-  const isGitUrl = source.startsWith("http://") || source.startsWith("https://") || source.startsWith("git@");
+  if (source.startsWith("git@")) {
+    return { success: false, error: "SSH (git@) URLs are not supported. Use HTTPS URLs instead." };
+  }
+
+  const isGitUrl = source.startsWith("http://") || source.startsWith("https://");
 
   let agentPath: string;
 
@@ -148,7 +152,7 @@ export async function installAgent(
       ? join(homedir(), ".agav", "agents")
       : join(cwd, ".agav", "agents");
   const destPath = join(agentsRoot, nameToCheck);
-  assertPathContained(destPath, agentsRoot);
+  await assertPathContained(destPath, agentsRoot);
 
   // Copy agent to destination
   try {
@@ -215,7 +219,7 @@ async function cloneAgent(url: string): Promise<{ success: boolean; path?: strin
 
       // Copy agent out of the clone, then clean up (avoids dragging .git into the install)
       const agentSrc = join(tempDir, subPath!.slice(1));
-      assertPathContained(agentSrc, tempDir);
+      await assertPathContained(agentSrc, tempDir);
       const outDir = join(tmpdir(), `agav-agent-${randomBytes(8).toString("hex")}`);
       await mkdir(outDir, { recursive: true });
       await cp(agentSrc, outDir, {
@@ -281,7 +285,7 @@ export async function uninstallAgent(nameOrAlias: string, destination: "global" 
       ? join(homedir(), ".agav", "agents")
       : join(cwd, ".agav", "agents");
   const agentPath = join(agentsRoot, nameOrAlias);
-  assertPathContained(agentPath, agentsRoot);
+  await assertPathContained(agentPath, agentsRoot);
 
   // Verify the path exists (registry entry is optional — agents can exist on disk
   // without a registry entry if the registry was pruned or manually edited)

--- a/source/agents/loader.ts
+++ b/source/agents/loader.ts
@@ -1,0 +1,312 @@
+/**
+ * Agent loader - scans three-tier search path and loads agent definitions
+ */
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join, resolve, dirname } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import type {
+  AgentDefinition,
+  AgentManifest,
+  AgentOrigin,
+} from "./types.js";
+import type { ToolDefinition } from "../tools/types.js";
+
+/**
+ * Simple YAML parser for frontmatter
+ * Handles basic YAML structures needed for AGENT.md
+ */
+function parseSimpleYAML(yamlText: string): Record<string, any> {
+  const result: Record<string, any> = {};
+  const lines = yamlText.split('\n');
+  let currentKey: string | null = null;
+  let currentArray: any[] | null = null;
+  let currentObject: Record<string, any> | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    // Array item
+    if (trimmed.startsWith('- ')) {
+      const value = trimmed.slice(2).trim();
+      if (currentArray) {
+        currentArray.push(value);
+      } else if (currentKey) {
+        currentArray = [value];
+        result[currentKey] = currentArray;
+      }
+      continue;
+    }
+
+    // Key-value pair
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex > 0) {
+      const key = trimmed.slice(0, colonIndex).trim();
+      const value = trimmed.slice(colonIndex + 1).trim();
+
+      // Check if it's a nested object key (indented lines will follow)
+      if (!value) {
+        currentKey = key;
+        currentArray = null;
+        currentObject = {};
+        result[key] = currentObject;
+      } else {
+        currentArray = null;
+        currentObject = null;
+        currentKey = key;
+        // Parse value
+        if (value === 'true') {
+          result[key] = true;
+        } else if (value === 'false') {
+          result[key] = false;
+        } else if (/^\d+$/.test(value)) {
+          result[key] = parseInt(value, 10);
+        } else if (value.startsWith('[') && value.endsWith(']')) {
+          // Parse bracket-style array: [item1, item2, item3]
+          const arrayContent = value.slice(1, -1).trim();
+          if (arrayContent) {
+            result[key] = arrayContent.split(',').map((item) => item.trim().replace(/^["']|["']$/g, ''));
+          } else {
+            result[key] = [];
+          }
+        } else {
+          // Remove quotes if present
+          result[key] = value.replace(/^["']|["']$/g, '');
+        }
+      }
+      continue;
+    }
+
+    // Nested key-value for objects
+    if (currentObject && trimmed.includes(':')) {
+      const nestedColonIndex = trimmed.indexOf(':');
+      const nestedKey = trimmed.slice(0, nestedColonIndex).trim();
+      const nestedValue = trimmed.slice(nestedColonIndex + 1).trim();
+      if (nestedValue === 'true') {
+        currentObject[nestedKey] = true;
+      } else if (nestedValue === 'false') {
+        currentObject[nestedKey] = false;
+      } else {
+        currentObject[nestedKey] = nestedValue.replace(/^["']|["']$/g, '');
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Three-tier search path for agents (later tiers override earlier by name)
+ */
+function getAgentSearchPaths(cwd: string): Array<{ path: string; origin: AgentOrigin }> {
+  const currentFilePath = fileURLToPath(import.meta.url);
+  const bundledPath = resolve(dirname(currentFilePath), "bundled");
+  const globalPath = join(homedir(), ".agav", "agents");
+  const projectPath = join(cwd, ".agav", "agents");
+
+  return [
+    { path: bundledPath, origin: "bundled" as AgentOrigin },
+    { path: globalPath, origin: "global" as AgentOrigin },
+    { path: projectPath, origin: "project" as AgentOrigin },
+  ];
+}
+
+/**
+ * Parse AGENT.md frontmatter and body
+ */
+async function parseAgentMarkdown(path: string): Promise<{ manifest: AgentManifest; systemPrompt: string }> {
+  const content = await readFile(path, "utf-8");
+
+  // Extract YAML frontmatter between --- delimiters
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) {
+    throw new Error(`Invalid AGENT.md format: missing YAML frontmatter in ${path}`);
+  }
+
+  const [, frontmatter, body] = match;
+  const manifest = parseSimpleYAML(frontmatter) as AgentManifest;
+
+  // Validate required fields
+  if (!manifest.name) {
+    throw new Error(`Invalid AGENT.md: missing 'name' field in ${path}`);
+  }
+  if (!manifest.description) {
+    throw new Error(`Invalid AGENT.md: missing 'description' field in ${path}`);
+  }
+  if (!manifest.version) {
+    throw new Error(`Invalid AGENT.md: missing 'version' field in ${path}`);
+  }
+
+  return { manifest, systemPrompt: body.trim() };
+}
+
+/**
+ * Load tools from agent's tools directory
+ */
+async function loadAgentTools(
+  agentDir: string,
+  toolsDir: string,
+  toolPermissions: Record<string, "safe" | "destructive"> = {}
+): Promise<ToolDefinition[]> {
+  const toolsDirPath = resolve(agentDir, toolsDir);
+  const tools: ToolDefinition[] = [];
+
+  let entries: string[];
+  try {
+    entries = await readdir(toolsDirPath);
+  } catch {
+    // No tools directory
+    return tools;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".mjs") && !entry.endsWith(".js")) continue;
+
+    const toolPath = join(toolsDirPath, entry);
+    try {
+      const mod = await import(pathToFileURL(toolPath).href);
+      const toolDef = mod.default || mod;
+
+      if (!toolDef.schema || !toolDef.execute) {
+        console.warn(`Skipping invalid tool in ${toolPath}: missing schema or execute`);
+        continue;
+      }
+
+      // Apply tool permission from manifest
+      const permission = toolPermissions[toolDef.schema.name];
+      if (permission === "safe") {
+        toolDef.schema.destructive = false;
+      } else if (permission === "destructive") {
+        toolDef.schema.destructive = true;
+      }
+
+      tools.push(toolDef);
+    } catch (error) {
+      console.warn(`Failed to load tool from ${toolPath}:`, error);
+    }
+  }
+
+  return tools;
+}
+
+/**
+ * Load a single agent from a directory
+ */
+export async function loadAgent(agentDir: string, origin: AgentOrigin, alias?: string): Promise<AgentDefinition | null> {
+  const manifestPath = join(agentDir, "AGENT.md");
+
+  try {
+    await stat(manifestPath);
+  } catch {
+    // No AGENT.md in this directory
+    return null;
+  }
+
+  try {
+    const { manifest, systemPrompt } = await parseAgentMarkdown(manifestPath);
+    const toolsDir = manifest["tools-dir"] || "./tools";
+    const tools = await loadAgentTools(agentDir, toolsDir, manifest["tool-permissions"]);
+
+    return {
+      manifest: { ...manifest, enabled: manifest.enabled ?? true },
+      systemPrompt,
+      tools,
+      origin,
+      path: agentDir,
+      alias,
+    };
+  } catch (error) {
+    console.warn(`Failed to load agent from ${agentDir}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Load all agents from the three-tier search path
+ */
+export async function loadAgents(cwd: string = process.cwd()): Promise<AgentDefinition[]> {
+  const searchPaths = getAgentSearchPaths(cwd);
+  const agentMap = new Map<string, AgentDefinition>();
+
+  for (const { path: searchPath, origin } of searchPaths) {
+    let entries: string[];
+    try {
+      entries = await readdir(searchPath);
+    } catch {
+      // Directory doesn't exist
+      continue;
+    }
+
+    for (const entry of entries) {
+      const agentDir = join(searchPath, entry);
+      const stats = await stat(agentDir).catch(() => null);
+      if (!stats?.isDirectory()) continue;
+
+      const agent = await loadAgent(agentDir, origin);
+      if (!agent) continue;
+
+      // Later tiers override earlier tiers by name
+      const key = agent.alias || agent.manifest.name;
+      agentMap.set(key, agent);
+    }
+  }
+
+  // Merge registry enabled state and prune stale entries
+  const { loadRegistry, saveRegistry } = await import("./agent-registry.js");
+  const registry = await loadRegistry();
+  let registryDirty = false;
+
+  const agents = Array.from(agentMap.values());
+  for (const agent of agents) {
+    const key = agent.alias || agent.manifest.name;
+    const registryEntry = registry.agents[key];
+    if (registryEntry) {
+      // Registry enabled state overrides manifest
+      agent.manifest.enabled = registryEntry.enabled;
+    }
+  }
+
+  // Prune stale registry entries (registered but no loadable files on disk)
+  for (const key of Object.keys(registry.agents)) {
+    if (agentMap.has(key)) continue; // already found via scan — fine
+    // Check if files exist at the global path for this registry key
+    const { homedir } = await import("node:os");
+    const globalPath = join(homedir(), ".agav", "agents", key);
+    const check = await loadAgent(globalPath, "global");
+    if (!check) {
+      // Stale entry — files are missing or AGENT.md is gone
+      delete registry.agents[key];
+      registryDirty = true;
+    }
+  }
+
+  if (registryDirty) {
+    await saveRegistry(registry).catch(() => {}); // non-fatal
+  }
+
+  return agents;
+}
+
+/**
+ * Get cached agents (singleton pattern for hot-reload support)
+ */
+let cachedAgents: AgentDefinition[] | null = null;
+
+export function getCachedAgents(): AgentDefinition[] {
+  return cachedAgents || [];
+}
+
+export function setCachedAgents(agents: AgentDefinition[]): void {
+  cachedAgents = agents;
+}
+
+/**
+ * Get a single agent by name or alias
+ */
+export function getAgent(nameOrAlias: string): AgentDefinition | undefined {
+  return getCachedAgents().find(
+    (a) => a.manifest.name === nameOrAlias || a.alias === nameOrAlias
+  );
+}

--- a/source/agents/loader.ts
+++ b/source/agents/loader.ts
@@ -67,7 +67,8 @@ async function parseAgentMarkdown(path: string): Promise<{ manifest: AgentManife
 async function scanAgentTools(
   agentDir: string,
   toolsDir: string,
-  toolPermissions: Record<string, "safe" | "destructive"> = {}
+  toolPermissions: Record<string, "safe" | "destructive"> = {},
+  manifestTools?: AgentManifest["tools"]
 ): Promise<ToolDefinition[]> {
   const toolsDirPath = resolve(agentDir, toolsDir);
   const tools: ToolDefinition[] = [];
@@ -79,29 +80,45 @@ async function scanAgentTools(
     return tools;
   }
 
+  // Index manifest-declared tool schemas by name for quick lookup
+  const manifestSchemaByName = new Map<string, NonNullable<AgentManifest["tools"]>[number]>();
+  if (manifestTools) {
+    for (const t of manifestTools) manifestSchemaByName.set(t.name, t);
+  }
+
   for (const entry of entries) {
     if (!entry.endsWith(".mjs") && !entry.endsWith(".js")) continue;
 
     const toolPath = join(toolsDirPath, entry);
     const toolName = entry.replace(/\.(mjs|js)$/, "").replace(/-/g, "_");
 
-    // Try to read schema from a companion .schema.json sidecar
+    // Schema resolution: (1) manifest tools section, (2) .schema.json sidecar, (3) placeholder
     let schema: ToolDefinition["schema"];
-    const sidecarPath = toolPath.replace(/\.(mjs|js)$/, ".schema.json");
-    try {
-      const sidecar = await readFile(sidecarPath, "utf-8");
-      schema = JSON.parse(sidecar);
-    } catch {
-      // No sidecar — use a placeholder schema derived from the filename
+    const manifestEntry = manifestSchemaByName.get(toolName);
+    if (manifestEntry) {
       schema = {
-        name: toolName,
-        description: `Tool from ${agentDir}`,
-        inputSchema: {
-          type: "object" as const,
-          properties: { task: { type: "string", description: "The task input" } },
-          required: ["task"],
-        },
+        name: manifestEntry.name,
+        description: manifestEntry.description,
+        destructive: manifestEntry.destructive,
+        inputSchema: manifestEntry.inputSchema,
       };
+    } else {
+      const sidecarPath = toolPath.replace(/\.(mjs|js)$/, ".schema.json");
+      try {
+        const sidecar = await readFile(sidecarPath, "utf-8");
+        schema = JSON.parse(sidecar);
+      } catch {
+        console.warn(`[agent] No schema for tool "${toolName}" in ${agentDir} — declare it in AGENT.md tools section or provide a .schema.json sidecar`);
+        schema = {
+          name: toolName,
+          description: `(schema unavailable — declare in AGENT.md tools section)`,
+          inputSchema: {
+            type: "object" as const,
+            properties: { task: { type: "string", description: "The task input" } },
+            required: ["task"],
+          },
+        };
+      }
     }
 
     // Apply tool permission from manifest
@@ -157,7 +174,7 @@ export async function loadAgent(agentDir: string, origin: AgentOrigin, alias?: s
   try {
     const { manifest, systemPrompt } = await parseAgentMarkdown(manifestPath);
     const toolsDir = manifest["tools-dir"] || "./tools";
-    const tools = await scanAgentTools(agentDir, toolsDir, manifest["tool-permissions"]);
+    const tools = await scanAgentTools(agentDir, toolsDir, manifest["tool-permissions"], manifest.tools);
 
     return {
       manifest: { ...manifest, enabled: manifest.enabled ?? true },

--- a/source/agents/loader.ts
+++ b/source/agents/loader.ts
@@ -6,6 +6,7 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import { join, resolve, dirname } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { homedir } from "node:os";
+import { parse as parseYAML } from "yaml";
 import type {
   AgentDefinition,
   AgentManifest,
@@ -14,93 +15,10 @@ import type {
 import type { ToolDefinition } from "../tools/types.js";
 
 /**
- * Simple YAML parser for frontmatter
- * Handles basic YAML structures needed for AGENT.md
- */
-function parseSimpleYAML(yamlText: string): Record<string, any> {
-  const result: Record<string, any> = {};
-  const lines = yamlText.split('\n');
-  let currentKey: string | null = null;
-  let currentArray: any[] | null = null;
-  let currentObject: Record<string, any> | null = null;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-
-    // Array item
-    if (trimmed.startsWith('- ')) {
-      const value = trimmed.slice(2).trim();
-      if (currentArray) {
-        currentArray.push(value);
-      } else if (currentKey) {
-        currentArray = [value];
-        result[currentKey] = currentArray;
-      }
-      continue;
-    }
-
-    // Key-value pair
-    const colonIndex = trimmed.indexOf(':');
-    if (colonIndex > 0) {
-      const key = trimmed.slice(0, colonIndex).trim();
-      const value = trimmed.slice(colonIndex + 1).trim();
-
-      // Check if it's a nested object key (indented lines will follow)
-      if (!value) {
-        currentKey = key;
-        currentArray = null;
-        currentObject = {};
-        result[key] = currentObject;
-      } else {
-        currentArray = null;
-        currentObject = null;
-        currentKey = key;
-        // Parse value
-        if (value === 'true') {
-          result[key] = true;
-        } else if (value === 'false') {
-          result[key] = false;
-        } else if (/^\d+$/.test(value)) {
-          result[key] = parseInt(value, 10);
-        } else if (value.startsWith('[') && value.endsWith(']')) {
-          // Parse bracket-style array: [item1, item2, item3]
-          const arrayContent = value.slice(1, -1).trim();
-          if (arrayContent) {
-            result[key] = arrayContent.split(',').map((item) => item.trim().replace(/^["']|["']$/g, ''));
-          } else {
-            result[key] = [];
-          }
-        } else {
-          // Remove quotes if present
-          result[key] = value.replace(/^["']|["']$/g, '');
-        }
-      }
-      continue;
-    }
-
-    // Nested key-value for objects
-    if (currentObject && trimmed.includes(':')) {
-      const nestedColonIndex = trimmed.indexOf(':');
-      const nestedKey = trimmed.slice(0, nestedColonIndex).trim();
-      const nestedValue = trimmed.slice(nestedColonIndex + 1).trim();
-      if (nestedValue === 'true') {
-        currentObject[nestedKey] = true;
-      } else if (nestedValue === 'false') {
-        currentObject[nestedKey] = false;
-      } else {
-        currentObject[nestedKey] = nestedValue.replace(/^["']|["']$/g, '');
-      }
-    }
-  }
-
-  return result;
-}
-
-/**
  * Three-tier search path for agents (later tiers override earlier by name)
  */
 function getAgentSearchPaths(cwd: string): Array<{ path: string; origin: AgentOrigin }> {
+  // NOTE: import.meta.url resolves inside /$bunfs under bun build --compile. See #69.
   const currentFilePath = fileURLToPath(import.meta.url);
   const bundledPath = resolve(dirname(currentFilePath), "bundled");
   const globalPath = join(homedir(), ".agav", "agents");
@@ -119,14 +37,14 @@ function getAgentSearchPaths(cwd: string): Array<{ path: string; origin: AgentOr
 async function parseAgentMarkdown(path: string): Promise<{ manifest: AgentManifest; systemPrompt: string }> {
   const content = await readFile(path, "utf-8");
 
-  // Extract YAML frontmatter between --- delimiters
-  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  // Extract YAML frontmatter between --- delimiters (handle both LF and CRLF)
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
   if (!match) {
     throw new Error(`Invalid AGENT.md format: missing YAML frontmatter in ${path}`);
   }
 
   const [, frontmatter, body] = match;
-  const manifest = parseSimpleYAML(frontmatter) as AgentManifest;
+  const manifest = parseYAML(frontmatter) as AgentManifest;
 
   // Validate required fields
   if (!manifest.name) {
@@ -143,9 +61,10 @@ async function parseAgentMarkdown(path: string): Promise<{ manifest: AgentManife
 }
 
 /**
- * Load tools from agent's tools directory
+ * Scan tools directory and return lazy ToolDefinitions that defer import() to first invocation.
+ * This prevents third-party tool code from running at scan time.
  */
-async function loadAgentTools(
+async function scanAgentTools(
   agentDir: string,
   toolsDir: string,
   toolPermissions: Record<string, "safe" | "destructive"> = {}
@@ -157,7 +76,6 @@ async function loadAgentTools(
   try {
     entries = await readdir(toolsDirPath);
   } catch {
-    // No tools directory
     return tools;
   }
 
@@ -165,27 +83,59 @@ async function loadAgentTools(
     if (!entry.endsWith(".mjs") && !entry.endsWith(".js")) continue;
 
     const toolPath = join(toolsDirPath, entry);
+    const toolName = entry.replace(/\.(mjs|js)$/, "").replace(/-/g, "_");
+
+    // Try to read schema from a companion .schema.json sidecar
+    let schema: ToolDefinition["schema"];
+    const sidecarPath = toolPath.replace(/\.(mjs|js)$/, ".schema.json");
     try {
-      const mod = await import(pathToFileURL(toolPath).href);
-      const toolDef = mod.default || mod;
-
-      if (!toolDef.schema || !toolDef.execute) {
-        console.warn(`Skipping invalid tool in ${toolPath}: missing schema or execute`);
-        continue;
-      }
-
-      // Apply tool permission from manifest
-      const permission = toolPermissions[toolDef.schema.name];
-      if (permission === "safe") {
-        toolDef.schema.destructive = false;
-      } else if (permission === "destructive") {
-        toolDef.schema.destructive = true;
-      }
-
-      tools.push(toolDef);
-    } catch (error) {
-      console.warn(`Failed to load tool from ${toolPath}:`, error);
+      const sidecar = await readFile(sidecarPath, "utf-8");
+      schema = JSON.parse(sidecar);
+    } catch {
+      // No sidecar — use a placeholder schema derived from the filename
+      schema = {
+        name: toolName,
+        description: `Tool from ${agentDir}`,
+        inputSchema: {
+          type: "object" as const,
+          properties: { task: { type: "string", description: "The task input" } },
+          required: ["task"],
+        },
+      };
     }
+
+    // Apply tool permission from manifest
+    const permission = toolPermissions[schema.name];
+    if (permission === "safe") {
+      schema.destructive = false;
+    } else if (permission === "destructive") {
+      schema.destructive = true;
+    }
+
+    // Lazy-load the actual module on first execute() call
+    let loadedExecute: ((input: Record<string, unknown>) => Promise<any>) | null = null;
+
+    tools.push({
+      schema,
+      async execute(input) {
+        if (!loadedExecute) {
+          const mod = await import(pathToFileURL(toolPath).href);
+          const toolDef = mod.default || mod;
+          if (!toolDef.execute) {
+            return { output: `Tool ${schema.name} has no execute function`, isError: true };
+          }
+          // Update schema with the real one from the module if available
+          if (toolDef.schema) {
+            Object.assign(schema, toolDef.schema);
+            // Re-apply permission override
+            if (permission === "safe") schema.destructive = false;
+            else if (permission === "destructive") schema.destructive = true;
+          }
+          loadedExecute = toolDef.execute;
+        }
+        return loadedExecute!(input);
+      },
+    });
   }
 
   return tools;
@@ -207,7 +157,7 @@ export async function loadAgent(agentDir: string, origin: AgentOrigin, alias?: s
   try {
     const { manifest, systemPrompt } = await parseAgentMarkdown(manifestPath);
     const toolsDir = manifest["tools-dir"] || "./tools";
-    const tools = await loadAgentTools(agentDir, toolsDir, manifest["tool-permissions"]);
+    const tools = await scanAgentTools(agentDir, toolsDir, manifest["tool-permissions"]);
 
     return {
       manifest: { ...manifest, enabled: manifest.enabled ?? true },
@@ -230,12 +180,15 @@ export async function loadAgents(cwd: string = process.cwd()): Promise<AgentDefi
   const searchPaths = getAgentSearchPaths(cwd);
   const agentMap = new Map<string, AgentDefinition>();
 
+  // Load registry first so we can skip disabled agents before importing their tools
+  const { loadRegistry, saveRegistry } = await import("./agent-registry.js");
+  const registry = await loadRegistry();
+
   for (const { path: searchPath, origin } of searchPaths) {
     let entries: string[];
     try {
       entries = await readdir(searchPath);
     } catch {
-      // Directory doesn't exist
       continue;
     }
 
@@ -244,49 +197,50 @@ export async function loadAgents(cwd: string = process.cwd()): Promise<AgentDefi
       const stats = await stat(agentDir).catch(() => null);
       if (!stats?.isDirectory()) continue;
 
+      // Skip agents that are explicitly disabled in the registry
+      const registryEntry = registry.agents[entry];
+      if (registryEntry && registryEntry.enabled === false) continue;
+
       const agent = await loadAgent(agentDir, origin);
       if (!agent) continue;
 
-      // Later tiers override earlier tiers by name
+      // If directory name differs from manifest name, treat it as an alias
+      if (entry !== agent.manifest.name && !agent.alias) {
+        agent.alias = entry;
+      }
+
+      // Apply registry enabled state
       const key = agent.alias || agent.manifest.name;
+      const regEntry = registry.agents[key];
+      if (regEntry) {
+        agent.manifest.enabled = regEntry.enabled;
+      }
+
+      // Later tiers override earlier tiers by name
       agentMap.set(key, agent);
     }
   }
 
-  // Merge registry enabled state and prune stale entries
-  const { loadRegistry, saveRegistry } = await import("./agent-registry.js");
-  const registry = await loadRegistry();
-  let registryDirty = false;
-
-  const agents = Array.from(agentMap.values());
-  for (const agent of agents) {
-    const key = agent.alias || agent.manifest.name;
-    const registryEntry = registry.agents[key];
-    if (registryEntry) {
-      // Registry enabled state overrides manifest
-      agent.manifest.enabled = registryEntry.enabled;
-    }
-  }
-
   // Prune stale registry entries (registered but no loadable files on disk)
+  let registryDirty = false;
   for (const key of Object.keys(registry.agents)) {
-    if (agentMap.has(key)) continue; // already found via scan — fine
-    // Check if files exist at the global path for this registry key
-    const { homedir } = await import("node:os");
+    if (agentMap.has(key)) continue;
+    // Check both global and project paths before marking as stale
     const globalPath = join(homedir(), ".agav", "agents", key);
-    const check = await loadAgent(globalPath, "global");
-    if (!check) {
-      // Stale entry — files are missing or AGENT.md is gone
+    const projectPath = join(cwd, ".agav", "agents", key);
+    const checkGlobal = await loadAgent(globalPath, "global");
+    const checkProject = await loadAgent(projectPath, "project");
+    if (!checkGlobal && !checkProject) {
       delete registry.agents[key];
       registryDirty = true;
     }
   }
 
   if (registryDirty) {
-    await saveRegistry(registry).catch(() => {}); // non-fatal
+    await saveRegistry(registry).catch(() => {});
   }
 
-  return agents;
+  return Array.from(agentMap.values());
 }
 
 /**

--- a/source/agents/loader.ts
+++ b/source/agents/loader.ts
@@ -83,7 +83,11 @@ async function scanAgentTools(
   // Index manifest-declared tool schemas by name for quick lookup
   const manifestSchemaByName = new Map<string, NonNullable<AgentManifest["tools"]>[number]>();
   if (manifestTools) {
-    for (const t of manifestTools) manifestSchemaByName.set(t.name, t);
+    for (const t of manifestTools) {
+      // Normalize hyphens to underscores to match filename-derived toolName
+      const normalized = t.name.replace(/-/g, "_");
+      manifestSchemaByName.set(normalized, t);
+    }
   }
 
   for (const entry of entries) {
@@ -94,6 +98,7 @@ async function scanAgentTools(
 
     // Schema resolution: (1) manifest tools section, (2) .schema.json sidecar, (3) placeholder
     let schema: ToolDefinition["schema"];
+    let hasDeclaredSchema = false;
     const manifestEntry = manifestSchemaByName.get(toolName);
     if (manifestEntry) {
       schema = {
@@ -102,11 +107,18 @@ async function scanAgentTools(
         destructive: manifestEntry.destructive,
         inputSchema: manifestEntry.inputSchema,
       };
+      hasDeclaredSchema = true;
     } else {
       const sidecarPath = toolPath.replace(/\.(mjs|js)$/, ".schema.json");
       try {
         const sidecar = await readFile(sidecarPath, "utf-8");
         schema = JSON.parse(sidecar);
+        // Sanitize schema name to prevent path traversal (e.g. in tool-gen.ts write paths)
+        if (schema.name && /[\/\\]/.test(schema.name)) {
+          console.warn(`[agent] Sidecar schema name "${schema.name}" contains path separators, using filename-derived name`);
+          schema.name = toolName;
+        }
+        hasDeclaredSchema = true;
       } catch {
         console.warn(`[agent] No schema for tool "${toolName}" in ${agentDir} — declare it in AGENT.md tools section or provide a .schema.json sidecar`);
         schema = {
@@ -134,23 +146,37 @@ async function scanAgentTools(
 
     tools.push({
       schema,
-      async execute(input) {
-        if (!loadedExecute) {
-          const mod = await import(pathToFileURL(toolPath).href);
-          const toolDef = mod.default || mod;
-          if (!toolDef.execute) {
-            return { output: `Tool ${schema.name} has no execute function`, isError: true };
+      async execute(input, context?) {
+        // Inject credentials into process.env for this tool call only
+        const envToRestore: Record<string, string | undefined> = {};
+        if (context?.env) {
+          for (const [k, v] of Object.entries(context.env)) {
+            envToRestore[k] = process.env[k];
+            process.env[k] = v;
           }
-          // Update schema with the real one from the module if available
-          if (toolDef.schema) {
-            Object.assign(schema, toolDef.schema);
-            // Re-apply permission override
-            if (permission === "safe") schema.destructive = false;
-            else if (permission === "destructive") schema.destructive = true;
-          }
-          loadedExecute = toolDef.execute;
         }
-        return loadedExecute!(input);
+        try {
+          if (!loadedExecute) {
+            const mod = await import(pathToFileURL(toolPath).href);
+            const toolDef = mod.default || mod;
+            if (!toolDef.execute) {
+              return { output: `Tool ${schema.name} has no execute function`, isError: true };
+            }
+            // Only update schema from the module if no manifest/sidecar schema was declared
+            if (toolDef.schema && !hasDeclaredSchema) {
+              Object.assign(schema, toolDef.schema);
+              if (permission === "safe") schema.destructive = false;
+              else if (permission === "destructive") schema.destructive = true;
+            }
+            loadedExecute = toolDef.execute;
+          }
+          return await loadedExecute!(input);
+        } finally {
+          for (const [k, v] of Object.entries(envToRestore)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+          }
+        }
       },
     });
   }

--- a/source/agents/loader.ts
+++ b/source/agents/loader.ts
@@ -123,7 +123,7 @@ async function scanAgentTools(
         console.warn(`[agent] No schema for tool "${toolName}" in ${agentDir} — declare it in AGENT.md tools section or provide a .schema.json sidecar`);
         schema = {
           name: toolName,
-          description: `(schema unavailable — declare in AGENT.md tools section)`,
+          description: `Tool: ${toolName}`,
           inputSchema: {
             type: "object" as const,
             properties: { task: { type: "string", description: "The task input" } },
@@ -185,6 +185,32 @@ async function scanAgentTools(
 }
 
 /**
+ * Load only the manifest (no tool scanning) — used for disabled agents
+ * so they appear in the TUI list without executing any tool code.
+ */
+async function loadAgentManifestOnly(agentDir: string, origin: AgentOrigin, alias?: string): Promise<AgentDefinition | null> {
+  const manifestPath = join(agentDir, "AGENT.md");
+  try {
+    await stat(manifestPath);
+  } catch {
+    return null;
+  }
+  try {
+    const { manifest, systemPrompt } = await parseAgentMarkdown(manifestPath);
+    return {
+      manifest: { ...manifest, enabled: false },
+      systemPrompt,
+      tools: [],
+      origin,
+      path: agentDir,
+      alias,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Load a single agent from a directory
  */
 export async function loadAgent(agentDir: string, origin: AgentOrigin, alias?: string): Promise<AgentDefinition | null> {
@@ -240,11 +266,14 @@ export async function loadAgents(cwd: string = process.cwd()): Promise<AgentDefi
       const stats = await stat(agentDir).catch(() => null);
       if (!stats?.isDirectory()) continue;
 
-      // Skip agents that are explicitly disabled in the registry
+      // Disabled agents are loaded (so they appear in the TUI list) but
+      // their tools are not scanned (no code execution for disabled agents).
       const registryEntry = registry.agents[entry];
-      if (registryEntry && registryEntry.enabled === false) continue;
+      const isDisabled = registryEntry && registryEntry.enabled === false;
 
-      const agent = await loadAgent(agentDir, origin);
+      const agent = isDisabled
+        ? await loadAgentManifestOnly(agentDir, origin)
+        : await loadAgent(agentDir, origin);
       if (!agent) continue;
 
       // If directory name differs from manifest name, treat it as an alias

--- a/source/agents/registry-factory.ts
+++ b/source/agents/registry-factory.ts
@@ -34,7 +34,6 @@ export function agentToTool(
     schema: {
       name: toolName,
       description: agent.manifest.description,
-      destructive: false, // Service agents themselves are not destructive; their tools are
       inputSchema: {
         type: "object",
         properties: {

--- a/source/agents/registry-factory.ts
+++ b/source/agents/registry-factory.ts
@@ -1,0 +1,101 @@
+/**
+ * Agent registry factory - converts agents into callable tools
+ */
+
+import type { AgentDefinition } from "./types.js";
+import type { ToolDefinition } from "../tools/types.js";
+import type { LLMProvider } from "../providers/types.js";
+import type { AgavConfig } from "../config/config.js";
+import { executeNativeAgent, executeA2AAgent } from "./executor.js";
+
+// AgavHooks type - defined locally since it's not exported from hooks.js
+interface AgavHooks {
+  afterEdit?: string;
+  afterShell?: string;
+  preCommit?: string;
+}
+
+/**
+ * Convert an agent into a ToolDefinition that can be called by the main agent
+ */
+export function agentToTool(
+  agent: AgentDefinition,
+  deps: {
+    provider: LLMProvider;
+    config: AgavConfig;
+    hooks?: AgavHooks;
+    onProgressUpdate?: (callId: string, event: import("../agent/loop.js").AgentEvent) => void;
+    confirmTool?: (toolName: string, input: Record<string, unknown>, diff?: any[]) => Promise<any>;
+  }
+): ToolDefinition {
+  const toolName = `${agent.alias || agent.manifest.name}_agent`;
+
+  return {
+    schema: {
+      name: toolName,
+      description: agent.manifest.description,
+      destructive: false, // Service agents themselves are not destructive; their tools are
+      inputSchema: {
+        type: "object",
+        properties: {
+          task: {
+            type: "string",
+            description: "The task to delegate to this specialized agent",
+          },
+        },
+        required: ["task"],
+      },
+    },
+    async execute(input) {
+      const task = String(input.task || "");
+
+      try {
+        // Guard: check required credentials before running.
+        // Bundled agents store credentials in ~/.agav/agents/<name>/, not agent.path.
+        const requiredConfig = agent.manifest["required-config"] ?? [];
+        if (requiredConfig.length > 0) {
+          const { getMissingCredentials } = await import("./credentials.js");
+          const { homedir } = await import("node:os");
+          const { join } = await import("node:path");
+          const credPath = agent.origin === "bundled"
+            ? join(homedir(), ".agav", "agents", agent.manifest.name)
+            : agent.path;
+          const missing = await getMissingCredentials(credPath, agent.manifest);
+          if (missing.length > 0) {
+            const agentName = agent.manifest.name;
+            const lines = [
+              `Cannot run the ${agentName} agent — missing required configuration: ${missing.join(", ")}.`,
+              ``,
+              `To configure, set the following environment variables before starting agav:`,
+              ...missing.map((k) => `  export ${k}=<your-value>`),
+              ``,
+              `Or store them permanently in ~/.agav/agents/${agentName}/config.json`,
+            ];
+            return { output: lines.join("\n"), isError: true };
+          }
+        }
+
+        const agentType = agent.manifest.type || "native";
+
+        let output: string;
+        if (agentType === "native") {
+          output = await executeNativeAgent(agent, task, deps);
+        } else if (agentType === "a2a") {
+          output = await executeA2AAgent(agent, task);
+        } else {
+          throw new Error(`Unknown agent type: ${agentType}`);
+        }
+
+        return {
+          output,
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          output: `Error executing ${toolName}: ${error instanceof Error ? error.message : String(error)}`,
+          isError: true,
+        };
+      }
+    },
+  };
+}

--- a/source/agents/tool-gen.ts
+++ b/source/agents/tool-gen.ts
@@ -45,7 +45,6 @@ export default {
   schema: {
     name: "${ctx.toolName}",
     description: "...",
-    destructive: false,
     inputSchema: { type: "object", properties: { /* all params */ }, required: [] }
   },
   async execute(input) {
@@ -115,6 +114,14 @@ export async function implementAgentTools(
     });
 
     if (generated) {
+      // Basic syntax check before writing LLM-generated code
+      try {
+        new Function(generated);
+      } catch (syntaxErr) {
+        onStatus(`Skipping ${tool.schema.name}: generated code has syntax errors (${syntaxErr instanceof Error ? syntaxErr.message : String(syntaxErr)})`);
+        continue;
+      }
+
       let actualPath: string;
       try {
         await readFile(join(toolsDir, `${tool.schema.name.replace(/_/g, "-")}.mjs`), "utf-8");

--- a/source/agents/tool-gen.ts
+++ b/source/agents/tool-gen.ts
@@ -92,6 +92,9 @@ export async function implementAgentTools(
   let fixed = 0;
 
   for (const tool of agent.tools) {
+    // Reject tool names containing path separators to prevent directory traversal
+    if (/[\/\\]/.test(tool.schema.name)) continue;
+
     const toolFile = join(toolsDir, `${tool.schema.name.replace(/_/g, "-")}.mjs`);
     let src: string;
     try { src = await readFile(toolFile, "utf-8"); } catch {

--- a/source/agents/tool-gen.ts
+++ b/source/agents/tool-gen.ts
@@ -114,11 +114,9 @@ export async function implementAgentTools(
     });
 
     if (generated) {
-      // Basic syntax check before writing LLM-generated code
-      try {
-        new Function(generated);
-      } catch (syntaxErr) {
-        onStatus(`Skipping ${tool.schema.name}: generated code has syntax errors (${syntaxErr instanceof Error ? syntaxErr.message : String(syntaxErr)})`);
+      // Structural validation: reject LLM output that doesn't look like a tool module
+      if (!generated.includes("export") || !generated.includes("execute")) {
+        onStatus(`Skipping ${tool.schema.name}: generated output does not look like a valid tool module`);
         continue;
       }
 

--- a/source/agents/tool-gen.ts
+++ b/source/agents/tool-gen.ts
@@ -1,0 +1,131 @@
+import type { AgentDefinition } from "./types.js";
+import type { LLMProvider } from "../providers/types.js";
+import type { AgavConfig } from "../config/config.js";
+
+export interface ToolGenContext {
+  toolName: string;
+  toolDescription: string;
+  agentName: string;
+  agentDescription: string;
+  agentSystemPrompt: string;
+  credentials: string[];
+  existingStub?: string;
+}
+
+export async function generateToolCode(
+  provider: LLMProvider,
+  config: AgavConfig,
+  ctx: ToolGenContext
+): Promise<string> {
+  const credList = ctx.credentials.length > 0
+    ? ctx.credentials.map((k) => `process.env.${k}`).join(", ")
+    : "no credentials required";
+
+  const basePrompt = ctx.existingStub
+    ? `Re-implement this agav agent tool stub — replace every TODO and placeholder with a real implementation.
+
+Agent: ${ctx.agentName} — ${ctx.agentDescription}
+Credentials available: ${credList}
+
+Current stub:
+${ctx.existingStub}
+
+Return the complete updated module. Use the real ${ctx.agentName} API. No TODOs, no placeholders.`
+    : `Implement a JavaScript ES module (.mjs) for an agav agent tool.
+
+Agent: ${ctx.agentName} — ${ctx.agentDescription}
+Agent purpose: ${ctx.agentSystemPrompt.slice(0, 400)}
+
+Tool name: ${ctx.toolName}
+Tool description: ${ctx.toolDescription}
+Credentials available: ${credList}
+
+Required format (export this exact shape):
+export default {
+  schema: {
+    name: "${ctx.toolName}",
+    description: "...",
+    destructive: false,
+    inputSchema: { type: "object", properties: { /* all params */ }, required: [] }
+  },
+  async execute(input) {
+    // real implementation using fetch() against the ${ctx.agentName} API
+    // access credentials via process.env.CRED_KEY
+    // return { output: string, isError: boolean }
+    // format output as readable text, handle errors gracefully
+  }
+};
+
+Use real API endpoints. No TODOs, no placeholders.`;
+
+  let result = "";
+  for await (const event of provider.stream({
+    model: config.model,
+    effort: "medium" as any,
+    messages: [{ role: "user", content: [{ type: "text", text: basePrompt }] }],
+    systemPrompt:
+      "You are an expert JavaScript developer generating agav agent tool implementations. " +
+      "Return ONLY the JavaScript code — no markdown fences, no explanation, no comments about what you changed.",
+    tools: [],
+  })) {
+    if (event.type === "text_delta") result += event.text;
+  }
+
+  result = result.trim();
+  if (result.startsWith("```")) {
+    result = result.replace(/^```(?:javascript|js|mjs)?\r?\n/, "").replace(/\r?\n```$/, "");
+  }
+  return result;
+}
+
+export async function implementAgentTools(
+  agent: AgentDefinition,
+  provider: LLMProvider,
+  config: AgavConfig,
+  onStatus: (msg: string) => void,
+): Promise<{ fixed: number }> {
+  const { readFile, writeFile } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+
+  onStatus("Reading tools...");
+  const toolsDir = join(agent.path, agent.manifest["tools-dir"] || "tools");
+  const credentials = agent.manifest["required-config"] ?? [];
+  let fixed = 0;
+
+  for (const tool of agent.tools) {
+    const toolFile = join(toolsDir, `${tool.schema.name.replace(/_/g, "-")}.mjs`);
+    let src: string;
+    try { src = await readFile(toolFile, "utf-8"); } catch {
+      try {
+        const alt = join(toolsDir, `${tool.schema.name}.mjs`);
+        src = await readFile(alt, "utf-8");
+      } catch { continue; }
+    }
+    if (!src.includes("TODO")) continue;
+
+    onStatus(`Implementing ${tool.schema.name}...`);
+    const generated = await generateToolCode(provider, config, {
+      toolName: tool.schema.name,
+      toolDescription: tool.schema.description || `Tool for ${agent.manifest.name}`,
+      agentName: agent.manifest.name,
+      agentDescription: agent.manifest.description,
+      agentSystemPrompt: agent.systemPrompt,
+      credentials,
+      existingStub: src,
+    });
+
+    if (generated) {
+      let actualPath: string;
+      try {
+        await readFile(join(toolsDir, `${tool.schema.name.replace(/_/g, "-")}.mjs`), "utf-8");
+        actualPath = join(toolsDir, `${tool.schema.name.replace(/_/g, "-")}.mjs`);
+      } catch {
+        actualPath = join(toolsDir, `${tool.schema.name}.mjs`);
+      }
+      await writeFile(actualPath, generated, "utf-8");
+      fixed++;
+    }
+  }
+
+  return { fixed };
+}

--- a/source/agents/types.ts
+++ b/source/agents/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Agent system types
+ */
+
+import type { ToolDefinition } from "../tools/types.js";
+import type { EffortLevel } from "../config/config.js";
+
+/**
+ * Agent type - native (JS/TS in-process) or A2A (external process via HTTP)
+ */
+export type AgentType = "native" | "a2a";
+
+/**
+ * Agent origin - where the agent was loaded from
+ */
+export type AgentOrigin = "bundled" | "global" | "project";
+
+/**
+ * Tool permission declaration - marks tools as safe or destructive
+ */
+export type ToolPermission = "safe" | "destructive";
+
+/**
+ * Agent manifest - parsed from AGENT.md frontmatter
+ */
+export interface AgentManifest {
+  name: string;
+  description: string;
+  version: string;
+  type?: AgentType; // defaults to "native"
+  author?: string;
+
+  // Configuration
+  "required-config"?: string[]; // env var names required for this agent
+  "tools-dir"?: string; // path to tools directory, relative to AGENT.md
+  model?: string; // optional model override
+  effort?: EffortLevel; // optional effort override
+  tags?: string[];
+  enabled?: boolean; // defaults to true
+
+  // Tool permissions
+  "tool-permissions"?: Record<string, ToolPermission>;
+
+  // Per-agent MCP servers (started when this agent runs, scoped to this agent)
+  "mcp-servers"?: Array<{
+    key: string;     // identifier for this MCP connection
+    command: string; // "npx" | "uvx" | "docker" | "http"
+    args?: string[]; // e.g. ["-y", "@scope/pkg"] or ["https://endpoint"]
+  }>;
+
+  // A2A-specific fields
+  "start-command"?: string; // command to start the A2A agent process
+  endpoint?: string; // A2A endpoint URL
+}
+
+/**
+ * Agent definition - manifest + loaded tools + metadata
+ */
+export interface AgentDefinition {
+  manifest: AgentManifest;
+  systemPrompt: string; // body of AGENT.md after frontmatter
+  tools: ToolDefinition[]; // loaded tool definitions
+  origin: AgentOrigin; // where this agent was loaded from
+  path: string; // absolute path to agent directory
+  alias?: string; // alias if there was a name conflict
+}
+
+/**
+ * Agent registry entry - stored in ~/.agav/agents/registry.json
+ */
+export interface AgentRegistryEntry {
+  name: string;
+  alias?: string; // user-provided alias to resolve name conflicts
+  enabled: boolean;
+  sourceUrl?: string; // git URL if installed from marketplace
+  installedAt: string; // ISO timestamp
+  version: string;
+}
+
+/**
+ * Agent registry file format
+ */
+export interface AgentRegistry {
+  agents: Record<string, AgentRegistryEntry>; // keyed by name or alias
+}
+
+/**
+ * Marketplace agent metadata - from index.json
+ */
+export interface MarketplaceAgent {
+  name: string;
+  description: string;
+  category: string;
+  tags: string[];
+  version: string;
+  path: string; // relative path in marketplace repo
+  "tool-count": number;
+  "has-destructive-tools": boolean;
+}
+
+/**
+ * Marketplace category
+ */
+export interface MarketplaceCategory {
+  id: string;
+  name: string;
+}
+
+/**
+ * Marketplace index.json format
+ */
+export interface MarketplaceIndex {
+  version: string;
+  agents: MarketplaceAgent[];
+  categories: MarketplaceCategory[];
+}

--- a/source/agents/types.ts
+++ b/source/agents/types.ts
@@ -36,6 +36,7 @@ export interface AgentManifest {
   model?: string; // optional model override
   effort?: EffortLevel; // optional effort override
   tags?: string[];
+  prerequisites?: string[];
   enabled?: boolean; // defaults to true
 
   // Tool permissions

--- a/source/agents/types.ts
+++ b/source/agents/types.ts
@@ -39,6 +39,14 @@ export interface AgentManifest {
   prerequisites?: string[];
   enabled?: boolean; // defaults to true
 
+  // Tool schemas declared in the manifest (avoids importing tool modules for schema)
+  tools?: Array<{
+    name: string;
+    description: string;
+    destructive?: boolean;
+    inputSchema: Record<string, unknown>;
+  }>;
+
   // Tool permissions
   "tool-permissions"?: Record<string, ToolPermission>;
 

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useMemo, useEffect } from "react";
+import React, { useState, useRef, useCallback, useMemo, useEffect, type MutableRefObject } from "react";
 import { Box, Text, Static, useInput, useApp } from "ink";
 import MessageList from "./components/message-list.js";
 import type { DisplayMessage } from "./components/message-list.js";
@@ -17,6 +17,7 @@ import { createProvider } from "./providers/registry.js";
 import type { ContentBlock } from "./providers/types.js";
 import { useAgent } from "./hooks/use-agent.js";
 import { CommandRegistry } from "./commands/registry.js";
+import { AgentsTUI } from "./components/agents-tui.js";
 import { saveSession } from "./config/history.js";
 import {
   type Attachment,
@@ -69,6 +70,8 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   const [showCompactionSummary, setShowCompactionSummary] = useState(false);
   const [runningSkillName, setRunningSkillName] = useState<string | null>(null);
   const [pickerActive, setPickerActive] = useState(false);
+  const [agentsTUIActive, setAgentsTUIActive] = useState(false);
+  const agentsTUIResolveRef = useRef<(() => void) | null>(null);
   const { exit } = useApp();
   const commandRegistryRef = useRef(new CommandRegistry());
   const keyResolverRef = useRef(new KeybindingResolver(keybindings, [
@@ -161,7 +164,9 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
     insertLabelRef.current?.(text);
   }, []);
 
-  useClipboardImageDetector(handleClipboardImage, !isLoading, handleLargePaste, handleShortPaste);
+  // Disable paste capture while any picker (wizard, model selector, etc.) is active
+  // so paste events don't silently land in the hidden InputPrompt buffer
+  useClipboardImageDetector(handleClipboardImage, !isLoading && !pickerActive, handleLargePaste, handleShortPaste);
 
   /** Run a side query independently so it never delays the active agent turn. */
   const runPsQuery = useCallback(async (query: { text: string; blocks: ContentBlock[] }) => {
@@ -409,6 +414,10 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
           addTokenUsage,
           setRunningSkill: setRunningSkillName,
           setPickerActive,
+          showAgentsTUI: (onDone: () => void) => {
+            agentsTUIResolveRef.current = onDone;
+            setAgentsTUIActive(true);
+          },
         });
 
         setRunningSkillName(null);
@@ -585,6 +594,21 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
 
       {showToolDetail && toolMessages.length > 0 && (
         <ToolDetailPanel tools={toolMessages} closeKey={formatKeybinding(keybindings, "toggleToolDetail")} />
+      )}
+
+      {agentsTUIActive && (
+        <AgentsTUI
+          onExit={() => {
+            setAgentsTUIActive(false);
+            setPickerActive(false);
+            setInput(""); // clear any paste that leaked into InputPrompt while wizard was active
+            const resolve = agentsTUIResolveRef.current;
+            agentsTUIResolveRef.current = null;
+            resolve?.();
+          }}
+          provider={activeProvider}
+          config={config}
+        />
       )}
 
       {!pendingConfirmation && (

--- a/source/cli/agents-cli.ts
+++ b/source/cli/agents-cli.ts
@@ -1,0 +1,223 @@
+/**
+ * CLI handlers for agent management commands
+ */
+
+import { loadAgents } from "../agents/loader.js";
+import { installAgent, uninstallAgent } from "../agents/installer.js";
+import { setAgentEnabled, loadRegistry } from "../agents/agent-registry.js";
+
+/**
+ * List installed agents
+ */
+async function listAgents(): Promise<number> {
+  const agents = await loadAgents();
+
+  if (agents.length === 0) {
+    console.log("\nNo agents installed.\n");
+    return 0;
+  }
+
+  console.log("\nInstalled agents:\n");
+
+  // Group by origin
+  const bundled = agents.filter((a) => a.origin === "bundled");
+  const global = agents.filter((a) => a.origin === "global");
+  const project = agents.filter((a) => a.origin === "project");
+
+  if (bundled.length > 0) {
+    console.log("Bundled:");
+    for (const agent of bundled) {
+      const status = agent.manifest.enabled === false ? "[disabled]" : "[enabled]";
+      const name = agent.alias || agent.manifest.name;
+      console.log(`  • ${name} ${status}`);
+      console.log(`    ${agent.manifest.description}`);
+      console.log(`    Tools: ${agent.tools.length}`);
+    }
+    console.log();
+  }
+
+  if (global.length > 0) {
+    console.log("Global:");
+    for (const agent of global) {
+      const status = agent.manifest.enabled === false ? "[disabled]" : "[enabled]";
+      const name = agent.alias || agent.manifest.name;
+      console.log(`  • ${name} ${status}`);
+      console.log(`    ${agent.manifest.description}`);
+      console.log(`    Tools: ${agent.tools.length}`);
+    }
+    console.log();
+  }
+
+  if (project.length > 0) {
+    console.log("Project:");
+    for (const agent of project) {
+      const status = agent.manifest.enabled === false ? "[disabled]" : "[enabled]";
+      const name = agent.alias || agent.manifest.name;
+      console.log(`  • ${name} ${status}`);
+      console.log(`    ${agent.manifest.description}`);
+      console.log(`    Tools: ${agent.tools.length}`);
+    }
+    console.log();
+  }
+
+  return 0;
+}
+
+/**
+ * Install agent from URL or local path
+ */
+async function installAgentCommand(args: string[]): Promise<number> {
+  if (args.length === 0) {
+    console.error("\nError: No source URL or path provided.\n");
+    console.error("Usage: agav agents install <url|path> [--alias name] [--destination global|project]\n");
+    return 1;
+  }
+
+  const source = args[0]!;
+  let alias: string | undefined;
+  let destination: "global" | "project" = "global";
+
+  // Parse flags
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--alias" && args[i + 1]) {
+      alias = args[++i]!;
+    } else if (arg === "--destination" && args[i + 1]) {
+      const dest = args[++i]!;
+      if (dest !== "global" && dest !== "project") {
+        console.error("\nError: --destination must be 'global' or 'project'\n");
+        return 1;
+      }
+      destination = dest;
+    }
+  }
+
+  console.log(`\nInstalling agent from ${source}...\n`);
+
+  const result = await installAgent(source, { alias, destination });
+
+  if (!result.success) {
+    console.error(`Error: ${result.error}\n`);
+    return 1;
+  }
+
+  const agentName = alias || result.agent?.manifest.name || "agent";
+  console.log(`✓ Successfully installed agent: ${agentName}`);
+  console.log(`  Description: ${result.agent?.manifest.description}`);
+  console.log(`  Tools: ${result.agent?.tools.length}`);
+  console.log(`  Origin: ${destination}\n`);
+
+  return 0;
+}
+
+/**
+ * Uninstall agent
+ */
+async function removeAgentCommand(args: string[]): Promise<number> {
+  if (args.length === 0) {
+    console.error("\nError: No agent name provided.\n");
+    console.error("Usage: agav agents remove <name> [--destination global|project]\n");
+    return 1;
+  }
+
+  const name = args[0]!;
+  let destination: "global" | "project" = "global";
+
+  // Parse flags
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--destination" && args[i + 1]) {
+      const dest = args[++i]!;
+      if (dest !== "global" && dest !== "project") {
+        console.error("\nError: --destination must be 'global' or 'project'\n");
+        return 1;
+      }
+      destination = dest;
+    }
+  }
+
+  console.log(`\nRemoving agent: ${name}...\n`);
+
+  const result = await uninstallAgent(name, destination);
+
+  if (!result.success) {
+    console.error(`Error: ${result.error}\n`);
+    return 1;
+  }
+
+  console.log(`✓ Successfully removed agent: ${name}\n`);
+  return 0;
+}
+
+/**
+ * Enable agent
+ */
+async function enableAgentCommand(args: string[]): Promise<number> {
+  if (args.length === 0) {
+    console.error("\nError: No agent name provided.\n");
+    console.error("Usage: agav agents enable <name>\n");
+    return 1;
+  }
+
+  const name = args[0]!;
+
+  console.log(`\nEnabling agent: ${name}...\n`);
+
+  try {
+    await setAgentEnabled(name, true);
+    console.log(`✓ Agent '${name}' enabled\n`);
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+/**
+ * Disable agent
+ */
+async function disableAgentCommand(args: string[]): Promise<number> {
+  if (args.length === 0) {
+    console.error("\nError: No agent name provided.\n");
+    console.error("Usage: agav agents disable <name>\n");
+    return 1;
+  }
+
+  const name = args[0]!;
+
+  console.log(`\nDisabling agent: ${name}...\n`);
+
+  try {
+    await setAgentEnabled(name, false);
+    console.log(`✓ Agent '${name}' disabled\n`);
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+/**
+ * Main entry point for agent CLI commands
+ */
+export async function runAgentsCommand(command: string | undefined, args: string[]): Promise<number> {
+  if (!command || command === "list") {
+    return await listAgents();
+  }
+
+  switch (command) {
+    case "install":
+      return await installAgentCommand(args);
+    case "remove":
+    case "uninstall":
+      return await removeAgentCommand(args);
+    case "enable":
+      return await enableAgentCommand(args);
+    case "disable":
+      return await disableAgentCommand(args);
+    default:
+      console.error(`\nError: Unknown command '${command}'\n`);
+      console.error("Available commands: list, install, remove, enable, disable\n");
+      return 1;
+  }
+}

--- a/source/cli/agents-cli.ts
+++ b/source/cli/agents-cli.ts
@@ -105,7 +105,11 @@ async function installAgentCommand(args: string[]): Promise<number> {
   console.log(`✓ Successfully installed agent: ${agentName}`);
   console.log(`  Description: ${result.agent?.manifest.description}`);
   console.log(`  Tools: ${result.agent?.tools.length}`);
-  console.log(`  Origin: ${destination}\n`);
+  console.log(`  Origin: ${destination}`);
+  if (result.warning) {
+    console.error(`  ⚠ ${result.warning}`);
+  }
+  console.log();
 
   return 0;
 }

--- a/source/commands/agents.ts
+++ b/source/commands/agents.ts
@@ -1,0 +1,16 @@
+import type { SlashCommand, CommandResult, CommandContext } from "./types.js";
+
+export const agentsCommand: SlashCommand = {
+  name: "agents",
+  description: "Manage service agents (list, install, create)",
+  usage:
+    "Usage: /agents\n\nOpens an interactive TUI for managing agents:\n  Tab 1: List installed agents\n  Tab 2: Browse marketplace\n\nKeyboard shortcuts:\n  1/2: Switch tabs\n  ↑/↓: Navigate\n  ENTER: Toggle enable/disable\n  i: Inspect agent details\n  d: Remove agent (global/project agents only)\n  r: Refresh marketplace\n  b/ESC: Back (in inspect view)\n  ESC: Exit",
+  async execute(args: string, context: CommandContext): Promise<CommandResult> {
+    context.setPickerActive(true);
+    return new Promise<CommandResult>((resolve) => {
+      context.showAgentsTUI(() => {
+        resolve({ type: "none" });
+      });
+    });
+  },
+};

--- a/source/commands/help.ts
+++ b/source/commands/help.ts
@@ -3,6 +3,7 @@ import type { SlashCommand, CommandResult } from "./types.js";
 const CATEGORIES: Record<string, string[]> = {
   "Chat": ["clear", "new", "model", "effort", "fast", "deep", "compact", "ps", "export"],
   "Sessions": ["history", "search", "branch", "name"],
+  "Agents": ["agents"],
   "Skills": ["skills"],
   "Workflow": ["plan", "steer", "loop", "schedule", "watch"],
   "Memory": ["memory", "remember", "forget"],

--- a/source/commands/registry.ts
+++ b/source/commands/registry.ts
@@ -22,6 +22,7 @@ import { skillsCommand } from "../skills/commands.js"
 import { steerCommand } from "./steer.js"
 import { changelogCommand } from "./changelog.js"
 import { contextCommand } from "./context.js"
+import { agentsCommand } from "./agents.js"
 
 /** Store slash commands and dispatch raw user input to the matching handler. */
 export class CommandRegistry {
@@ -57,6 +58,7 @@ export class CommandRegistry {
     this.register(steerCommand)
     this.register(changelogCommand)
     this.register(contextCommand)
+    this.register(agentsCommand)
   }
 
   /** Add a command to the registry by name. */

--- a/source/commands/types.ts
+++ b/source/commands/types.ts
@@ -45,6 +45,7 @@ export interface CommandContext {
   addTokenUsage: (usage: TokenUsage) => void
   setRunningSkill: (name: string | null) => void
   setPickerActive: (active: boolean) => void
+  showAgentsTUI: (onDone: () => void) => void
 }
 
 /** Represents the result of executing a slash command. */

--- a/source/components/agents-inspect.tsx
+++ b/source/components/agents-inspect.tsx
@@ -294,7 +294,7 @@ export function ConfigEditView({
   );
 }
 
-export function MarketplaceInspectView({ marketplaceAgent, marketplaceUrl, isInstalled, installedOrigin }: { marketplaceAgent: MarketplaceAgent; marketplaceUrl: string; isInstalled?: boolean; installedOrigin?: string }) {
+export function MarketplaceInspectView({ marketplaceAgent, marketplaceUrl, isInstalled, installedOrigin, hasUpdate }: { marketplaceAgent: MarketplaceAgent; marketplaceUrl: string; isInstalled?: boolean; installedOrigin?: string; hasUpdate?: boolean }) {
   const [loadedAgent, setLoadedAgent] = useState<AgentDefinition | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -350,7 +350,8 @@ export function MarketplaceInspectView({ marketplaceAgent, marketplaceUrl, isIns
       <Box marginBottom={1}>
         <Text bold color="cyan">{marketplaceAgent.name}</Text>
         <Text dimColor> v{marketplaceAgent.version}</Text>
-        {isInstalled && <Text color="green"> ✓ installed ({installedOrigin ?? "global"})</Text>}
+        {isInstalled && !hasUpdate && <Text color="green"> ✓ installed ({installedOrigin ?? "global"})</Text>}
+        {hasUpdate && <Text color="yellow"> ↑ update available</Text>}
         {marketplaceAgent["has-destructive-tools"] && <Text color="yellow"> ⚠ Has tools that modify data</Text>}
       </Box>
       <Box flexDirection="column" marginBottom={1}>

--- a/source/components/agents-inspect.tsx
+++ b/source/components/agents-inspect.tsx
@@ -1,0 +1,362 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text } from "ink";
+import type { AgentDefinition, MarketplaceAgent } from "../agents/types.js";
+import type { AgentReadiness, ConfigItem } from "./agents-types.js";
+import { resolveConfigPath, parseFileUrl } from "./agents-types.js";
+
+export function InspectView({ agent, statusLabel, readiness, runtimeConfig, sessionModel, sessionEffort, sessionProvider }: {
+  agent: AgentDefinition;
+  statusLabel?: string;
+  readiness?: AgentReadiness;
+  runtimeConfig?: Record<string, string>;
+  sessionModel?: string;
+  sessionEffort?: string;
+  sessionProvider?: string;
+}) {
+  const name = agent.alias || agent.manifest.name;
+  const manifest = agent.manifest;
+  const hasRequiredConfig = (manifest["required-config"] ?? []).length > 0;
+  const isMarketplace = statusLabel === "marketplace";
+
+  const agentModelOverride  = runtimeConfig?.["model"];
+  const agentEffortOverride = runtimeConfig?.["effort"];
+
+  const hasModelOverride  = Boolean(agentModelOverride);
+  const hasEffortOverride = Boolean(agentEffortOverride);
+
+  const providerMatchesModel = (model: string, provider: string): boolean => {
+    if (provider === "anthropic" && model.startsWith("claude-")) return true;
+    if (provider === "openai" && (model.startsWith("gpt-") || model.startsWith("o1-") || model.startsWith("o3-") || model.startsWith("o4-"))) return true;
+    if (provider === "gemini" && model.startsWith("gemini-")) return true;
+    if (provider === "ollama") return true;
+    return false;
+  };
+
+  const showSessionModel  = sessionModel && sessionProvider && providerMatchesModel(sessionModel, sessionProvider);
+  const showSessionEffort = Boolean(sessionEffort);
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color="cyan">{name}</Text>
+        <Text> </Text>
+        {statusLabel
+          ? <Text dimColor>[{statusLabel}]</Text>
+          : <Text color={manifest.enabled === false ? "red" : "green"}>
+              {manifest.enabled === false ? "[disabled]" : "[enabled]"}
+            </Text>
+        }
+        {readiness !== undefined && (
+          readiness.ready
+            ? <Text color="green">  Ready ✓</Text>
+            : <Text color="yellow">  ⚠ Needs config</Text>
+        )}
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text dimColor>Description:</Text>
+        <Text>{manifest.description}</Text>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text dimColor>Origin: {agent.origin}</Text>
+        <Text dimColor>Version: {manifest.version}</Text>
+        <Text dimColor>Type: {manifest.type || "native"}</Text>
+        <Box>
+          <Text dimColor>Model:  </Text>
+          {hasModelOverride
+            ? <Text color="green">{agentModelOverride} <Text dimColor>(agent override)</Text></Text>
+            : showSessionModel
+            ? <Text dimColor>{sessionModel} (inherited)</Text>
+            : <Text dimColor>inherited from session</Text>}
+        </Box>
+        <Box>
+          <Text dimColor>Effort: </Text>
+          {hasEffortOverride
+            ? <Text color="green">{agentEffortOverride} <Text dimColor>(agent override)</Text></Text>
+            : showSessionEffort
+            ? <Text dimColor>{sessionEffort} (inherited)</Text>
+            : <Text dimColor>inherited from session</Text>}
+        </Box>
+      </Box>
+
+      {manifest.tags && manifest.tags.length > 0 && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text dimColor>Tags: {manifest.tags.join(", ")}</Text>
+        </Box>
+      )}
+
+      {hasRequiredConfig && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Box>
+            <Text dimColor>Required Config  </Text>
+            <Text dimColor>({resolveConfigPath(agent)})</Text>
+          </Box>
+          {(manifest["required-config"] ?? []).map((cfg) => {
+            const isMissing = readiness?.missing.includes(cfg);
+            const checked = readiness !== undefined;
+            return (
+              <Box key={cfg}>
+                <Text dimColor>  • {cfg}  </Text>
+                {checked
+                  ? isMissing
+                    ? <Text color="red">✗ not set</Text>
+                    : <Text color="green">✓ configured</Text>
+                  : <Text dimColor>checking...</Text>
+                }
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold>Tools ({agent.tools.length}):</Text>
+        {agent.tools.map((tool) => (
+          <Box key={tool.schema.name} flexDirection="column" marginLeft={2} marginTop={1}>
+            <Box>
+              <Text color="cyan">{tool.schema.name}</Text>
+              <Text> </Text>
+              {tool.schema.destructive === true && <Text color="red">[modifies]</Text>}
+              {tool.schema.destructive === false && <Text color="green">[safe]</Text>}
+            </Box>
+            <Text dimColor>{tool.schema.description}</Text>
+          </Box>
+        ))}
+      </Box>
+
+      {!isMarketplace && (
+        <Box marginTop={1}>
+          <Text dimColor>e: Edit config &amp; settings</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function ConfigEditView({
+  agent,
+  items,
+  editIndex,
+  editKey,
+  editBuffer,
+  isEditing,
+  savedKeys,
+  error,
+  readiness,
+  runtimeConfig,
+  pickerActive,
+  pickerItems,
+  pickerIndex,
+}: {
+  agent: AgentDefinition;
+  items: ConfigItem[];
+  editIndex: number;
+  editKey: string;
+  editBuffer: string;
+  isEditing: boolean;
+  savedKeys: Record<string, string>;
+  error: string | null;
+  readiness?: AgentReadiness;
+  runtimeConfig: Record<string, string>;
+  pickerActive?: boolean;
+  pickerItems?: string[];
+  pickerIndex?: number;
+}) {
+  const configPath = resolveConfigPath(agent);
+
+  const renderPicker = () => {
+    if (!pickerActive || !pickerItems || pickerItems.length === 0) return null;
+    const label = editKey === "model" ? "Model" : "Effort";
+    const curIdx = pickerIndex ?? 0;
+    const WINDOW = 6;
+
+    const getProvider = (id: string): string => {
+      if (id.startsWith("claude-") || id.startsWith("us.anthropic")) return "Anthropic";
+      if (id.startsWith("gpt-") || id.startsWith("o1-") || id.startsWith("o3-") || id.startsWith("o4-") || id.startsWith("chatgpt")) return "OpenAI";
+      if (id.startsWith("gemini-")) return "Google";
+      return "";
+    };
+
+    const total = pickerItems.length;
+    const half = Math.floor(WINDOW / 2);
+    const startIdx = Math.max(0, Math.min(curIdx - half, total - WINDOW));
+    const endIdx = Math.min(total, startIdx + WINDOW);
+    const visibleItems = pickerItems.slice(startIdx, endIdx);
+    const aboveCount = startIdx;
+    const belowCount = total - endIdx;
+    let lastProvider = "";
+
+    return (
+      <Box flexDirection="column" marginTop={1}>
+        <Text dimColor bold>Select {label}: ({curIdx + 1}/{total})</Text>
+        {aboveCount > 0 && <Text dimColor>  ↑ {aboveCount} more</Text>}
+        {visibleItems.map((item, visIdx) => {
+          const absIdx = startIdx + visIdx;
+          const isSelected = absIdx === curIdx;
+          const isInherit = absIdx === 0;
+          let header: React.ReactNode = null;
+          if (editKey === "model" && !isInherit) {
+            const p = getProvider(item);
+            if (p && p !== lastProvider) { lastProvider = p; header = <Text dimColor>  {p}:</Text>; }
+          }
+          return (
+            <Box key={`${item}-${absIdx}`} flexDirection="column">
+              {header}
+              <Box>
+                <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+                  {isSelected ? "  → " : "    "}
+                </Text>
+                <Text color={isSelected ? "cyan" : undefined} dimColor={isInherit}>{item}</Text>
+              </Box>
+            </Box>
+          );
+        })}
+        {belowCount > 0 && <Text dimColor>  ↓ {belowCount} more</Text>}
+        {error && <Text color="red">{error}</Text>}
+      </Box>
+    );
+  };
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color="cyan">{agent.alias || agent.manifest.name}</Text>
+        <Text dimColor> — config &amp; settings</Text>
+      </Box>
+
+      <Box marginBottom={1}>
+        <Text dimColor>Config file: {configPath}</Text>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        {items.map((item, idx) => {
+          const isSelected = idx === editIndex;
+          const isEditingThis = isEditing && editKey === item.key;
+
+          let valueNode: React.ReactNode;
+          if (isEditingThis) {
+            const display = item.secret ? "•".repeat(editBuffer.length) : editBuffer;
+            valueNode = (
+              <Box>
+                <Text color="cyan">{display}</Text>
+                <Text color="cyan">█</Text>
+              </Box>
+            );
+          } else if (item.key === "model" || item.key === "effort") {
+            const val = savedKeys[item.key] !== undefined ? savedKeys[item.key] : runtimeConfig[item.key];
+            valueNode = val
+              ? <Text color="green">{val} <Text dimColor>(override)</Text></Text>
+              : <Text dimColor>inherited from session</Text>;
+          } else {
+            if (savedKeys[item.key] !== undefined) {
+              valueNode = <Text color="green">✓ just saved</Text>;
+            } else if (readiness?.missing.includes(item.key)) {
+              valueNode = <Text color="red">✗ not set</Text>;
+            } else {
+              valueNode = <Text color="green">✓ configured</Text>;
+            }
+          }
+
+          return (
+            <Box key={item.key} flexDirection="column">
+              <Box>
+                <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+                  {isSelected ? "→ " : "  "}
+                  {item.label}{"  "}
+                </Text>
+                {valueNode}
+              </Box>
+              {isSelected && (item.key === "model" || item.key === "effort") && renderPicker()}
+            </Box>
+          );
+        })}
+      </Box>
+
+      {error && !pickerActive && (
+        <Box marginBottom={1}>
+          <Text color="red">{error}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function MarketplaceInspectView({ marketplaceAgent, marketplaceUrl, isInstalled, installedOrigin }: { marketplaceAgent: MarketplaceAgent; marketplaceUrl: string; isInstalled?: boolean; installedOrigin?: string }) {
+  const [loadedAgent, setLoadedAgent] = useState<AgentDefinition | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { loadAgent } = await import("../agents/loader.js");
+        let agentPath: string;
+        if (marketplaceUrl.startsWith("file://")) {
+          const basePath = parseFileUrl(marketplaceUrl);
+          agentPath = `${basePath}/${marketplaceAgent.path}`;
+        } else {
+          setLoadError("placeholder");
+          return;
+        }
+        const agent = await loadAgent(agentPath, "global");
+        if (agent) {
+          setLoadedAgent(agent);
+        } else {
+          setLoadError("placeholder");
+        }
+      } catch {
+        setLoadError("placeholder");
+      }
+    };
+    load();
+  }, [marketplaceAgent.path, marketplaceUrl]);
+
+  if (!loadedAgent && !loadError) {
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Text bold color="cyan">{marketplaceAgent.name}</Text>
+          <Text dimColor> v{marketplaceAgent.version}</Text>
+        </Box>
+        <Text dimColor>Loading agent details...</Text>
+        <Box marginTop={1}><Text dimColor>b/ESC: Back | ENTER: Install</Text></Box>
+      </Box>
+    );
+  }
+
+  if (loadedAgent) {
+    return (
+      <Box flexDirection="column">
+        <InspectView agent={loadedAgent} statusLabel="marketplace" />
+        <Box marginTop={1}><Text dimColor>b/ESC: Back | ENTER: Install</Text></Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color="cyan">{marketplaceAgent.name}</Text>
+        <Text dimColor> v{marketplaceAgent.version}</Text>
+        {isInstalled && <Text color="green"> ✓ installed ({installedOrigin ?? "global"})</Text>}
+        {marketplaceAgent["has-destructive-tools"] && <Text color="yellow"> ⚠ Has tools that modify data</Text>}
+      </Box>
+      <Box flexDirection="column" marginBottom={1}>
+        <Text dimColor>Description:</Text>
+        <Text>{marketplaceAgent.description}</Text>
+      </Box>
+      <Box flexDirection="column" marginBottom={1}>
+        <Text dimColor>Category: {marketplaceAgent.category}</Text>
+        <Text dimColor>Tools: {marketplaceAgent["tool-count"]}</Text>
+      </Box>
+      {marketplaceAgent.tags.length > 0 && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text dimColor>Tags: {marketplaceAgent.tags.join(", ")}</Text>
+        </Box>
+      )}
+      <Box marginTop={1}>
+        <Text dimColor>b/ESC: Back{isInstalled ? "" : " | ENTER: Install"}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/source/components/agents-inspect.tsx
+++ b/source/components/agents-inspect.tsx
@@ -86,6 +86,18 @@ export function InspectView({ agent, statusLabel, readiness, runtimeConfig, sess
         </Box>
       )}
 
+      {manifest.prerequisites && manifest.prerequisites.length > 0 && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text dimColor>Prerequisites:</Text>
+          {manifest.prerequisites.map((prereq) => (
+            <Box key={prereq}>
+              <Text dimColor>  - </Text>
+              <Text color="yellow">{prereq}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
       {hasRequiredConfig && (
         <Box flexDirection="column" marginBottom={1}>
           <Box>

--- a/source/components/agents-list.tsx
+++ b/source/components/agents-list.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { AgentDefinition } from "../agents/types.js";
+import type { AgentReadiness, ReadinessMap } from "./agents-types.js";
+import { SearchBar } from "./agents-search.js";
+
+export function ListTab({
+  agents,
+  allAgents,
+  selectedIndex,
+  searchQuery,
+  searching,
+  confirmingRemove,
+  removeStatus,
+  readinessMap,
+}: {
+  agents: AgentDefinition[];
+  allAgents: AgentDefinition[];
+  selectedIndex: number;
+  searchQuery: string;
+  searching: boolean;
+  confirmingRemove: boolean;
+  removeStatus: string | null;
+  readinessMap: ReadinessMap;
+}) {
+  const selectedAgent = agents[selectedIndex];
+
+  return (
+    <Box flexDirection="column">
+      {!searchQuery && !searching && (() => {
+        const b = allAgents.filter(a => a.origin === "bundled").length;
+        const g = allAgents.filter(a => a.origin === "global").length;
+        const p = allAgents.filter(a => a.origin === "project").length;
+        const parts = [
+          b > 0 ? `${b} bundled` : "",
+          g > 0 ? `${g} global` : "",
+          p > 0 ? `${p} project` : "",
+        ].filter(Boolean);
+        return <Box marginBottom={1}><Text dimColor>{parts.join(" · ")}</Text></Box>;
+      })()}
+      {(searchQuery || searching) && (
+        <SearchBar
+          query={searchQuery}
+          searching={searching}
+          resultCount={agents.length}
+          itemLabel={`agent (of ${allAgents.length})`}
+        />
+      )}
+
+      {removeStatus && (
+        <Box marginBottom={1}>
+          <Text color={removeStatus.startsWith("Removed") ? "green" : "red"}>{removeStatus}</Text>
+        </Box>
+      )}
+
+      {confirmingRemove && selectedAgent && (
+        <Box marginBottom={1} flexDirection="column">
+          <Text color="yellow">
+            Remove agent "{selectedAgent.alias || selectedAgent.manifest.name}"? This deletes it from disk.
+          </Text>
+          <Text dimColor>[Y]es, remove | [N]o, cancel</Text>
+        </Box>
+      )}
+
+      {agents.length === 0 && searchQuery && (
+        <Text dimColor>No agents match "{searchQuery}"</Text>
+      )}
+      {agents.length === 0 && !searchQuery && (
+        <Text>No agents installed.</Text>
+      )}
+
+      {searchQuery ? (
+        <Box flexDirection="column">
+          {agents.map((agent, idx) => (
+            <AgentListItem
+              key={agent.manifest.name}
+              agent={agent}
+              isSelected={idx === selectedIndex}
+              readiness={readinessMap[agent.alias || agent.manifest.name]}
+            />
+          ))}
+        </Box>
+      ) : (
+        <GroupedAgentList agents={agents} selectedIndex={selectedIndex} readinessMap={readinessMap} />
+      )}
+    </Box>
+  );
+}
+
+function GroupedAgentList({ agents, selectedIndex, readinessMap }: { agents: AgentDefinition[]; selectedIndex: number; readinessMap: ReadinessMap }) {
+  const bundled = agents.filter((a) => a.origin === "bundled");
+  const global = agents.filter((a) => a.origin === "global");
+  const project = agents.filter((a) => a.origin === "project");
+
+  let currentIndex = 0;
+
+  return (
+    <Box flexDirection="column">
+      {bundled.length > 0 && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text bold color="yellow">Bundled:</Text>
+          {bundled.map((agent) => {
+            const isSelected = currentIndex === selectedIndex;
+            currentIndex++;
+            return <AgentListItem key={agent.manifest.name} agent={agent} isSelected={isSelected} readiness={readinessMap[agent.alias || agent.manifest.name]} />;
+          })}
+        </Box>
+      )}
+      {global.length > 0 && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text bold color="green">Global:</Text>
+          {global.map((agent) => {
+            const isSelected = currentIndex === selectedIndex;
+            currentIndex++;
+            return <AgentListItem key={agent.manifest.name} agent={agent} isSelected={isSelected} readiness={readinessMap[agent.alias || agent.manifest.name]} />;
+          })}
+        </Box>
+      )}
+      {project.length > 0 && (
+        <Box flexDirection="column">
+          <Text bold color="blue">Project:</Text>
+          {project.map((agent) => {
+            const isSelected = currentIndex === selectedIndex;
+            currentIndex++;
+            return <AgentListItem key={agent.manifest.name} agent={agent} isSelected={isSelected} readiness={readinessMap[agent.alias || agent.manifest.name]} />;
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function AgentListItem({ agent, isSelected, readiness }: { agent: AgentDefinition; isSelected: boolean; readiness?: AgentReadiness }) {
+  const name = agent.alias || agent.manifest.name;
+  const status = agent.manifest.enabled === false ? "[disabled]" : "[enabled]";
+  const statusColor = agent.manifest.enabled === false ? "red" : "green";
+
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      <Box>
+        <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+          {isSelected ? "→ " : "  "}
+          {name}{" "}
+        </Text>
+        <Text color={statusColor}>{status}</Text>
+        {readiness !== undefined && (
+          readiness.ready
+            ? <Text color="green"> Ready ✓</Text>
+            : <Text color="yellow"> ⚠ Needs config</Text>
+        )}
+      </Box>
+      <Box marginLeft={2}>
+        <Text dimColor>{agent.manifest.description}</Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text dimColor>Tools: {agent.tools.length}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/source/components/agents-marketplace.tsx
+++ b/source/components/agents-marketplace.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import type { MarketplaceAgent } from "../agents/types.js";
 import { installAgent, uninstallAgent } from "../agents/installer.js";
-import { DEFAULT_MARKETPLACE_URL } from "../config/config.js";
+import { getDefaultMarketplaceUrl } from "../config/config.js";
 import { parseFileUrl } from "./agents-types.js";
 import { useSearch, filterMarketplaceAgents, SearchBar } from "./agents-search.js";
 import { MarketplaceInspectView } from "./agents-inspect.js";
@@ -40,7 +40,7 @@ export function MarketplaceTab({
       const { loadConfig } = await import("../config/config.js");
       const config = await loadConfig();
       const marketplaceUrl =
-        config.agentMarketplace || DEFAULT_MARKETPLACE_URL;
+        config.agentMarketplace || getDefaultMarketplaceUrl();
 
       setResolvedMarketplaceUrl(marketplaceUrl);
 
@@ -54,13 +54,16 @@ export function MarketplaceTab({
         data = JSON.parse(content);
       } else {
         const indexUrl = `${marketplaceUrl}/index.json`;
-        const response = await fetch(indexUrl);
+        const response = await fetch(indexUrl, { signal: AbortSignal.timeout(10_000) });
 
         if (!response.ok) {
           throw new Error(`Failed to fetch marketplace: ${response.statusText}`);
         }
 
         data = await response.json() as { agents?: MarketplaceAgent[] };
+        if (!data || !Array.isArray(data.agents)) {
+          throw new Error("Invalid marketplace index: missing agents array");
+        }
       }
 
       setMarketplaceAgents(data.agents || []);
@@ -77,7 +80,7 @@ export function MarketplaceTab({
     const { loadConfig } = await import("../config/config.js");
     const config = await loadConfig();
     const marketplaceUrl =
-      config.agentMarketplace || DEFAULT_MARKETPLACE_URL;
+      config.agentMarketplace || getDefaultMarketplaceUrl();
     let agentUrl: string;
     if (marketplaceUrl.startsWith("file://")) {
       const basePath = parseFileUrl(marketplaceUrl);
@@ -89,7 +92,7 @@ export function MarketplaceTab({
     if (result.success) {
       setInstallStatus(`✓ Installed ${agent.name} (${destination})`);
       await onReloadAgents();
-    } else if (result.error?.includes("already installed")) {
+    } else if (result.error?.startsWith("Agent '") && result.error?.includes("is already installed")) {
       setInstallStatus(null);
       setReinstallCandidate({ agent, destination });
     } else {

--- a/source/components/agents-marketplace.tsx
+++ b/source/components/agents-marketplace.tsx
@@ -1,0 +1,358 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+import type { MarketplaceAgent } from "../agents/types.js";
+import { installAgent, uninstallAgent } from "../agents/installer.js";
+import { DEFAULT_MARKETPLACE_URL } from "../config/config.js";
+import { parseFileUrl } from "./agents-types.js";
+import { useSearch, filterMarketplaceAgents, SearchBar } from "./agents-search.js";
+import { MarketplaceInspectView } from "./agents-inspect.js";
+
+export function MarketplaceTab({
+  onReloadAgents,
+  onExit,
+  installedAgents,
+}: {
+  onReloadAgents: () => Promise<void>;
+  onExit: () => void;
+  installedAgents: Map<string, string>;
+}) {
+  const [marketplaceAgents, setMarketplaceAgents] = useState<MarketplaceAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [installing, setInstalling] = useState(false);
+  const [installStatus, setInstallStatus] = useState<string | null>(null);
+  const [inspecting, setInspecting] = useState(false);
+  const [pendingInstallAgent, setPendingInstallAgent] = useState<MarketplaceAgent | null>(null);
+  const [reinstallCandidate, setReinstallCandidate] = useState<{ agent: MarketplaceAgent; destination: "global" | "project" } | null>(null);
+  const [resolvedMarketplaceUrl, setResolvedMarketplaceUrl] = useState("");
+  const { searchQuery, searching, handleSearchKey } = useSearch();
+
+  useEffect(() => {
+    loadMarketplace();
+  }, []);
+
+  const loadMarketplace = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { loadConfig } = await import("../config/config.js");
+      const config = await loadConfig();
+      const marketplaceUrl =
+        config.agentMarketplace || DEFAULT_MARKETPLACE_URL;
+
+      setResolvedMarketplaceUrl(marketplaceUrl);
+
+      let data: { agents?: MarketplaceAgent[] };
+
+      if (marketplaceUrl.startsWith("file://")) {
+        const { readFile } = await import("node:fs/promises");
+        const basePath = parseFileUrl(marketplaceUrl);
+        const indexPath = `${basePath}/index.json`;
+        const content = await readFile(indexPath, "utf-8");
+        data = JSON.parse(content);
+      } else {
+        const indexUrl = `${marketplaceUrl}/index.json`;
+        const response = await fetch(indexUrl);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch marketplace: ${response.statusText}`);
+        }
+
+        data = await response.json() as { agents?: MarketplaceAgent[] };
+      }
+
+      setMarketplaceAgents(data.agents || []);
+      setLoading(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  };
+
+  const doInstall = async (agent: MarketplaceAgent, destination: "global" | "project") => {
+    setInstalling(true);
+    setInstallStatus("Installing...");
+    const { loadConfig } = await import("../config/config.js");
+    const config = await loadConfig();
+    const marketplaceUrl =
+      config.agentMarketplace || DEFAULT_MARKETPLACE_URL;
+    let agentUrl: string;
+    if (marketplaceUrl.startsWith("file://")) {
+      const basePath = parseFileUrl(marketplaceUrl);
+      agentUrl = `${basePath}/${agent.path}`;
+    } else {
+      agentUrl = `${marketplaceUrl}/${agent.path}`;
+    }
+    const result = await installAgent(agentUrl, { destination });
+    if (result.success) {
+      setInstallStatus(`✓ Installed ${agent.name} (${destination})`);
+      await onReloadAgents();
+    } else if (result.error?.includes("already installed")) {
+      setInstallStatus(null);
+      setReinstallCandidate({ agent, destination });
+    } else {
+      setInstallStatus(`✗ Failed: ${result.error}`);
+    }
+    setInstalling(false);
+    setPendingInstallAgent(null);
+  };
+
+  const doReinstall = async () => {
+    if (!reinstallCandidate) return;
+    const { agent, destination } = reinstallCandidate;
+    setReinstallCandidate(null);
+    setInstalling(true);
+    setInstallStatus(`Reinstalling ${agent.name}...`);
+    try {
+      await uninstallAgent(agent.name, destination === "project" ? "project" : "global");
+    } catch {
+      // If uninstall fails, proceed anyway
+    }
+    await doInstall(agent, destination);
+  };
+
+  useInput(async (input, key) => {
+    const filteredAgents = filterMarketplaceAgents(marketplaceAgents, searchQuery);
+
+    if (reinstallCandidate) {
+      if (input === "y" || input === "Y") await doReinstall();
+      else if (key.escape || input === "n" || input === "N") { setReinstallCandidate(null); }
+      return;
+    }
+
+    if (pendingInstallAgent) {
+      const existingOrigin = installedAgents.get(pendingInstallAgent.name);
+      if (existingOrigin === "global") {
+        if (key.escape) { setPendingInstallAgent(null); setInstallStatus(null); }
+      } else if (existingOrigin === "project") {
+        if (input === "1") {
+          const name = pendingInstallAgent.name;
+          setPendingInstallAgent(null);
+          await uninstallAgent(name, "project").catch(() => {});
+          await doInstall({ ...pendingInstallAgent, name }, "global");
+        } else if (key.escape || input === "2") {
+          setPendingInstallAgent(null); setInstallStatus(null);
+        }
+      } else {
+        if (input === "1") await doInstall(pendingInstallAgent, "global");
+        else if (input === "2") await doInstall(pendingInstallAgent, "project");
+        else if (key.escape) { setPendingInstallAgent(null); setInstallStatus(null); }
+      }
+      return;
+    }
+
+    if (inspecting) {
+      if (key.escape || input === "b") {
+        setInspecting(false);
+      } else if (key.return) {
+        setInspecting(false);
+        const agent = filteredAgents[selectedIndex];
+        if (agent) {
+          const existingOrigin = installedAgents.get(agent.name);
+          if (existingOrigin === "global" || existingOrigin === "bundled") {
+            setInstallStatus(`${agent.name} is already installed globally. Use the List tab to manage it.`);
+          } else {
+            setPendingInstallAgent(agent);
+            setInstallStatus(null);
+          }
+        }
+      }
+      return;
+    }
+
+    if (handleSearchKey(input, key)) {
+      setSelectedIndex(0);
+      if (key.escape && !searchQuery) onExit();
+      return;
+    }
+
+    if (key.escape) {
+      onExit();
+      return;
+    }
+
+    if (installing) return;
+
+    const PAGE_SIZE = 3;
+    const currentPage = Math.floor(selectedIndex / PAGE_SIZE);
+    const totalPages = Math.ceil(filteredAgents.length / PAGE_SIZE);
+
+    if (key.upArrow && selectedIndex > 0) {
+      setSelectedIndex(selectedIndex - 1);
+      setInstallStatus(null);
+    } else if (key.downArrow && selectedIndex < filteredAgents.length - 1) {
+      setSelectedIndex(selectedIndex + 1);
+      setInstallStatus(null);
+    } else if (key.leftArrow && currentPage > 0) {
+      const prevPageStart = (currentPage - 1) * PAGE_SIZE;
+      const prevPageEnd = Math.min(prevPageStart + PAGE_SIZE, filteredAgents.length) - 1;
+      setSelectedIndex(prevPageEnd);
+      setInstallStatus(null);
+    } else if (key.rightArrow && currentPage < totalPages - 1) {
+      setSelectedIndex((currentPage + 1) * PAGE_SIZE);
+      setInstallStatus(null);
+    } else if (input === "i" && filteredAgents[selectedIndex]) {
+      setInspecting(true);
+      setInstallStatus(null);
+    } else if (key.return && filteredAgents[selectedIndex]) {
+      const target = filteredAgents[selectedIndex]!;
+      const existingOrigin = installedAgents.get(target.name);
+      if (existingOrigin === "global" || existingOrigin === "bundled") {
+        setInstallStatus(`${target.name} is already installed globally. Use the List tab to manage it.`);
+      } else {
+        setPendingInstallAgent(target);
+        setInstallStatus(null);
+      }
+    } else if (input === "r") {
+      await loadMarketplace();
+      setInstallStatus(null);
+    }
+  });
+
+  if (loading) {
+    return (
+      <Box flexDirection="column">
+        <Text>Loading marketplace...</Text>
+      </Box>
+    );
+  }
+
+  if (inspecting) {
+    const filteredForInspect = filterMarketplaceAgents(marketplaceAgents, searchQuery);
+    const agent = filteredForInspect[selectedIndex];
+    if (agent) {
+      return <MarketplaceInspectView marketplaceAgent={agent} marketplaceUrl={resolvedMarketplaceUrl} isInstalled={installedAgents.has(agent.name)} />;
+    }
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">Error loading marketplace: {error}</Text>
+        <Box marginTop={1}>
+          <Text dimColor>Press 'r' to retry</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Configure marketplace URL in ~/.agav/config.json:</Text>
+        </Box>
+        <Text dimColor>  "agentMarketplace": "https://your-repo-url"</Text>
+      </Box>
+    );
+  }
+
+  if (marketplaceAgents.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text>No agents found in marketplace.</Text>
+        <Box marginTop={1}>
+          <Text dimColor>Press 'r' to refresh</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  const filteredAgents = filterMarketplaceAgents(marketplaceAgents, searchQuery);
+  const PAGE_SIZE = 3;
+  const currentPage = Math.floor(selectedIndex / PAGE_SIZE);
+  const totalPages = Math.ceil(filteredAgents.length / PAGE_SIZE);
+  const pageAgents = filteredAgents.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE);
+
+  return (
+    <Box flexDirection="column">
+      <SearchBar
+        query={searchQuery}
+        searching={searching}
+        resultCount={filteredAgents.length}
+        itemLabel={`marketplace agent${searchQuery ? ` (of ${marketplaceAgents.length})` : ""}`}
+      />
+
+      {installStatus && (
+        <Box marginBottom={1}>
+          <Text color={installStatus.startsWith("✓") ? "green" : "red"}>{installStatus}</Text>
+        </Box>
+      )}
+
+      {reinstallCandidate && (
+        <Box flexDirection="column" marginBottom={1} borderStyle="single" padding={1}>
+          <Text bold color="yellow">{reinstallCandidate.agent.name} is already installed.</Text>
+          <Text>Reinstall / update to the latest version?</Text>
+          <Text>[Y]es — uninstall and reinstall | [N]o / ESC — cancel</Text>
+        </Box>
+      )}
+
+      {pendingInstallAgent && (() => {
+        const existingOrigin = installedAgents.get(pendingInstallAgent.name);
+        if (existingOrigin === "global") {
+          return (
+            <Box flexDirection="column" marginBottom={1} borderStyle="single" padding={1}>
+              <Text bold color="yellow">{pendingInstallAgent.name} is already installed globally.</Text>
+              <Text dimColor>Global installation is available in all projects — no action needed.</Text>
+              <Text dimColor>ESC: Cancel</Text>
+            </Box>
+          );
+        }
+        if (existingOrigin === "project") {
+          return (
+            <Box flexDirection="column" marginBottom={1} borderStyle="single" padding={1}>
+              <Text bold>{pendingInstallAgent.name} is installed in this project.</Text>
+              <Text>[1] Promote to Global — removes project copy, installs globally</Text>
+              <Text dimColor>[2] Project — already installed, no change</Text>
+              <Text dimColor>ESC: Cancel</Text>
+            </Box>
+          );
+        }
+        return (
+          <Box flexDirection="column" marginBottom={1} borderStyle="single" padding={1}>
+            <Text bold>Install {pendingInstallAgent.name}:</Text>
+            <Text>[1] Global (~/.agav/agents/) — available in all projects</Text>
+            <Text>[2] Project (.agav/agents/) — this project only</Text>
+            <Text dimColor>ESC: Cancel</Text>
+          </Box>
+        );
+      })()}
+
+      {totalPages > 1 && (
+        <Box marginBottom={1}>
+          <Text dimColor>{currentPage > 0 ? "← " : "  "}</Text>
+          <Text dimColor>Page {currentPage + 1} of {totalPages}</Text>
+          <Text dimColor>{currentPage < totalPages - 1 ? " →" : ""}</Text>
+        </Box>
+      )}
+
+      {pageAgents.map((agent) => {
+        const absIndex = filteredAgents.indexOf(agent);
+        const isSelected = absIndex === selectedIndex;
+        const installedOrigin = installedAgents.get(agent.name);
+        const isInstalled = installedOrigin !== undefined;
+        return (
+          <Box key={agent.name} flexDirection="column" marginBottom={1}>
+            <Box>
+              <Text color={isSelected ? "cyan" : undefined} bold={isSelected}>
+                {isSelected ? "→ " : "  "}
+                {agent.name}
+              </Text>
+              <Text dimColor> v{agent.version}</Text>
+              {isInstalled && <Text color="green"> ✓ {installedOrigin}</Text>}
+            </Box>
+            <Box marginLeft={2}>
+              <Text dimColor>{agent.description}</Text>
+            </Box>
+            <Box marginLeft={2}>
+              <Text dimColor>
+                Tools: {agent["tool-count"]} | Category: {agent.category}
+              </Text>
+              {agent["has-destructive-tools"] && <Text color="yellow"> ⚠ Has tools that modify data</Text>}
+            </Box>
+            {agent.tags.length > 0 && (
+              <Box marginLeft={2}>
+                <Text dimColor>Tags: {agent.tags.join(", ")}</Text>
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/source/components/agents-marketplace.tsx
+++ b/source/components/agents-marketplace.tsx
@@ -14,7 +14,7 @@ export function MarketplaceTab({
 }: {
   onReloadAgents: () => Promise<void>;
   onExit: () => void;
-  installedAgents: Map<string, string>;
+  installedAgents: Map<string, { origin: string; version: string }>;
 }) {
   const [marketplaceAgents, setMarketplaceAgents] = useState<MarketplaceAgent[]>([]);
   const [loading, setLoading] = useState(true);
@@ -90,7 +90,10 @@ export function MarketplaceTab({
     }
     const result = await installAgent(agentUrl, { destination });
     if (result.success) {
-      setInstallStatus(`✓ Installed ${agent.name} (${destination})`);
+      const msg = result.warning
+        ? `✓ Installed ${agent.name} (${destination}) — ⚠ ${result.warning}`
+        : `✓ Installed ${agent.name} (${destination})`;
+      setInstallStatus(msg);
       await onReloadAgents();
     } else if (result.error?.startsWith("Agent '") && result.error?.includes("is already installed")) {
       setInstallStatus(null);
@@ -116,6 +119,30 @@ export function MarketplaceTab({
     await doInstall(agent, destination);
   };
 
+  const doUpdate = async (agent: MarketplaceAgent) => {
+    const installed = installedAgents.get(agent.name);
+    if (!installed) return;
+    setInstalling(true);
+
+    // Update in all installed locations (global and/or project)
+    const locations: Array<"global" | "project"> = [];
+    if (installed.origin === "global" || installed.origin === "bundled") {
+      locations.push("global");
+    } else if (installed.origin === "project") {
+      locations.push("project");
+    }
+
+    setInstallStatus(`Updating ${agent.name} (v${installed.version} → v${agent.version})...`);
+    for (const loc of locations) {
+      try {
+        await uninstallAgent(agent.name, loc);
+      } catch {
+        // Continue even if uninstall fails
+      }
+      await doInstall(agent, loc);
+    }
+  };
+
   useInput(async (input, key) => {
     const filteredAgents = filterMarketplaceAgents(marketplaceAgents, searchQuery);
 
@@ -126,7 +153,8 @@ export function MarketplaceTab({
     }
 
     if (pendingInstallAgent) {
-      const existingOrigin = installedAgents.get(pendingInstallAgent.name);
+      const existingEntry = installedAgents.get(pendingInstallAgent.name);
+      const existingOrigin = existingEntry?.origin;
       if (existingOrigin === "global") {
         if (key.escape) { setPendingInstallAgent(null); setInstallStatus(null); }
       } else if (existingOrigin === "project") {
@@ -153,7 +181,8 @@ export function MarketplaceTab({
         setInspecting(false);
         const agent = filteredAgents[selectedIndex];
         if (agent) {
-          const existingOrigin = installedAgents.get(agent.name);
+          const existingEntry = installedAgents.get(agent.name);
+          const existingOrigin = existingEntry?.origin;
           if (existingOrigin === "global" || existingOrigin === "bundled") {
             setInstallStatus(`${agent.name} is already installed globally. Use the List tab to manage it.`);
           } else {
@@ -201,12 +230,23 @@ export function MarketplaceTab({
       setInstallStatus(null);
     } else if (key.return && filteredAgents[selectedIndex]) {
       const target = filteredAgents[selectedIndex]!;
-      const existingOrigin = installedAgents.get(target.name);
+      const existingEntry = installedAgents.get(target.name);
+      const existingOrigin = existingEntry?.origin;
       if (existingOrigin === "global" || existingOrigin === "bundled") {
         setInstallStatus(`${target.name} is already installed globally. Use the List tab to manage it.`);
       } else {
         setPendingInstallAgent(target);
         setInstallStatus(null);
+      }
+    } else if (input === "u" && filteredAgents[selectedIndex]) {
+      const target = filteredAgents[selectedIndex]!;
+      const entry = installedAgents.get(target.name);
+      if (entry && entry.version !== target.version) {
+        await doUpdate(target);
+      } else if (entry) {
+        setInstallStatus(`${target.name} is already up to date (v${target.version}).`);
+      } else {
+        setInstallStatus(`${target.name} is not installed. Press ENTER to install.`);
       }
     } else if (input === "r") {
       await loadMarketplace();
@@ -226,7 +266,7 @@ export function MarketplaceTab({
     const filteredForInspect = filterMarketplaceAgents(marketplaceAgents, searchQuery);
     const agent = filteredForInspect[selectedIndex];
     if (agent) {
-      return <MarketplaceInspectView marketplaceAgent={agent} marketplaceUrl={resolvedMarketplaceUrl} isInstalled={installedAgents.has(agent.name)} />;
+      return <MarketplaceInspectView marketplaceAgent={agent} marketplaceUrl={resolvedMarketplaceUrl} isInstalled={installedAgents.has(agent.name)} hasUpdate={installedAgents.has(agent.name) && installedAgents.get(agent.name)!.version !== agent.version} />;
     }
   }
 
@@ -286,7 +326,8 @@ export function MarketplaceTab({
       )}
 
       {pendingInstallAgent && (() => {
-        const existingOrigin = installedAgents.get(pendingInstallAgent.name);
+        const existingEntry = installedAgents.get(pendingInstallAgent.name);
+        const existingOrigin = existingEntry?.origin;
         if (existingOrigin === "global") {
           return (
             <Box flexDirection="column" marginBottom={1} borderStyle="single" padding={1}>
@@ -327,8 +368,9 @@ export function MarketplaceTab({
       {pageAgents.map((agent) => {
         const absIndex = filteredAgents.indexOf(agent);
         const isSelected = absIndex === selectedIndex;
-        const installedOrigin = installedAgents.get(agent.name);
-        const isInstalled = installedOrigin !== undefined;
+        const installed = installedAgents.get(agent.name);
+        const isInstalled = installed !== undefined;
+        const hasUpdate = isInstalled && installed.version !== agent.version;
         return (
           <Box key={agent.name} flexDirection="column" marginBottom={1}>
             <Box>
@@ -337,7 +379,8 @@ export function MarketplaceTab({
                 {agent.name}
               </Text>
               <Text dimColor> v{agent.version}</Text>
-              {isInstalled && <Text color="green"> ✓ {installedOrigin}</Text>}
+              {isInstalled && !hasUpdate && <Text color="green"> ✓ {installed.origin}</Text>}
+              {hasUpdate && <Text color="yellow"> ↑ update available (installed: v{installed.version})</Text>}
             </Box>
             <Box marginLeft={2}>
               <Text dimColor>{agent.description}</Text>

--- a/source/components/agents-search.tsx
+++ b/source/components/agents-search.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { Box, Text } from "ink";
+import type { Key } from "ink";
+import type { AgentDefinition, MarketplaceAgent } from "../agents/types.js";
+
+export function matchesQuery(query: string, ...fields: (string | string[])[]): boolean {
+  const q = query.toLowerCase();
+  return fields.some((f) =>
+    Array.isArray(f) ? f.some((v) => v.toLowerCase().includes(q)) : f.toLowerCase().includes(q)
+  );
+}
+
+export function filterInstalledAgents(agents: AgentDefinition[], query: string): AgentDefinition[] {
+  if (!query) return agents;
+  return agents.filter((a) =>
+    matchesQuery(query, a.alias ?? "", a.manifest.name, a.manifest.description ?? "", a.manifest.tags ?? [])
+  );
+}
+
+export function filterMarketplaceAgents(agents: MarketplaceAgent[], query: string): MarketplaceAgent[] {
+  if (!query) return agents;
+  return agents.filter((a) =>
+    matchesQuery(query, a.name, a.description, a.category, a.tags)
+  );
+}
+
+export function useSearch() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searching, setSearching] = useState(false);
+
+  function handleSearchKey(input: string, key: Key): boolean {
+    if (searching) {
+      if (key.escape) {
+        setSearchQuery("");
+        setSearching(false);
+        return true;
+      }
+      if (key.return) {
+        setSearching(false);
+        return true;
+      }
+      if (key.backspace || key.delete) {
+        setSearchQuery((q) => q.slice(0, -1));
+        return true;
+      }
+      if (input && input.length === 1) {
+        setSearchQuery((q) => q + input);
+        return true;
+      }
+      return true;
+    }
+    if (input === "s") {
+      setSearching(true);
+      return true;
+    }
+    if (key.escape && searchQuery) {
+      setSearchQuery("");
+      return true;
+    }
+    return false;
+  }
+
+  return { searchQuery, searching, handleSearchKey };
+}
+
+export function SearchBar({
+  query,
+  searching,
+  resultCount,
+  itemLabel = "agent",
+}: {
+  query: string;
+  searching: boolean;
+  resultCount: number;
+  itemLabel?: string;
+}) {
+  if (searching) {
+    return (
+      <Box marginBottom={1}>
+        <Text>Search: </Text>
+        <Text color="cyan">{query}</Text>
+        <Text color="cyan">█</Text>
+        <Text dimColor>  (ENTER to confirm | ESC to reset)</Text>
+      </Box>
+    );
+  }
+  return (
+    <Box marginBottom={1}>
+      <Text>
+        {resultCount} {itemLabel}{resultCount !== 1 ? "s" : ""}
+        {query && <Text dimColor> matching "{query}"</Text>}
+        {!query && <Text dimColor> total</Text>}
+      </Text>
+      {query && <Text dimColor>  (ESC to clear filter)</Text>}
+    </Box>
+  );
+}

--- a/source/components/agents-tui.tsx
+++ b/source/components/agents-tui.tsx
@@ -99,6 +99,8 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
     setLoading(true);
     const loaded = await loadAgents();
     setAgents(loaded);
+    const { setCachedAgents } = await import("../agents/loader.js");
+    setCachedAgents(loaded);
     setLoading(false);
     computeReadiness(loaded);
     loadAllRuntimeConfigs(loaded);
@@ -395,7 +397,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
         <MarketplaceTab
           onReloadAgents={reloadAgents}
           onExit={onExit}
-          installedAgents={new Map(agents.map((a) => [a.alias || a.manifest.name, a.origin]))}
+          installedAgents={new Map(agents.map((a) => [a.alias || a.manifest.name, { origin: a.origin, version: a.manifest.version }]))}
         />
       )}
 
@@ -424,7 +426,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
           </Text>
         )}
         {activeTab === "marketplace" && (
-          <Text dimColor>↑↓: Navigate | ←→: Page | ENTER: Install | i: Inspect | s: Search | r: Refresh | ESC: Exit/clear</Text>
+          <Text dimColor>↑↓: Navigate | ←→: Page | ENTER: Install | u: Update | i: Inspect | s: Search | r: Refresh | ESC: Exit/clear</Text>
         )}
       </Box>
     </Box>

--- a/source/components/agents-tui.tsx
+++ b/source/components/agents-tui.tsx
@@ -1,0 +1,432 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput, usePaste } from "ink";
+import { mkdir } from "node:fs/promises";
+import { loadAgents } from "../agents/loader.js";
+import { setAgentEnabled } from "../agents/agent-registry.js";
+import { uninstallAgent } from "../agents/installer.js";
+import { loadAgentConfig, saveAgentConfig } from "../agents/credentials.js";
+import { implementAgentTools } from "../agents/tool-gen.js";
+import type { AgentDefinition } from "../agents/types.js";
+import type {
+  Tab, ListView, AgentsTUIProps, ReadinessMap,
+} from "./agents-types.js";
+import {
+  EFFORT_VALUES, resolveConfigDir, getConfigItems,
+} from "./agents-types.js";
+import { useSearch, filterInstalledAgents } from "./agents-search.js";
+import { ListTab } from "./agents-list.js";
+import { InspectView, ConfigEditView } from "./agents-inspect.js";
+import { MarketplaceTab } from "./agents-marketplace.js";
+
+export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
+  const [activeTab, setActiveTab] = useState<Tab>("list");
+  const [agents, setAgents] = useState<AgentDefinition[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [listView, setListView] = useState<ListView>("list");
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const [removeStatus, setRemoveStatus] = useState<string | null>(null);
+  const [readinessMap, setReadinessMap] = useState<ReadinessMap>({});
+
+  const [configEditIndex, setConfigEditIndex]     = useState(0);
+  const [configEditKey, setConfigEditKey]         = useState("");
+  const [configEditBuffer, setConfigEditBuffer]   = useState("");
+  const [configEditing, setConfigEditing]         = useState(false);
+  const [configSavedKeys, setConfigSavedKeys]     = useState<Record<string, string>>({});
+  const [configError, setConfigError]             = useState<string | null>(null);
+  const [configPickerActive, setConfigPickerActive] = useState(false);
+  const [configPickerItems, setConfigPickerItems]   = useState<string[]>([]);
+  const [configPickerIndex, setConfigPickerIndex]   = useState(0);
+  const [runtimeConfigs, setRuntimeConfigs]       = useState<Record<string, Record<string, string>>>({});
+
+  const [implementingTools, setImplementingTools] = useState(false);
+  const [implementStatus, setImplementStatus]     = useState<string | null>(null);
+
+  const runImplementTools = async (agent: AgentDefinition) => {
+    if (!provider || !config) return;
+    setImplementingTools(true);
+    setImplementStatus("Reading tools...");
+    try {
+      const { fixed } = await implementAgentTools(agent, provider, config, (msg) => {
+        setImplementStatus(msg);
+      });
+      setImplementStatus(`✓ Implemented ${fixed} tool${fixed !== 1 ? "s" : ""}. Restart agav to reload.`);
+    } catch (err) {
+      setImplementStatus(`✗ Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    setImplementingTools(false);
+  };
+
+  const computeReadiness = async (agentList: AgentDefinition[]) => {
+    const { getMissingCredentials } = await import("../agents/credentials.js");
+    const result: ReadinessMap = {};
+    for (const agent of agentList) {
+      const key = agent.alias || agent.manifest.name;
+      const required = agent.manifest["required-config"] ?? [];
+      if (required.length === 0) {
+        result[key] = { ready: true, missing: [] };
+      } else {
+        const missing = await getMissingCredentials(resolveConfigDir(agent), agent.manifest);
+        result[key] = { ready: missing.length === 0, missing };
+      }
+    }
+    setReadinessMap(result);
+  };
+
+  const loadAllRuntimeConfigs = async (agentList: AgentDefinition[]) => {
+    const configs: Record<string, Record<string, string>> = {};
+    for (const agent of agentList) {
+      const key = agent.alias || agent.manifest.name;
+      configs[key] = await loadAgentConfig(resolveConfigDir(agent));
+    }
+    setRuntimeConfigs(configs);
+  };
+
+  useEffect(() => {
+    loadAgents()
+      .then((loaded) => {
+        setAgents(loaded);
+        setLoading(false);
+        computeReadiness(loaded);
+        loadAllRuntimeConfigs(loaded);
+      })
+      .catch(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  const reloadAgents = async () => {
+    setLoading(true);
+    const loaded = await loadAgents();
+    setAgents(loaded);
+    setLoading(false);
+    computeReadiness(loaded);
+    loadAllRuntimeConfigs(loaded);
+  };
+
+  const { searchQuery: listSearch, searching: listSearching, handleSearchKey: handleListSearch } = useSearch();
+  const filteredAgents = filterInstalledAgents(agents, listSearch);
+
+  useInput(async (input, key) => {
+    const isEditingConfig = listView === "config" && (configEditing || configPickerActive);
+    if (!listSearching && !isEditingConfig && (input === "1" || input === "2")) {
+      if (input === "1") { setActiveTab("list"); setSelectedIndex(0); setListView("list"); }
+      else if (input === "2") { setActiveTab("marketplace"); setSelectedIndex(0); }
+      return;
+    }
+
+    if (activeTab === "list") {
+      if (listView === "list") {
+        if (confirmingRemove) {
+          if (input === "y" || input === "Y") {
+            const agent = filteredAgents[selectedIndex];
+            if (agent) {
+              const agentKey = agent.alias || agent.manifest.name;
+              const destination = agent.origin === "project" ? "project" : "global";
+              const result = await uninstallAgent(agentKey, destination);
+              if (result.success) {
+                setRemoveStatus(`Removed ${agentKey}`);
+                setSelectedIndex(Math.max(0, selectedIndex - 1));
+                const { getCachedAgents, setCachedAgents } = await import("../agents/loader.js");
+                setCachedAgents(getCachedAgents().filter((a) => (a.alias || a.manifest.name) !== agentKey));
+                await reloadAgents();
+              } else {
+                setRemoveStatus(`Failed: ${result.error}`);
+              }
+            }
+            setConfirmingRemove(false);
+          } else if (input === "n" || input === "N" || key.escape) {
+            setConfirmingRemove(false);
+          }
+          return;
+        }
+
+        if (handleListSearch(input, key)) {
+          setSelectedIndex(0);
+          return;
+        }
+
+        if (key.upArrow && selectedIndex > 0) {
+          setSelectedIndex(selectedIndex - 1);
+          setRemoveStatus(null);
+        } else if (key.downArrow && selectedIndex < filteredAgents.length - 1) {
+          setSelectedIndex(selectedIndex + 1);
+          setRemoveStatus(null);
+        } else if (key.return && filteredAgents[selectedIndex]) {
+          const agent = filteredAgents[selectedIndex]!;
+          const agentKey = agent.alias || agent.manifest.name;
+          const isEnabled = agent.manifest.enabled !== false;
+          await setAgentEnabled(agentKey, !isEnabled);
+          await reloadAgents();
+        } else if (input === "i" && filteredAgents[selectedIndex]) {
+          setListView("inspect");
+        } else if (input === "d" && filteredAgents[selectedIndex]) {
+          const agent = filteredAgents[selectedIndex]!;
+          if (agent.origin === "bundled") {
+            setRemoveStatus("Bundled agents cannot be removed");
+          } else {
+            setConfirmingRemove(true);
+            setRemoveStatus(null);
+          }
+        } else if (key.escape) {
+          onExit();
+        }
+      } else if (listView === "inspect") {
+        const agent = filteredAgents[selectedIndex];
+        const hasTODOTools = agent?.tools.some(t => t.schema.description?.includes("TODO"));
+        if (input === "f" && agent && provider && config && agent.origin === "global" && hasTODOTools) {
+          runImplementTools(agent);
+        } else if (input === "e" && agent) {
+          const agentKey = agent.alias || agent.manifest.name;
+          const existingConfig = await loadAgentConfig(resolveConfigDir(agent));
+          setRuntimeConfigs((prev) => ({ ...prev, [agentKey]: existingConfig }));
+          setConfigEditIndex(0);
+          setConfigEditKey("");
+          setConfigEditBuffer("");
+          setConfigEditing(false);
+          setConfigSavedKeys({});
+          setConfigError(null);
+          setListView("config");
+        } else if (key.escape || input === "b") {
+          setListView("list");
+        }
+      } else if (listView === "config") {
+        const agent = filteredAgents[selectedIndex];
+        if (!agent) return;
+        const agentKey = agent.alias || agent.manifest.name;
+        const items = getConfigItems(agent);
+
+        const saveConfigValue = async (value: string) => {
+          setConfigError(null);
+          try {
+            const dir = resolveConfigDir(agent);
+            await mkdir(dir, { recursive: true });
+            const existing = await loadAgentConfig(dir);
+            const merged: Record<string, string> = { ...existing };
+            if (value) { merged[configEditKey] = value; } else { delete merged[configEditKey]; }
+            await saveAgentConfig(dir, merged);
+            setRuntimeConfigs((prev) => ({ ...prev, [agentKey]: merged }));
+            setConfigSavedKeys((prev) => ({ ...prev, [configEditKey]: value }));
+            computeReadiness(agents);
+          } catch (err) {
+            setConfigError(`Save failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        };
+
+        if (configPickerActive) {
+          if (key.escape) {
+            setConfigPickerActive(false); setConfigError(null);
+          } else if (key.upArrow) {
+            setConfigPickerIndex((i) => Math.max(0, i - 1));
+          } else if (key.downArrow) {
+            setConfigPickerIndex((i) => Math.min(configPickerItems.length - 1, i + 1));
+          } else if (key.return) {
+            const chosen = configPickerIndex === 0 ? "" : configPickerItems[configPickerIndex];
+            await saveConfigValue(chosen);
+            setConfigPickerActive(false);
+            setConfigEditing(false);
+          }
+        } else if (configEditing) {
+          if (key.escape) {
+            setConfigEditing(false); setConfigError(null);
+          } else if (key.return) {
+            await saveConfigValue(configEditBuffer);
+            setConfigEditing(false);
+          } else if (key.backspace || key.delete) {
+            setConfigEditBuffer((b) => b.slice(0, -1));
+          } else if (input && input.length === 1) {
+            setConfigEditBuffer((b) => b + input);
+          }
+        } else {
+          if (key.escape) {
+            setListView("inspect"); setConfigError(null);
+          } else if (key.upArrow) {
+            setConfigEditIndex((i) => Math.max(0, i - 1)); setConfigError(null);
+          } else if (key.downArrow) {
+            setConfigEditIndex((i) => Math.min(items.length - 1, i + 1)); setConfigError(null);
+          } else if (key.return && items[configEditIndex]) {
+            const selectedItem = items[configEditIndex]!;
+            const existingConfig = runtimeConfigs[agentKey] ?? {};
+            setConfigEditKey(selectedItem.key);
+            setConfigEditBuffer(existingConfig[selectedItem.key] ?? "");
+            setConfigError(null);
+
+            if (selectedItem.key === "model") {
+              const modelItems: string[] = [];
+              const fetches: Promise<string[]>[] = [];
+              if (config?.anthropicApiKey) {
+                fetches.push(
+                  fetch("https://api.anthropic.com/v1/models", {
+                    headers: { "x-api-key": config?.anthropicApiKey ?? "", "anthropic-version": "2023-06-01" },
+                    signal: AbortSignal.timeout(5000),
+                  }).then(r => r.ok ? r.json() : { data: [] })
+                    .then((d: any) => (d.data ?? []).map((m: any) => m.id).sort())
+                    .catch(() => [])
+                );
+              }
+              if (config?.openaiApiKey) {
+                fetches.push(
+                  fetch("https://api.openai.com/v1/models", {
+                    headers: { Authorization: `Bearer ${config.openaiApiKey}` },
+                    signal: AbortSignal.timeout(5000),
+                  }).then(r => r.ok ? r.json() : { data: [] })
+                    .then((d: any) => (d.data ?? [])
+                      .map((m: any) => m.id)
+                      .filter((id: string) => /^(gpt-|o[0-9])/.test(id) && !/embed|whisper|tts|image/.test(id))
+                      .sort())
+                    .catch(() => [])
+                );
+              }
+              const results = await Promise.allSettled(fetches);
+              for (const r of results) {
+                if (r.status === "fulfilled") modelItems.push(...r.value);
+              }
+
+              if (!modelItems.length) {
+                setConfigEditing(true);
+              } else {
+                const allItems = ["(inherit session)", ...modelItems];
+                const currentVal = existingConfig["model"] ?? "";
+                const currentIdx = allItems.indexOf(currentVal);
+                setConfigPickerItems(allItems);
+                setConfigPickerIndex(currentIdx >= 0 ? currentIdx : 0);
+                setConfigPickerActive(true);
+              }
+            } else if (selectedItem.key === "effort") {
+              const allItems = ["(inherit session)", ...EFFORT_VALUES];
+              const currentVal = existingConfig["effort"] ?? "";
+              const currentIdx = allItems.indexOf(currentVal);
+              setConfigPickerItems(allItems);
+              setConfigPickerIndex(currentIdx >= 0 ? currentIdx : 0);
+              setConfigPickerActive(true);
+            } else {
+              setConfigEditing(true);
+            }
+          }
+        }
+      }
+    }
+  });
+
+  usePaste((text) => {
+    if (listView === "config" && configEditing && !configEditKey.match(/^(model|effort)$/)) {
+      const cleaned = text.replace(/\n/g, "").trim();
+      setConfigEditBuffer((b) => b + cleaned);
+    }
+  });
+
+  if (loading) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text>Loading agents...</Text>
+      </Box>
+    );
+  }
+
+  const selectedAgent = filteredAgents[selectedIndex];
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Box marginBottom={1}>
+        <Text bold>Agents Management</Text>
+      </Box>
+
+      <Box marginBottom={1}>
+        <Text color={activeTab === "list" ? "cyan" : "gray"}>
+          [1] List
+        </Text>
+        <Text> </Text>
+        <Text color={activeTab === "marketplace" ? "cyan" : "gray"}>
+          [2] Marketplace
+        </Text>
+        <Text> </Text>
+      </Box>
+
+      {activeTab === "list" && listView === "list" && (
+        <ListTab
+          agents={filteredAgents}
+          allAgents={agents}
+          selectedIndex={selectedIndex}
+          searchQuery={listSearch}
+          searching={listSearching}
+          confirmingRemove={confirmingRemove}
+          removeStatus={removeStatus}
+          readinessMap={readinessMap}
+        />
+      )}
+      {activeTab === "list" && listView === "inspect" && selectedAgent && (
+        <Box flexDirection="column">
+          <InspectView
+            agent={selectedAgent}
+            readiness={readinessMap[selectedAgent.alias || selectedAgent.manifest.name]}
+            runtimeConfig={runtimeConfigs[selectedAgent.alias || selectedAgent.manifest.name]}
+            sessionModel={config?.model}
+            sessionEffort={config?.effort}
+            sessionProvider={config?.provider}
+          />
+          {implementingTools && implementStatus && (
+            <Box marginTop={1}><Text color="cyan">{implementStatus}</Text></Box>
+          )}
+          {!implementingTools && implementStatus && (
+            <Box marginTop={1}>
+              <Text color={implementStatus.startsWith("✓") ? "green" : "yellow"}>{implementStatus}</Text>
+            </Box>
+          )}
+        </Box>
+      )}
+      {activeTab === "list" && listView === "config" && selectedAgent && (
+        <ConfigEditView
+          agent={selectedAgent}
+          items={getConfigItems(selectedAgent)}
+          editIndex={configEditIndex}
+          editKey={configEditKey}
+          editBuffer={configEditBuffer}
+          isEditing={configEditing}
+          savedKeys={configSavedKeys}
+          error={configError}
+          readiness={readinessMap[selectedAgent.alias || selectedAgent.manifest.name]}
+          runtimeConfig={runtimeConfigs[selectedAgent.alias || selectedAgent.manifest.name] ?? {}}
+          pickerActive={configPickerActive}
+          pickerItems={configPickerItems}
+          pickerIndex={configPickerIndex}
+        />
+      )}
+      {activeTab === "marketplace" && (
+        <MarketplaceTab
+          onReloadAgents={reloadAgents}
+          onExit={onExit}
+          installedAgents={new Map(agents.map((a) => [a.alias || a.manifest.name, a.origin]))}
+        />
+      )}
+
+      <Box marginTop={1} borderStyle="single" borderTop paddingTop={1}>
+        {activeTab === "list" && listView === "list" && (
+          <Text dimColor>
+            ↑↓: Navigate | ENTER: Toggle | i: Inspect | d: Remove | s: Search | ESC: Exit/clear
+          </Text>
+        )}
+        {activeTab === "list" && listView === "inspect" && (
+          <Text dimColor>
+            {(() => {
+              const a = filteredAgents[selectedIndex];
+              const canImplement = a && a.origin === "global" && a.tools.some(t => t.schema.description?.includes("TODO")) && provider;
+              return `e: Edit config${canImplement ? " | f: Implement tools" : ""} | b/ESC: Back`;
+            })()}
+          </Text>
+        )}
+        {activeTab === "list" && listView === "config" && (
+          <Text dimColor>
+            {configPickerActive
+              ? "↑↓: Navigate | ENTER: Select | ESC: Cancel"
+              : configEditing
+              ? "Type value (blank = inherit) | ENTER: Save | ESC: Cancel"
+              : "↑↓: Navigate | ENTER: Edit value | ESC: Back to inspect"}
+          </Text>
+        )}
+        {activeTab === "marketplace" && (
+          <Text dimColor>↑↓: Navigate | ←→: Page | ENTER: Install | i: Inspect | s: Search | r: Refresh | ESC: Exit/clear</Text>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/source/components/agents-types.ts
+++ b/source/components/agents-types.ts
@@ -1,0 +1,54 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentDefinition } from "../agents/types.js";
+
+export type Tab = "list" | "marketplace";
+
+export type ListView = "list" | "inspect" | "config";
+
+export interface AgentsTUIProps {
+  onExit: () => void;
+  provider?: import("../providers/types.js").LLMProvider | null;
+  config?: import("../config/config.js").AgavConfig;
+}
+
+export type AgentReadiness = { ready: boolean; missing: string[] };
+export type ReadinessMap = Record<string, AgentReadiness>;
+
+export interface ConfigItem {
+  key: string;
+  label: string;
+  secret: boolean;
+}
+
+export const EFFORT_VALUES = ["low", "medium", "high", "max"] as const;
+
+export function resolveConfigDir(agent: AgentDefinition): string {
+  if (agent.origin === "bundled") {
+    return join(homedir(), ".agav", "agents", agent.manifest.name);
+  }
+  return agent.path;
+}
+
+export function resolveConfigPath(agent: AgentDefinition): string {
+  return join(resolveConfigDir(agent), "config.json");
+}
+
+export function getConfigItems(agent: AgentDefinition): ConfigItem[] {
+  const credItems: ConfigItem[] = (agent.manifest["required-config"] ?? []).map((k) => ({
+    key: k,
+    label: k,
+    secret: true,
+  }));
+  return [
+    ...credItems,
+    { key: "model",  label: "Model  (blank = inherit session)", secret: false },
+    { key: "effort", label: "Effort (blank = inherit session)", secret: false },
+  ];
+}
+
+export function parseFileUrl(url: string): string {
+  let path = url.replace(/^file:\/\//, "");
+  if (path.match(/^\/[A-Za-z]:/)) path = path.substring(1);
+  return path;
+}

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -9,6 +9,11 @@ export type EffortLevel = "low" | "medium" | "high" | "max";
 
 export const EFFORT_LEVELS: readonly EffortLevel[] = ["low", "medium", "high", "max"];
 
+/** Default marketplace URL — override via agentMarketplace in config.json or AGAV_MARKETPLACE_URL env var */
+export const DEFAULT_MARKETPLACE_URL =
+  process.env.AGAV_MARKETPLACE_URL ||
+  "https://raw.githubusercontent.com/prapaa-ai/agav-marketplace/main";
+
 export function isEffortLevel(value: unknown): value is EffortLevel {
   return typeof value === "string" && EFFORT_LEVELS.includes(value as EffortLevel);
 }
@@ -43,6 +48,7 @@ export interface AgavConfig {
   hooks?: AgavHooks;
   theme?: Partial<AgavTheme>;
   mcpServers?: Record<string, MCPServerConfig>;
+  agentMarketplace?: string; // URL to agent marketplace repository
 }
 
 const AGAV_DIR = join(homedir(), ".agav");

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -9,10 +9,15 @@ export type EffortLevel = "low" | "medium" | "high" | "max";
 
 export const EFFORT_LEVELS: readonly EffortLevel[] = ["low", "medium", "high", "max"];
 
-/** Default marketplace URL — override via agentMarketplace in config.json or AGAV_MARKETPLACE_URL env var */
-export const DEFAULT_MARKETPLACE_URL =
-  process.env.AGAV_MARKETPLACE_URL ||
-  "https://raw.githubusercontent.com/prapaa-ai/agav-marketplace/main";
+const DEFAULT_MARKETPLACE_FALLBACK = "https://raw.githubusercontent.com/prapaa-ai/agav-marketplace/main";
+
+/** Default marketplace URL — override via AGAV_MARKETPLACE_URL env var or agentMarketplace in config.json */
+export function getDefaultMarketplaceUrl(): string {
+  return process.env.AGAV_MARKETPLACE_URL || DEFAULT_MARKETPLACE_FALLBACK;
+}
+
+/** @deprecated Use getDefaultMarketplaceUrl() instead */
+export const DEFAULT_MARKETPLACE_URL = DEFAULT_MARKETPLACE_FALLBACK;
 
 export function isEffortLevel(value: unknown): value is EffortLevel {
   return typeof value === "string" && EFFORT_LEVELS.includes(value as EffortLevel);

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -289,6 +289,13 @@ export function useAgent(
         .map((s) => createSkillSlashCommand(s));
       setSkillCommands(userSkillCmds);
 
+      // Load agents — do NOT register as tools yet; registration happens lazily per-turn
+      if (provider) {
+        const { loadAgents, setCachedAgents } = await import("../agents/loader.js");
+        const agents = await loadAgents();
+        setCachedAgents(agents);
+      }
+
       // Start MCP servers
       if (config.mcpServers) {
         for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
@@ -459,12 +466,59 @@ export function useAgent(
         let currentThinking = "";
 
         try {
-          // Refresh dynamic context (git state, AGAV.md) before each turn
+          // Refresh dynamic context (git state, AGAV.md, agent catalog) before each turn.
+          // Pass the user message so the agent catalog is only injected when relevant.
           const { refreshDynamicContext } = await import("../utils/system-prompt.js");
-          const dynamicCtx = await refreshDynamicContext(mcpManagerRef.current);
+          const { context: dynamicCtx, includeAgentTools } = await refreshDynamicContext(
+            mcpManagerRef.current,
+            trimmed
+          );
           let effectiveSystemPrompt = dynamicCtx
             ? (config.systemPrompt ?? "") + "\n\n" + dynamicCtx
             : config.systemPrompt;
+
+          // Tool registration: always register enabled agents so they are callable
+          // regardless of whether the catalog was included in the system prompt.
+          // Lazy catalog injection (via includeAgentTools) only controls the hint text
+          // in the system prompt — it must not gate whether tools are actually available.
+          if (provider) {
+            const { getCachedAgents } = await import("../agents/loader.js");
+            const { agentToTool } = await import("../agents/registry-factory.js");
+            const agents = getCachedAgents();
+            const enabledAgents = agents.filter((a) => a.manifest.enabled !== false);
+            for (const agent of enabledAgents) {
+              const toolName = `${agent.alias || agent.manifest.name}_agent`;
+              if (!toolRegistryRef.current.getSchemas().find((s) => s.name === toolName)) {
+                const { makeAgentProgressTracker } = await import("../agent/subagent-progress.js");
+                // Cache one tracker per callId so seed() runs exactly once per invocation,
+                // not once per event (which caused duplicate subagentStates entries).
+                const trackerCache = new Map<string, (event: import("../agent/loop.js").AgentEvent) => void>();
+                toolRegistryRef.current.register(agentToTool(agent, {
+                  provider,
+                  config: configRef.current,
+                  onProgressUpdate: (callId, event) => {
+                    if (!trackerCache.has(callId)) {
+                      trackerCache.set(callId, makeAgentProgressTracker(
+                        callId,
+                        agent.alias || agent.manifest.name,
+                        agent.manifest.description || agent.manifest.name,
+                        setSubagentStates,
+                      ));
+                    }
+                    trackerCache.get(callId)!(event);
+                  },
+                  confirmTool: confirmToolCallback,
+                }));
+              }
+            }
+            // Remove tools for agents that were disabled since last turn
+            const enabledNames = new Set(enabledAgents.map((a) => `${a.alias || a.manifest.name}_agent`));
+            for (const schema of toolRegistryRef.current.getSchemas()) {
+              if (schema.name.endsWith("_agent") && !enabledNames.has(schema.name)) {
+                toolRegistryRef.current.unregister(schema.name);
+              }
+            }
+          }
 
           const existingPlan = await loadPlan();
           const hasActivePlan = existingPlan && existingPlan.steps.some((s) => s.status !== "done");

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -480,7 +480,7 @@ export function useAgent(
           // the tool schemas and the whole conversation from the provider's prefix cache.
           const { refreshStableContext, refreshVolatileContext, formatTurnContext } =
             await import("../utils/system-prompt.js");
-          const [stableCtx, { context: volatileCtx, includeAgentTools }] = await Promise.all([
+          const [stableCtx, { context: volatileCtx }] = await Promise.all([
             refreshStableContext(mcpManagerRef.current),
             refreshVolatileContext(trimmed),
           ]);
@@ -521,9 +521,13 @@ export function useAgent(
                 }));
               }
             }
+            // Unregister agent tools that are no longer enabled, using the
+            // full set of known agent names to avoid accidentally removing
+            // unrelated MCP tools that happen to end with "_agent".
+            const allAgentToolNames = new Set(agents.map((a) => `${a.alias || a.manifest.name}_agent`));
             const enabledNames = new Set(enabledAgents.map((a) => `${a.alias || a.manifest.name}_agent`));
             for (const schema of toolRegistryRef.current.getSchemas()) {
-              if (schema.name.endsWith("_agent") && !enabledNames.has(schema.name)) {
+              if (allAgentToolNames.has(schema.name) && !enabledNames.has(schema.name)) {
                 toolRegistryRef.current.unregister(schema.name);
               }
             }

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -14,6 +14,7 @@ import { createToolRegistry } from "./tools/registry-factory.js";
 import { getToolLabel } from "./utils/tool-labels.js";
 import { loadKeybindings } from "./config/keybindings.js";
 import { dim, icons } from "./utils/color.js";
+import { stopAllA2AAgents } from "./agents/a2a-client.js";
 import {
   createOutputValidator,
   formatValidationErrors,
@@ -419,8 +420,11 @@ export async function main() {
   if (flags.agents) {
     const { runAgentsCommand } = await import("./cli/agents-cli.js");
     const agentsCommand = typeof flags.agentsCommand === "string" ? flags.agentsCommand : undefined;
-    // Calculate offset: "agents" at position 2, command (if present) at position 3
-    const argsStartIndex = agentsCommand ? 4 : 3;
+    // Find "agents" position in argv to correctly slice remaining args
+    const agentsIdx = process.argv.indexOf("agents");
+    const argsStartIndex = agentsIdx >= 0
+      ? agentsIdx + (agentsCommand ? 2 : 1)
+      : (agentsCommand ? 4 : 3);
     const exitCode = await runAgentsCommand(agentsCommand, process.argv.slice(argsStartIndex));
     process.exit(exitCode);
     return;
@@ -689,21 +693,16 @@ export async function main() {
   // Mark clean exits so crash recovery only offers truly interrupted sessions.
   process.on("exit", () => {
     markCleanExit();
-    // Clean up any running A2A agent processes
-    import("./agents/a2a-client.js").then(({ stopAllA2AAgents }) => {
-      stopAllA2AAgents();
-    }).catch(() => {});
+    stopAllA2AAgents();
   });
   process.on("SIGINT", async () => {
     markCleanExit();
-    const { stopAllA2AAgents } = await import("./agents/a2a-client.js");
     stopAllA2AAgents();
     await showResumeHint();
     process.exit(0);
   });
   process.on("SIGTERM", async () => {
     markCleanExit();
-    const { stopAllA2AAgents } = await import("./agents/a2a-client.js");
     stopAllA2AAgents();
     await showResumeHint();
     process.exit(0);

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -131,6 +131,11 @@ export function parseArgs(argv: string[]) {
       if (argv[i + 1] && !argv[i + 1]!.startsWith("-")) {
         flags.updateVersion = argv[++i]!;
       }
+    } else if (arg === "agents" && i === 0) {
+      flags.agents = true;
+      if (argv[i + 1] && !argv[i + 1]!.startsWith("-")) {
+        flags.agentsCommand = argv[++i]!;
+      }
     } else if (arg === "run" && i === 0) {
       flags.run = true;
     } else if (flags.run && !arg.startsWith("-") && !flags.runPrompt) {
@@ -331,6 +336,7 @@ export async function main() {
     $ agav [options]
     $ agav run "prompt"            Non-interactive agent mode (CI/scripting)
     $ agav update                  Update to the latest version
+    $ agav agents [command]        Manage service agents
     $ agav --print "prompt"
     $ cat file | agav -P "explain this"
 
@@ -353,6 +359,13 @@ export async function main() {
     --help, -h           Show this help
     --version, -v        Show version
 
+  Agent Commands
+    $ agav agents list             List installed agents
+    $ agav agents install <url>    Install agent from git URL or local path
+    $ agav agents remove <name>    Uninstall an agent
+    $ agav agents enable <name>    Enable an agent
+    $ agav agents disable <name>   Disable an agent
+
   Examples
     $ agav
     $ agav --provider openai --model gpt-4o
@@ -361,6 +374,8 @@ export async function main() {
     $ agav -P "what does this project do?"
     $ agav -P --stream "explain this repository"
     $ cat error.log | agav -P "explain this error"
+    $ agav agents install https://github.com/user/repo/agents/jira
+    $ agav agents list
 `);
     process.exit(0);
   }
@@ -377,6 +392,17 @@ export async function main() {
     const targetVersion = typeof flags.updateVersion === "string" ? flags.updateVersion : undefined;
     const ok = await forceUpdate(targetVersion);
     process.exit(ok ? 0 : 1);
+    return;
+  }
+
+  // Agent management: agav agents <command>
+  if (flags.agents) {
+    const { runAgentsCommand } = await import("./cli/agents-cli.js");
+    const agentsCommand = typeof flags.agentsCommand === "string" ? flags.agentsCommand : undefined;
+    // Calculate offset: "agents" at position 2, command (if present) at position 3
+    const argsStartIndex = agentsCommand ? 4 : 3;
+    const exitCode = await runAgentsCommand(agentsCommand, process.argv.slice(argsStartIndex));
+    process.exit(exitCode);
     return;
   }
 
@@ -656,14 +682,24 @@ export async function main() {
   }
 
   // Mark clean exits so crash recovery only offers truly interrupted sessions.
-  process.on("exit", () => { markCleanExit(); });
+  process.on("exit", () => {
+    markCleanExit();
+    // Clean up any running A2A agent processes
+    import("./agents/a2a-client.js").then(({ stopAllA2AAgents }) => {
+      stopAllA2AAgents();
+    }).catch(() => {});
+  });
   process.on("SIGINT", async () => {
     markCleanExit();
+    const { stopAllA2AAgents } = await import("./agents/a2a-client.js");
+    stopAllA2AAgents();
     await showResumeHint();
     process.exit(0);
   });
   process.on("SIGTERM", async () => {
     markCleanExit();
+    const { stopAllA2AAgents } = await import("./agents/a2a-client.js");
+    stopAllA2AAgents();
     await showResumeHint();
     process.exit(0);
   });

--- a/source/providers/types.ts
+++ b/source/providers/types.ts
@@ -37,6 +37,7 @@ export interface ToolSchema {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  destructive?: boolean; // true = always confirm; false = always safe; undefined = current SAFE_TOOLS logic
 }
 
 export interface StreamParams {

--- a/source/tools/github.ts
+++ b/source/tools/github.ts
@@ -30,7 +30,8 @@ export const githubTool: ToolDefinition = {
     description:
       "Interact with GitHub via the gh CLI. Supports creating/viewing PRs and issues. " +
       "Requires the gh CLI to be installed and authenticated.",
-    destructive: true, // create_pr and create_issue are write operations
+    // Not marked destructive — loop.ts handles non-SAFE_TOOLS confirmation.
+    // This avoids blocking read-only operations like view_pr and list_prs.
     inputSchema: {
       type: "object",
       properties: {

--- a/source/tools/github.ts
+++ b/source/tools/github.ts
@@ -30,6 +30,7 @@ export const githubTool: ToolDefinition = {
     description:
       "Interact with GitHub via the gh CLI. Supports creating/viewing PRs and issues. " +
       "Requires the gh CLI to be installed and authenticated.",
+    destructive: true, // create_pr and create_issue are write operations
     inputSchema: {
       type: "object",
       properties: {

--- a/source/tools/types.ts
+++ b/source/tools/types.ts
@@ -9,7 +9,11 @@ export interface ToolResult {
   contentBlocks?: ContentBlock[];
 }
 
+export interface ToolContext {
+  env?: Record<string, string>;
+}
+
 export interface ToolDefinition {
   schema: ToolSchema;
-  execute(input: Record<string, unknown>): Promise<ToolResult>;
+  execute(input: Record<string, unknown>, context?: ToolContext): Promise<ToolResult>;
 }

--- a/source/utils/system-prompt.ts
+++ b/source/utils/system-prompt.ts
@@ -4,6 +4,30 @@ import { formatMemoriesForPrompt } from "../config/memory.js";
 import type { MCPManager } from "../mcp/manager.js";
 import { getCachedSkills, buildSkillCatalog, loadSkills } from "../skills/loader.js";
 import { formatSteersForPrompt } from "../commands/steer.js";
+import type { AgentDefinition } from "../agents/types.js";
+
+/**
+ * Returns true if the user's message suggests they may want to delegate to a
+ * specialized agent. Used to gate agent catalog injection and tool registration
+ * so they don't add tokens/tools on every unrelated turn.
+ */
+export function shouldIncludeAgentCatalog(userMessage: string, agents: AgentDefinition[]): boolean {
+  if (agents.length === 0) return false;
+  const msg = userMessage.toLowerCase();
+  // Always include if the message explicitly mentions any installed agent by name
+  if (agents.some((a) => msg.includes(a.manifest.name.toLowerCase()))) return true;
+  // Include if message contains integration or delegation keywords
+  const keywords = [
+    "jira", "github", "gitlab", "slack", "aws", "gcp", "azure", "argocd",
+    "ticket", "issue", "pr ", "pull request", "pipeline", "deploy", "deployment",
+    "kubernetes", "k8s", "kubectl", "cluster", "pod", "node",
+    "agent", "use the", "ask the", "delegate to", "check with",
+    "repo", "repository", "commit", "branch", "merge",
+    "cloud", "ec2", "s3", "bucket", "instance", "vm",
+    "sprint", "backlog", "story", "epic", "workflow",
+  ];
+  return keywords.some((k) => msg.includes(k));
+}
 
 const STATIC_BASE = [
   "You are Agav, an AI coding assistant running in the user's terminal.",
@@ -61,8 +85,13 @@ const STATIC_BASE = [
   `The user's current working directory is: ${process.cwd()}`,
 ].join("\n");
 
-/** Rebuild dynamic prompt context that depends on the current repo state and local instructions. */
-export async function refreshDynamicContext(mcpManager?: MCPManager): Promise<string> {
+/** Rebuild dynamic prompt context that depends on the current repo state and local instructions.
+ * Pass `userMessage` to enable lazy agent catalog injection — the catalog is only included
+ * when the message suggests the user wants to delegate to a specialized agent. */
+export async function refreshDynamicContext(
+  mcpManager?: MCPManager,
+  userMessage?: string
+): Promise<{ context: string; includeAgentTools: boolean }> {
   const parts: string[] = [];
 
   const gitCtx = await getGitContext();
@@ -99,7 +128,20 @@ export async function refreshDynamicContext(mcpManager?: MCPManager): Promise<st
     parts.push(steers);
   }
 
-  return parts.join("\n\n");
+  // Agent catalog — only inject when the user message suggests agent delegation
+  const { getCachedAgents } = await import("../agents/loader.js");
+  const { buildAgentCatalog } = await import("../agents/catalog.js");
+  const agents = getCachedAgents();
+  const includeAgentTools = !userMessage || shouldIncludeAgentCatalog(userMessage, agents);
+
+  if (includeAgentTools) {
+    const agentCatalog = buildAgentCatalog(agents);
+    if (agentCatalog) {
+      parts.push(agentCatalog);
+    }
+  }
+
+  return { context: parts.join("\n\n"), includeAgentTools };
 }
 
 /** Assemble the baseline system prompt (memories are now loaded per-turn in refreshDynamicContext). */

--- a/source/utils/system-prompt.ts
+++ b/source/utils/system-prompt.ts
@@ -19,7 +19,11 @@ export function shouldIncludeAgentCatalog(userMessage: string, agents: AgentDefi
     const escaped = a.manifest.name.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     return new RegExp(`\\b${escaped}\\b`).test(msg);
   })) return true;
-  // Include if message contains integration or delegation keywords (word boundary match)
+  // These keywords gate catalog text injection into the system prompt.
+  // Tools are always registered regardless of this check — the catalog
+  // hint only adds context tokens. Custom agents whose names don't match
+  // these keywords are still callable; the LLM just won't see the
+  // "Available specialized agents:" hint for that turn.
   const keywords = [
     "jira", "github", "gitlab", "slack", "aws", "gcp", "azure", "argocd",
     "ticket", "issue", "pull request", "pipeline", "deploy", "deployment",

--- a/source/utils/system-prompt.ts
+++ b/source/utils/system-prompt.ts
@@ -14,19 +14,22 @@ import type { AgentDefinition } from "../agents/types.js";
 export function shouldIncludeAgentCatalog(userMessage: string, agents: AgentDefinition[]): boolean {
   if (agents.length === 0) return false;
   const msg = userMessage.toLowerCase();
-  // Always include if the message explicitly mentions any installed agent by name
-  if (agents.some((a) => msg.includes(a.manifest.name.toLowerCase()))) return true;
-  // Include if message contains integration or delegation keywords
+  // Always include if the message explicitly mentions any installed agent by name (word boundary)
+  if (agents.some((a) => {
+    const escaped = a.manifest.name.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`\\b${escaped}\\b`).test(msg);
+  })) return true;
+  // Include if message contains integration or delegation keywords (word boundary match)
   const keywords = [
     "jira", "github", "gitlab", "slack", "aws", "gcp", "azure", "argocd",
-    "ticket", "issue", "pr ", "pull request", "pipeline", "deploy", "deployment",
-    "kubernetes", "k8s", "kubectl", "cluster", "pod", "node",
+    "ticket", "issue", "pull request", "pipeline", "deploy", "deployment",
+    "kubernetes", "k8s", "kubectl", "cluster", "pod",
     "agent", "use the", "ask the", "delegate to", "check with",
-    "repo", "repository", "commit", "branch", "merge",
     "cloud", "ec2", "s3", "bucket", "instance", "vm",
     "sprint", "backlog", "story", "epic", "workflow",
   ];
-  return keywords.some((k) => msg.includes(k));
+  const kwRegex = new RegExp(`\\b(?:${keywords.join("|")})\\b`, "i");
+  return kwRegex.test(msg);
 }
 
 const STATIC_BASE = [

--- a/source/utils/tool-labels.ts
+++ b/source/utils/tool-labels.ts
@@ -99,12 +99,31 @@ const DEFAULT_META: ToolMeta = {
 };
 
 export function getToolLabel(name: string): string {
-  return (TOOL_META[name] ?? DEFAULT_META).label;
+  if (TOOL_META[name]) return TOOL_META[name].label;
+  // Named agent tools (e.g. "win_cua_agent" → "win-cua agent")
+  if (name.endsWith("_agent")) {
+    const agentName = name.slice(0, -6).replace(/_/g, "-");
+    return `${agentName} agent`;
+  }
+  // Agent sub-tools with namespace prefix (e.g. "wincua_run_powershell" → "Run PowerShell")
+  // Strip the prefix (everything up to and including the first underscore after a namespace)
+  const prefixMatch = name.match(/^[a-z]+_(.+)$/);
+  if (prefixMatch) {
+    const rest = prefixMatch[1].replace(/_/g, " ");
+    return rest.charAt(0).toUpperCase() + rest.slice(1);
+  }
+  return DEFAULT_META.label;
 }
 
 export function getToolSummary(
   name: string,
   input: Record<string, unknown>,
 ): string {
-  return (TOOL_META[name] ?? DEFAULT_META).formatSummary(input);
+  if (TOOL_META[name]) return TOOL_META[name].formatSummary(input);
+  // For agent tools, show the task they were given
+  if (name.endsWith("_agent") && typeof input.task === "string") {
+    const task = input.task as string;
+    return task.length > 60 ? task.slice(0, 60) + "..." : task;
+  }
+  return DEFAULT_META.formatSummary(input);
 }


### PR DESCRIPTION
## Summary

Adds agent marketplace and service agents system with native implementation support. User can:
1. Use custom agents via natural language — the LLM routes tasks to the right agent automatically
2. Install agents from a configurable marketplace (`/agents` TUI → Marketplace tab)
3. Manage agent installations, credentials, model/effort overrides, and enable/disable state

## Changes

- **Agent runtime** (`source/agents/`): loader with three-tier discovery (bundled → global `~/.agav/agents/` → project `.agav/agents/`), per-agent credential isolation (`config.json` injected as `process.env`), executor with HITL confirmation for destructive tools, agent registry with enable/disable persistence, and installer supporting local paths and remote URLs
- **A2A protocol support** (`source/agents/a2a-client.ts`): HTTP-based agent-to-agent client (`/health`, `/execute`, `/stream`) for external agent processes — experimental
- **Agent TUI** (`source/components/agents-*.tsx`): interactive `/agents` command with List and Marketplace tabs, agent inspect view, config editor with model/effort picker (fetches available models from Anthropic/OpenAI APIs), search, pagination, install/uninstall/reinstall flows
- **Lazy agent catalog injection** (`source/utils/system-prompt.ts`): keyword-based gate so agent catalog and tools only enter the context window when the user message suggests delegation — avoids bloating every turn
- **Subagent progress tracking** (`source/agent/subagent-progress.ts`): shared tracker for named agent execution with tool call counts, streaming text, and token usage display
- **Tool label system** (`source/utils/tool-labels.ts`): humanizes agent sub-tool names in the UI (e.g., `wincua_run_powershell` → "Run powershell")
- **LLM-powered tool generation** (`source/agents/tool-gen.ts`): press `f` in inspect view to auto-implement TODO tool stubs using the session LLM
- **CLI subcommands** (`source/cli/agents-cli.ts`): `agav agents list|install|remove|enable|disable` for non-interactive use
- **Config** (`source/config/config.ts`): added `agentMarketplace` URL config with env var override (`AGAV_MARKETPLACE_URL`)
- **Developer docs** (`AGENTS.md`): comprehensive reference for the agent system architecture

## Related Issues

N/A

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

- [x] `npx tsc --noEmit` passes
- [x] Manually tested in terminal
- [x] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)