### PR TITLE
feat: support of vertex-ai llm provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ source/
 ├── hooks/          # React hooks (use-agent, use-paste-handler)
 ├── mcp/            # MCP server integration
 ├── plugins/        # Plugin system
-├── providers/      # LLM providers (Anthropic, OpenAI, Gemini, Ollama)
+├── providers/      # LLM providers (Anthropic, OpenAI, Gemini, Vertex AI, Ollama)
 ├── skills/         # Skill system (loader, executor, bundled skills)
 ├── tools/          # Agent tools (file read/write, shell, grep, etc.)
 ├── utils/          # Shared utilities (sandbox, diff, encrypt, etc.)
@@ -68,6 +68,8 @@ pnpm start -- --provider gemini         # Use a specific provider
 4. Update `source/main.tsx` (flags, validation, auto-detection, help text)
 5. Add model entries in `source/commands/model-routing.ts`
 6. Add model fetching in `source/commands/model.ts`
+7. Update session restoration in `source/main.tsx` and `source/commands/history.ts`
+8. Update provider memoization in `source/app.tsx` and add provider/config tests
 
 ### Adding a new slash command
 
@@ -180,7 +182,7 @@ Every contribution matters — code is just one of many ways to make Agav better
 - Translate docs into other languages
 
 ### Test and give feedback
-- Try Agav with different providers (Anthropic, OpenAI, Gemini, Ollama) and report issues
+- Try Agav with different providers (Anthropic, OpenAI, Gemini, Vertex AI, Ollama) and report issues
 - Test on different platforms (macOS, Linux, WSL)
 - Try edge cases — large files, long conversations, unusual prompts
 - Report UI glitches, confusing output, or missing feedback

--- a/README.md
+++ b/README.md
@@ -124,31 +124,6 @@ On Windows, remove the Agav entry from your user `PATH` under **Settings → Edi
 
 Agav also writes per-project directories inside repositories you've worked in — `.agav/` (cached images) and `.agav-worktrees/`. Delete those individually if you want them gone.
 
-### Vertex AI
-
-Vertex AI uses a Google Cloud service-account JSON file. Enable it with both settings, then select the provider:
-
-```bash
-export AGAV_USE_VERTEX_AI=true
-export VERTEX_AI_CREDENTIALS_PATH=/path/to/service-account.json
-agav --provider vertex-ai --model google/gemini-2.5-flash
-# Claude partner models are supported by the same provider and credentials:
-agav --provider vertex-ai --model anthropic/claude-sonnet-4-5@20250929
-```
-
-The same settings can be placed in `.agav/config.json` (project) or `~/.agav/config.json` (global):
-
-```json
-{
-  "provider": "vertex-ai",
-  "model": "google/gemini-2.5-flash",
-  "AGAV_USE_VERTEX_AI": true,
-  "VERTEX_AI_CREDENTIALS_PATH": "/path/to/service-account.json"
-}
-```
-
-The service account's `project_id`, `client_email`, `private_key`, and optional `token_uri` are read from that file. Agav exchanges the signed credentials for a short-lived OAuth token and refreshes it automatically. The provider supports Gemini (`google/gemini-*`) and Claude (`anthropic/claude-*`) models. Use the versioned Claude model ID exposed by Vertex AI, including its `@YYYYMMDD` suffix. Vertex AI's implicit Gemini caching and Claude's ephemeral prompt caching are used automatically when supported.
-
 ### Run from source
 
 #### macOS
@@ -168,6 +143,39 @@ git clone https://github.com/prapaa-ai/agav && cd agav && pnpm install --frozen-
 ```powershell
 git clone https://github.com/prapaa-ai/agav; cd agav; pnpm install --frozen-lockfile; pnpm build; pnpm start
 ```
+
+## Provider setup
+
+Anthropic, OpenAI, and Gemini need nothing more than their API key in the environment — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` — and Ollama just needs a local server running. Vertex AI takes a little more.
+
+### Vertex AI
+
+Vertex AI authenticates with a Google Cloud service-account JSON file. Point Agav at it, then select the provider:
+
+```bash
+export VERTEX_AI_CREDENTIALS_PATH=/path/to/service-account.json
+agav --provider vertex-ai --model vertex/gemini-3.5-flash
+# Claude partner models are supported by the same provider and credentials:
+agav --provider vertex-ai --model vertex/claude-sonnet-4-5@20250929
+```
+
+Setting the credentials path is what enables the provider; there is no separate on/off flag to keep in sync with it. Agav uses the multi-region `global` endpoint by default — set `VERTEX_AI_LOCATION` (for example `us-east5`) to pin a region instead, which some Claude partner models require.
+
+The same settings can go in `.agav/config.json` (project) or `~/.agav/config.json` (global):
+
+```json
+{
+  "provider": "vertex-ai",
+  "model": "vertex/gemini-3.5-flash",
+  "vertexAICredentialsPath": "/path/to/service-account.json",
+  "vertexAILocation": "global"
+}
+```
+
+> [!IMPORTANT]
+> **Protect the key file.** The service-account JSON holds an unencrypted private key that can act as that service account against your entire Google Cloud project. Unlike the API keys Agav encrypts into `config.json`, this file is yours to secure: keep it outside the repository, `chmod 600` it, and grant the service account only the `roles/aiplatform.user` role it actually needs.
+
+The service account's `project_id`, `client_email`, `private_key`, and optional `token_uri` are read from that file. Agav exchanges the signed credentials for a short-lived OAuth token and refreshes it automatically. Both model families are addressed with the same `vertex/` prefix — `vertex/gemini-3.5-flash`, `vertex/claude-sonnet-4-5@20250929` — and Claude needs the versioned ID that Vertex AI exposes, including its `@YYYYMMDD` suffix. Vertex AI's implicit Gemini caching and Claude's ephemeral prompt caching are used automatically when supported.
 
 ## Multi-line input
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ On Windows, remove the Agav entry from your user `PATH` under **Settings → Edi
 
 Agav also writes per-project directories inside repositories you've worked in — `.agav/` (cached images) and `.agav-worktrees/`. Delete those individually if you want them gone.
 
+### Vertex AI
+
+Vertex AI uses a Google Cloud service-account JSON file. Enable it with both settings, then select the provider:
+
+```bash
+export AGAV_USE_VERTEX_AI=true
+export VERTEX_AI_CREDENTIALS_PATH=/path/to/service-account.json
+agav --provider vertex-ai --model google/gemini-2.5-flash
+# Claude partner models are supported by the same provider and credentials:
+agav --provider vertex-ai --model anthropic/claude-sonnet-4-5@20250929
+```
+
+The same settings can be placed in `.agav/config.json` (project) or `~/.agav/config.json` (global):
+
+```json
+{
+  "provider": "vertex-ai",
+  "model": "google/gemini-2.5-flash",
+  "AGAV_USE_VERTEX_AI": true,
+  "VERTEX_AI_CREDENTIALS_PATH": "/path/to/service-account.json"
+}
+```
+
+The service account's `project_id`, `client_email`, `private_key`, and optional `token_uri` are read from that file. Agav exchanges the signed credentials for a short-lived OAuth token and refreshes it automatically. The provider supports Gemini (`google/gemini-*`) and Claude (`anthropic/claude-*`) models. Use the versioned Claude model ID exposed by Vertex AI, including its `@YYYYMMDD` suffix. Vertex AI's implicit Gemini caching and Claude's ephemeral prompt caching are used automatically when supported.
+
 ### Run from source
 
 #### macOS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A terminal-native environment for running local AI systems",
   "type": "module",
   "bin": {

--- a/source/__tests__/agent.conversation-compaction.test.ts
+++ b/source/__tests__/agent.conversation-compaction.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { ConversationState } from "../agent/conversation.js";
+import type { ContentBlock, Message } from "../providers/types.js";
+
+/**
+ * Build a conversation long and heavy enough that a forced compaction has
+ * something to drop: alternating user turns, assistant tool calls, and the
+ * matching tool results.
+ */
+function buildConversation(cycles: number): ConversationState {
+  const convo = new ConversationState();
+  convo.setModel("test");
+  for (let i = 0; i < cycles; i++) {
+    convo.addUserMessage(`question ${i} `.repeat(200));
+    convo.addAssistantMessage([
+      { type: "tool_use", toolCallId: `call-${i}`, toolName: "read_file", toolInput: { path: `f${i}.ts` } } as ContentBlock,
+    ]);
+    convo.addToolResults([
+      { type: "tool_result", toolCallId: `call-${i}`, toolResult: `contents ${i} `.repeat(200) } as ContentBlock,
+    ]);
+  }
+  return convo;
+}
+
+function textBlocks(messages: Message[]): string[] {
+  return messages.flatMap((m) => m.content.filter((b) => b.type === "text").map((b) => b.text ?? ""));
+}
+
+describe("conversation compaction", () => {
+  // A blank summary used to be stored verbatim, and every later request failed
+  // with "text content blocks must be non-empty" until the session was cleared.
+  it("falls back to a placeholder when the summarizer returns nothing", async () => {
+    const convo = buildConversation(8);
+    const result = await convo.compactIfNeeded(true, async () => "");
+
+    expect(result.compacted).toBe(true);
+    expect(textBlocks(convo.getMessages()).some((t) => t.trim() === "")).toBe(false);
+    expect(convo.lastCompactionSummary).toContain("compacted to save context");
+  });
+
+  it("falls back to a placeholder when the summarizer only returns whitespace", async () => {
+    const convo = buildConversation(8);
+    await convo.compactIfNeeded(true, async () => "  \n\t ");
+
+    expect(textBlocks(convo.getMessages()).some((t) => t.trim() === "")).toBe(false);
+  });
+
+  it("falls back to a placeholder when the summarizer throws", async () => {
+    const convo = buildConversation(8);
+    const result = await convo.compactIfNeeded(true, async () => {
+      throw new Error("Vertex AI Claude API error 400");
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(textBlocks(convo.getMessages()).some((t) => t.trim() === "")).toBe(false);
+  });
+
+  it("keeps a real summary when the summarizer produces one", async () => {
+    const convo = buildConversation(8);
+    await convo.compactIfNeeded(true, async () => "## Task\nreal summary");
+
+    expect(convo.getMessages()[0]?.content[0]?.text).toBe("## Task\nreal summary");
+  });
+
+  // Sessions saved before the fix already carry the empty block, so loading one
+  // has to repair it rather than fail the same way all over again.
+  it("strips empty text blocks out of a restored session", async () => {
+    const convo = new ConversationState();
+    convo.setMessages([
+      { role: "user", content: [{ type: "text", text: "" }] },
+      { role: "user", content: [{ type: "text", text: "  " }, { type: "text", text: "real" }] },
+      { role: "assistant", content: [{ type: "text", text: "" }, { type: "text", text: "answer" }] },
+    ] as Message[]);
+
+    expect(convo.length).toBe(2);
+    expect(textBlocks(convo.getMessages())).toEqual(["real", "answer"]);
+  });
+
+  // When the newest messages dominate the budget, the split falls back to the
+  // "keep at least 4" floor — which for a tool-heavy history lands squarely on
+  // a tool_result whose tool_use sits just before it.
+  it("moves the boundary off a tool_result when the keep-4 floor decides it", async () => {
+    // 21 messages, so the keep-4 floor lands on index 17 — a tool_result. The
+    // final result is large enough that the token budget keeps nothing on its
+    // own, leaving the floor to pick the boundary.
+    const convo = buildConversation(6);
+    convo.addUserMessage("one more");
+    convo.addAssistantMessage([
+      { type: "tool_use", toolCallId: "call-6", toolName: "read_file", toolInput: {} } as ContentBlock,
+    ]);
+    convo.addToolResults([
+      { type: "tool_result", toolCallId: "call-6", toolResult: "huge ".repeat(20000) } as ContentBlock,
+    ]);
+
+    let dropped: Message[] = [];
+    await convo.compactIfNeeded(true, async (msgs) => {
+      dropped = msgs;
+      return "summary";
+    });
+
+    // The summary is index 0; the first surviving real message must not open
+    // with a tool_result, or its tool_use went out with the dropped half.
+    const firstKept = convo.getMessages()[1];
+    expect(firstKept?.content.some((b) => b.type === "tool_result")).toBe(false);
+    expect(dropped.at(-1)?.content.some((b) => b.type === "tool_use")).toBe(false);
+  });
+
+  // Both halves of the split are used as standalone conversations, so a
+  // tool_result must never be separated from the tool_use it answers.
+  it("never splits a tool cycle across the compaction boundary", async () => {
+    const convo = buildConversation(10);
+    let dropped: Message[] = [];
+    await convo.compactIfNeeded(true, async (msgs) => {
+      dropped = msgs;
+      return "summary";
+    });
+
+    const keptIds = new Set<string>();
+    for (const msg of convo.getMessages()) {
+      for (const block of msg.content) {
+        if (block.type === "tool_use" && block.toolCallId) keptIds.add(block.toolCallId);
+      }
+    }
+    for (const msg of convo.getMessages()) {
+      for (const block of msg.content) {
+        if (block.type === "tool_result" && block.toolCallId) {
+          expect(keptIds.has(block.toolCallId)).toBe(true);
+        }
+      }
+    }
+
+    const droppedIds = new Set<string>();
+    for (const msg of dropped) {
+      for (const block of msg.content) {
+        if (block.type === "tool_use" && block.toolCallId) droppedIds.add(block.toolCallId);
+      }
+    }
+    for (const msg of dropped) {
+      for (const block of msg.content) {
+        if (block.type === "tool_result" && block.toolCallId) {
+          expect(droppedIds.has(block.toolCallId)).toBe(true);
+        }
+      }
+    }
+    // The two halves must not both claim the same call.
+    for (const id of droppedIds) expect(keptIds.has(id)).toBe(false);
+  });
+});

--- a/source/__tests__/commands.model-routing.test.ts
+++ b/source/__tests__/commands.model-routing.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { deepCommand, fastCommand } from "../commands/model-routing.js";
+import type { CommandContext } from "../commands/types.js";
+import type { AgavConfig } from "../config/config.js";
+import { PROVIDERS } from "../config/startup.js";
+
+const createContext = (provider: AgavConfig["provider"]): CommandContext => ({
+  conversation: {} as any,
+  config: { provider } as any,
+  setModel: vi.fn(),
+  setProvider: vi.fn(),
+  setEffort: vi.fn(),
+  clearMessages: vi.fn(),
+  showStatus: vi.fn(),
+  saveSession: vi.fn(),
+  refreshDisplay: vi.fn(),
+  loadSession: vi.fn(),
+  activateSession: vi.fn(),
+  renameSession: vi.fn(),
+  exit: vi.fn(),
+  getDebugState: vi.fn(),
+  submit: vi.fn(),
+  handleSubmit: vi.fn(),
+  toolRegistry: {} as any,
+  addTokenUsage: vi.fn(),
+  setRunningSkill: vi.fn(),
+  setPickerActive: vi.fn(),
+});
+
+const route = async (command: typeof fastCommand, provider: AgavConfig["provider"]) => {
+  const context = createContext(provider);
+  await command.execute("", context);
+  return (context.setModel as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+};
+
+// Ollama models are whatever the user has pulled locally, so a static table
+// cannot name one — every other provider must be covered.
+const CLOUD_PROVIDERS = PROVIDERS.filter((provider) => provider !== "ollama");
+
+describe("commands/model-routing", () => {
+  it("/fast routes each provider to its own model", async () => {
+    await expect(route(fastCommand, "anthropic")).resolves.toBe("claude-haiku-4-5-20251001");
+    await expect(route(fastCommand, "openai")).resolves.toBe("gpt-4o-mini");
+    await expect(route(fastCommand, "gemini")).resolves.toBe("gemini-3.5-flash-lite");
+    await expect(route(fastCommand, "vertex-ai")).resolves.toBe("vertex/gemini-3.5-flash-lite");
+  });
+
+  it("/deep routes each provider to its own model", async () => {
+    await expect(route(deepCommand, "anthropic")).resolves.toBe("claude-sonnet-4-20250514");
+    await expect(route(deepCommand, "openai")).resolves.toBe("gpt-4o");
+    await expect(route(deepCommand, "gemini")).resolves.toBe("gemini-3.5-pro");
+    await expect(route(deepCommand, "vertex-ai")).resolves.toBe("vertex/gemini-3.5-pro");
+  });
+
+  it("never silently falls back to an OpenAI model for another provider", async () => {
+    for (const provider of CLOUD_PROVIDERS) {
+      if (provider === "openai") continue;
+      await expect(route(fastCommand, provider)).resolves.not.toMatch(/^gpt-/);
+      await expect(route(deepCommand, provider)).resolves.not.toMatch(/^gpt-/);
+    }
+  });
+
+  it("addresses Vertex AI models with the vertex/ prefix the provider expects", async () => {
+    await expect(route(fastCommand, "vertex-ai")).resolves.toMatch(/^vertex\//);
+    await expect(route(deepCommand, "vertex-ai")).resolves.toMatch(/^vertex\//);
+  });
+});

--- a/source/__tests__/commands.model.test.ts
+++ b/source/__tests__/commands.model.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../providers/vertex-ai.js", () => ({
+  fetchVertexAIModels: vi.fn(),
+}));
+
+const { fetchVertexAIModels } = await import("../providers/vertex-ai.js");
+const fetchVertexAIModelsMock = vi.mocked(fetchVertexAIModels);
+const { modelCommand } = await import("../commands/model.js");
+
+import type { CommandContext } from "../commands/types.js";
+import type { AgavConfig } from "../config/config.js";
+
+const originalFetch = globalThis.fetch;
+
+/**
+ * Answer only the Anthropic listing; every other endpoint (Ollama in
+ * particular) is treated as unreachable so the tests never touch the network.
+ */
+function stubFetch(anthropicModels: string[]): void {
+  globalThis.fetch = vi.fn(async (input: any) => {
+    if (String(input).includes("api.anthropic.com")) {
+      return {
+        ok: true,
+        json: async () => ({ data: anthropicModels.map((id) => ({ id })) }),
+      } as any;
+    }
+    throw new Error("unreachable");
+  }) as any;
+}
+
+/** Narrow a CommandResult to the message text these tests assert on. */
+function messageText(result: Awaited<ReturnType<typeof modelCommand.execute>>): string {
+  expect(result.type).toBe("message");
+  return result.type === "message" ? result.text : "";
+}
+
+function createContext(config: Partial<AgavConfig>): CommandContext {
+  return {
+    conversation: {} as any,
+    config: { provider: "vertex-ai", model: "vertex/gemini-3.5-flash", ...config } as any,
+    setModel: vi.fn(),
+    setProvider: vi.fn(),
+    setEffort: vi.fn(),
+    clearMessages: vi.fn(),
+    showStatus: vi.fn(),
+    saveSession: vi.fn(),
+    refreshDisplay: vi.fn(),
+    loadSession: vi.fn(),
+    activateSession: vi.fn(),
+    renameSession: vi.fn(),
+    exit: vi.fn(),
+    getDebugState: vi.fn(),
+    submit: vi.fn(),
+    handleSubmit: vi.fn(),
+    toolRegistry: {} as any,
+    addTokenUsage: vi.fn(),
+    setRunningSkill: vi.fn(),
+    setPickerActive: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  fetchVertexAIModelsMock.mockReset();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("commands/model", () => {
+  it("lists Vertex AI models alongside the other providers", async () => {
+    stubFetch([]);
+    fetchVertexAIModelsMock.mockResolvedValue(["vertex/gemini-3.5-pro"]);
+
+    const context = createContext({ vertexAICredentialsPath: "/tmp/sa.json", vertexAILocation: "us-east5" });
+    const result = await modelCommand.execute("vertex/gemini-3.5-pro", context);
+
+    expect(fetchVertexAIModelsMock).toHaveBeenCalledWith("/tmp/sa.json", "us-east5");
+    expect(context.setModel).toHaveBeenCalledWith("vertex/gemini-3.5-pro");
+    expect(messageText(result)).toContain("Model changed to: vertex/gemini-3.5-pro");
+  });
+
+  // A misread key file used to be swallowed, so /model just showed no Vertex
+  // entries — indistinguishable from a provider that has nothing to offer.
+  it("reports why Vertex AI produced no models instead of hiding the failure", async () => {
+    stubFetch(["claude-sonnet-4-20250514"]);
+    fetchVertexAIModelsMock.mockRejectedValue(
+      new Error("Unable to read Vertex AI credentials from /tmp/sa.json: ENOENT"),
+    );
+
+    const context = createContext({
+      anthropicApiKey: "test-key",
+      vertexAICredentialsPath: "/tmp/sa.json",
+    });
+    const result = await modelCommand.execute("vertex/gemini-3.5-pro", context);
+
+    expect(context.setModel).not.toHaveBeenCalled();
+    expect(messageText(result)).toContain("not found");
+    expect(messageText(result)).toContain("Vertex AI models unavailable");
+    expect(messageText(result)).toContain("ENOENT");
+  });
+
+  it("surfaces the Vertex AI failure when it is the only configured provider", async () => {
+    stubFetch([]);
+    fetchVertexAIModelsMock.mockRejectedValue(new Error("missing required key: project_id"));
+
+    const context = createContext({ vertexAICredentialsPath: "/tmp/sa.json" });
+    const result = await modelCommand.execute("", context);
+
+    expect(context.setPickerActive).not.toHaveBeenCalled();
+    expect(messageText(result)).toContain("No providers reachable");
+    expect(messageText(result)).toContain("missing required key: project_id");
+  });
+
+  it("does not query Vertex AI when no credentials path is configured", async () => {
+    stubFetch(["claude-sonnet-4-20250514"]);
+
+    const context = createContext({ anthropicApiKey: "test-key", vertexAICredentialsPath: undefined });
+    const result = await modelCommand.execute("claude-sonnet-4-20250514", context);
+
+    expect(fetchVertexAIModelsMock).not.toHaveBeenCalled();
+    expect(messageText(result)).not.toContain("Vertex AI models unavailable");
+  });
+});

--- a/source/__tests__/config.test.ts
+++ b/source/__tests__/config.test.ts
@@ -28,6 +28,8 @@ describe("config", () => {
     delete process.env.OLLAMA_HOST;
     delete process.env.OLLAMA_PORT;
     delete process.env.OLLAMA_API_KEY;
+    delete process.env.AGAV_USE_VERTEX_AI;
+    delete process.env.VERTEX_AI_CREDENTIALS_PATH;
   });
 
   it("accepts valid effort levels", async () => {
@@ -53,6 +55,37 @@ describe("config", () => {
     expect(result.permissionMode).toBe("ask");
   });
 
+  it("loads project-level secrets when env vars are absent", async () => {
+    readFile.mockImplementation(async (path: any) => {
+      const s = String(path);
+      if (/[\\/]\.agav[\\/]config\.json$/.test(s)) {
+        return JSON.stringify({
+          anthropicApiKey: "enc:anthropic-project",
+          openaiApiKey: "enc:openai-project",
+          geminiApiKey: "enc:gemini-project",
+          ollamaApiKey: "enc:ollama-project",
+        });
+      }
+      if (/[\\/]config\.json$/.test(s)) {
+        return JSON.stringify({
+          anthropicApiKey: "enc:anthropic-global",
+          openaiApiKey: "enc:openai-global",
+          geminiApiKey: "enc:gemini-global",
+          ollamaApiKey: "enc:ollama-global",
+        });
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+
+    const mod = await import("../config/config.js");
+    const loaded = await mod.loadConfig();
+
+    expect(loaded.anthropicApiKey).toBe("anthropic-project");
+    expect(loaded.openaiApiKey).toBe("openai-project");
+    expect(loaded.geminiApiKey).toBe("gemini-project");
+    expect(loaded.ollamaApiKey).toBe("ollama-project");
+  });
+
   it("applies env overrides and encrypts secrets on save", async () => {
     process.env.ANTHROPIC_API_KEY = "enc:anthropic-env";
     process.env.OPENAI_API_KEY = "enc:openai-env";
@@ -61,6 +94,8 @@ describe("config", () => {
     process.env.OLLAMA_HOST = "127.0.0.1";
     process.env.OLLAMA_PORT = "11435";
     process.env.OLLAMA_API_KEY = "enc:ollama-env";
+    process.env.AGAV_USE_VERTEX_AI = "true";
+    process.env.VERTEX_AI_CREDENTIALS_PATH = "/tmp/service-account.json";
 
     readFile.mockImplementation(async (path: any) => {
       const s = String(path);
@@ -83,6 +118,8 @@ describe("config", () => {
     expect(loaded.ollamaEndpoint).toBe("http://localhost:11434");
     expect(loaded.ollamaHost).toBe("127.0.0.1");
     expect(loaded.ollamaPort).toBe(11435);
+    expect(loaded.AGAV_USE_VERTEX_AI).toBe(true);
+    expect(loaded.VERTEX_AI_CREDENTIALS_PATH).toBe("/tmp/service-account.json");
 
     await mod.saveConfig({
       provider: "anthropic",

--- a/source/__tests__/config.test.ts
+++ b/source/__tests__/config.test.ts
@@ -28,8 +28,8 @@ describe("config", () => {
     delete process.env.OLLAMA_HOST;
     delete process.env.OLLAMA_PORT;
     delete process.env.OLLAMA_API_KEY;
-    delete process.env.AGAV_USE_VERTEX_AI;
     delete process.env.VERTEX_AI_CREDENTIALS_PATH;
+    delete process.env.VERTEX_AI_LOCATION;
   });
 
   it("accepts valid effort levels", async () => {
@@ -86,6 +86,42 @@ describe("config", () => {
     expect(loaded.ollamaApiKey).toBe("ollama-project");
   });
 
+  // No shell is involved when config.json is read back, so a `~` written there
+  // would otherwise reach fs.readFile literally and fail with ENOENT.
+  it("expands a leading ~ in the Vertex AI credentials path", async () => {
+    const { homedir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    readFile.mockImplementation(async (path: any) => {
+      if (/[\\/]\.agav[\\/]config\.json$/.test(String(path))) {
+        return JSON.stringify({ vertexAICredentialsPath: "~/.gcp/sa.json" });
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+
+    const mod = await import("../config/config.js");
+    const loaded = await mod.loadConfig();
+
+    expect(loaded.vertexAICredentialsPath).toBe(join(homedir(), ".gcp/sa.json"));
+  });
+
+  it("expands ~ from the env var and leaves absolute paths untouched", async () => {
+    const { homedir } = await import("node:os");
+    const { join } = await import("node:path");
+    process.env.VERTEX_AI_CREDENTIALS_PATH = "~/keys/sa.json";
+
+    readFile.mockImplementation(async () => {
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+
+    const mod = await import("../config/config.js");
+    expect((await mod.loadConfig()).vertexAICredentialsPath).toBe(join(homedir(), "keys/sa.json"));
+
+    expect(mod.expandHome("/absolute/sa.json")).toBe("/absolute/sa.json");
+    expect(mod.expandHome("relative/~/sa.json")).toBe("relative/~/sa.json");
+    expect(mod.expandHome("~")).toBe(homedir());
+  });
+
   it("applies env overrides and encrypts secrets on save", async () => {
     process.env.ANTHROPIC_API_KEY = "enc:anthropic-env";
     process.env.OPENAI_API_KEY = "enc:openai-env";
@@ -94,8 +130,8 @@ describe("config", () => {
     process.env.OLLAMA_HOST = "127.0.0.1";
     process.env.OLLAMA_PORT = "11435";
     process.env.OLLAMA_API_KEY = "enc:ollama-env";
-    process.env.AGAV_USE_VERTEX_AI = "true";
     process.env.VERTEX_AI_CREDENTIALS_PATH = "/tmp/service-account.json";
+    process.env.VERTEX_AI_LOCATION = "us-east5";
 
     readFile.mockImplementation(async (path: any) => {
       const s = String(path);
@@ -118,8 +154,8 @@ describe("config", () => {
     expect(loaded.ollamaEndpoint).toBe("http://localhost:11434");
     expect(loaded.ollamaHost).toBe("127.0.0.1");
     expect(loaded.ollamaPort).toBe(11435);
-    expect(loaded.AGAV_USE_VERTEX_AI).toBe(true);
-    expect(loaded.VERTEX_AI_CREDENTIALS_PATH).toBe("/tmp/service-account.json");
+    expect(loaded.vertexAICredentialsPath).toBe("/tmp/service-account.json");
+    expect(loaded.vertexAILocation).toBe("us-east5");
 
     await mod.saveConfig({
       provider: "anthropic",

--- a/source/__tests__/providers.vertex-ai.test.ts
+++ b/source/__tests__/providers.vertex-ai.test.ts
@@ -234,4 +234,44 @@ describe("VertexAIProvider", () => {
       "vertex/gemini-2.5-flash",
     ]);
   });
+
+  it("surfaces a publisher failure instead of reporting an empty catalog", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access-token" }), { status: 200 }))
+      // Gemini errors while Claude legitimately returns nothing, so the only
+      // honest answer is the error — not "no models exist".
+      .mockResolvedValueOnce(new Response("boom", { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ publisherModels: [] }), { status: 200 }));
+
+    await expect(fetchVertexAIModels(credentialsPath)).rejects.toThrow(
+      "Unable to list Vertex AI Gemini or Claude models",
+    );
+  });
+
+  it("targets the regional host when a location is configured", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access-token", expires_in: 3600 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response('data: [DONE]\n\n', { status: 200, headers: { "Content-Type": "text/event-stream" } }));
+
+    const provider = new VertexAIProvider(credentialsPath, "us-east5");
+    for await (const _event of provider.stream({
+      model: "vertex/gemini-3.5-flash",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    })) { /* drain */ }
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://us-east5-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-east5/endpoints/openapi/chat/completions",
+    );
+  });
+
+  it("mints one access token for concurrent callers", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ access_token: "access-token", expires_in: 3600 }), { status: 200 }));
+
+    const auth = new VertexAIAuth(credentialsPath);
+    const tokens = await Promise.all([auth.getAccessToken(), auth.getAccessToken(), auth.getAccessToken()]);
+
+    expect(tokens).toEqual(["access-token", "access-token", "access-token"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/source/__tests__/providers.vertex-ai.test.ts
+++ b/source/__tests__/providers.vertex-ai.test.ts
@@ -1,0 +1,237 @@
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const serviceAccount = JSON.stringify({
+  type: "service_account",
+  project_id: "test-project",
+  private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+  client_email: "agav@test-project.iam.gserviceaccount.com",
+  token_uri: "https://oauth2.googleapis.com/token",
+});
+
+import { VertexAIAuth, VertexAIProvider, fetchVertexAIModels } from "../providers/vertex-ai.js";
+
+let testDir: string;
+let credentialsPath: string;
+
+describe("VertexAIProvider", () => {
+  beforeAll(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "agav-vertex-test-"));
+    credentialsPath = join(testDir, "service-account.json");
+    await writeFile(credentialsPath, serviceAccount);
+  });
+  afterAll(async () => rm(testDir, { recursive: true, force: true }));
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("reports every missing required service-account key", async () => {
+    const incompleteCredentialsPath = join(testDir, "incomplete-service-account.json");
+    await writeFile(incompleteCredentialsPath, JSON.stringify({ type: "service_account", project_id: "" }));
+
+    await expect(new VertexAIAuth(incompleteCredentialsPath).getProjectId()).rejects.toThrow(
+      "missing required keys: project_id, private_key, client_email",
+    );
+  });
+
+  it("reports an invalid service-account type separately", async () => {
+    const invalidTypeCredentialsPath = join(testDir, "invalid-type-service-account.json");
+    await writeFile(invalidTypeCredentialsPath, JSON.stringify({
+      type: "authorized_user",
+      project_id: "test-project",
+      private_key: "key",
+      client_email: "user@example.com",
+    }));
+
+    await expect(new VertexAIAuth(invalidTypeCredentialsPath).getProjectId()).rejects.toThrow(
+      'key "type" must be "service_account" (received "authorized_user")',
+    );
+  });
+
+  it("authenticates with the service account and streams chat/tool/usage events", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access-token", expires_in: 3600 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response([
+        'data: {"choices":[{"delta":{"content":"hello ","tool_calls":[{"index":0,"id":"call_1","extra_content":{"google":{"thought_signature":"opaque-signature"}},"function":{"name":"lookup","arguments":"{\\"q\\":"}}]}}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"x\\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":3,"prompt_tokens_details":{"cached_tokens":4}}}',
+        "data: [DONE]",
+        "",
+      ].join("\n"), { status: 200, headers: { "Content-Type": "text/event-stream" } }))
+      .mockResolvedValueOnce(new Response([
+        'data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}',
+        "data: [DONE]",
+        "",
+      ].join("\n"), { status: 200, headers: { "Content-Type": "text/event-stream" } }));
+
+    const events = [];
+    const provider = new VertexAIProvider(credentialsPath);
+    for await (const event of provider.stream({
+      model: "vertex/gemini-2.5-flash",
+      systemPrompt: "system",
+      effort: "high",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      tools: [{ name: "lookup", description: "Look up", inputSchema: { type: "object" } }],
+    })) events.push(event);
+
+    expect(events).toEqual([
+      { type: "message_start" },
+      { type: "text_delta", text: "hello " },
+      { type: "tool_call_start", toolCallId: "call_1", toolName: "lookup" },
+      { type: "tool_call_delta", toolCallId: "call_1", argsJson: '{"q":', providerMetadata: { vertexAIThoughtSignature: "opaque-signature" } },
+      { type: "usage", inputTokens: 10, outputTokens: 3, cacheReadTokens: 4 },
+      { type: "tool_call_delta", toolCallId: "call_1", argsJson: '"x"}' },
+      { type: "tool_call_end", toolCallId: "call_1" },
+      { type: "message_end", stopReason: "tool_calls" },
+    ]);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://oauth2.googleapis.com/token");
+    const request = fetchMock.mock.calls[1]!;
+    expect(request[0]).toBe("https://aiplatform.googleapis.com/v1beta1/projects/test-project/locations/global/endpoints/openapi/chat/completions");
+    const body = JSON.parse(String(request[1]?.body));
+    expect(body.model).toBe("google/gemini-2.5-flash");
+    expect(body.reasoning_effort).toBe("high");
+    expect(body.stream_options).toEqual({ include_usage: true });
+
+    for await (const _event of provider.stream({
+      model: "vertex/gemini-2.5-flash",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+        { role: "assistant", content: [{
+          type: "tool_use",
+          toolCallId: "call_1",
+          toolName: "lookup",
+          toolInput: { q: "x" },
+          providerMetadata: { vertexAIThoughtSignature: "opaque-signature" },
+        }] },
+        { role: "user", content: [{ type: "tool_result", toolCallId: "call_1", toolResult: "result" }] },
+      ],
+    })) {}
+    const followUpBody = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
+    expect(followUpBody.messages[1].tool_calls[0].extra_content.google.thought_signature).toBe("opaque-signature");
+  });
+
+  it("uses Vertex's compatibility sentinel for legacy history without stored signatures", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access-token" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response('data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n', { status: 200 }));
+
+    for await (const _event of new VertexAIProvider(credentialsPath).stream({
+      model: "vertex/gemini-3.5-flash",
+      messages: [
+        { role: "assistant", content: [{ type: "tool_use", toolCallId: "old", toolName: "overview", toolInput: {} }] },
+        { role: "user", content: [{ type: "tool_result", toolCallId: "old", toolResult: "result" }] },
+      ],
+    })) {}
+    const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(body.messages[0].tool_calls[0].extra_content.google.thought_signature).toBe("skip_thought_signature_validator");
+  });
+
+  it("repairs unsigned parallel calls once when Vertex rejects the request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access-token" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: { message: "Function call is missing a thought_signature in functionCall parts." } }), { status: 400 }))
+      .mockResolvedValueOnce(new Response('data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n', { status: 200 }));
+
+    for await (const _event of new VertexAIProvider(credentialsPath).stream({
+      model: "vertex/gemini-3.5-flash",
+      messages: [
+        { role: "assistant", content: [
+          {
+            type: "tool_use",
+            toolCallId: "first",
+            toolName: "overview",
+            toolInput: {},
+            providerMetadata: { vertexAIThoughtSignature: "real-signature" },
+          },
+          { type: "tool_use", toolCallId: "second", toolName: "read_file", toolInput: { path: "x" } },
+        ] },
+        { role: "user", content: [
+          { type: "tool_result", toolCallId: "first", toolResult: "one" },
+          { type: "tool_result", toolCallId: "second", toolResult: "two" },
+        ] },
+      ],
+    })) {}
+
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    const repairedBody = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
+    expect(firstBody.messages[0].tool_calls[0].extra_content.google.thought_signature).toBe("real-signature");
+    expect(firstBody.messages[0].tool_calls[1].extra_content).toBeUndefined();
+    expect(repairedBody.messages[0].tool_calls[0].extra_content.google.thought_signature).toBe("real-signature");
+    expect(repairedBody.messages[0].tool_calls[1].extra_content.google.thought_signature).toBe("skip_thought_signature_validator");
+  });
+
+  it("streams Claude models through Vertex's Anthropic endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access-token" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response([
+        'event: message_start',
+        'data: {"type":"message_start","message":{"usage":{"input_tokens":12,"cache_read_input_tokens":5,"cache_creation_input_tokens":2}}}',
+        'event: content_block_start',
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+        'event: content_block_delta',
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Checking"}}',
+        'event: content_block_start',
+        'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool_1","name":"lookup","input":{}}}',
+        'event: content_block_delta',
+        'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"q\\":\\"x\\"}"}}',
+        'event: content_block_stop',
+        'data: {"type":"content_block_stop","index":1}',
+        'event: message_delta',
+        'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}',
+        "",
+      ].join("\n"), { status: 200, headers: { "Content-Type": "text/event-stream" } }));
+
+    const events = [];
+    for await (const event of new VertexAIProvider(credentialsPath).stream({
+      model: "vertex/claude-sonnet-4-5@20250929",
+      systemPrompt: "system",
+      effort: "high",
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      tools: [{ name: "lookup", description: "Look up", inputSchema: { type: "object" } }],
+    })) events.push(event);
+
+    expect(events).toEqual([
+      { type: "message_start" },
+      { type: "usage", inputTokens: 12, outputTokens: 0, cacheReadTokens: 5, cacheWriteTokens: 2 },
+      { type: "text_delta", text: "Checking" },
+      { type: "tool_call_start", toolCallId: "tool_1", toolName: "lookup" },
+      { type: "tool_call_delta", toolCallId: "tool_1", argsJson: '{"q":"x"}' },
+      { type: "tool_call_end", toolCallId: "tool_1" },
+      { type: "usage", inputTokens: 0, outputTokens: 7 },
+      { type: "message_end", stopReason: "tool_use" },
+    ]);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/anthropic/models/claude-sonnet-4-5%4020250929:streamRawPredict",
+    );
+    const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(body.model).toBeUndefined();
+    expect(body.anthropic_version).toBe("vertex-2023-10-16");
+    expect(body.output_config).toEqual({ effort: "high" });
+    expect(body.system[0]).toMatchObject({ text: "system", cache_control: { type: "ephemeral" } });
+    expect(body.tools[0]).toMatchObject({ name: "lookup", cache_control: { type: "ephemeral" } });
+  });
+
+  it("lists and normalizes Gemini and Claude publisher models", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access-token" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        publisherModels: [
+          { name: "publishers/google/models/gemini-2.5-flash@001" },
+          { name: "publishers/google/models/gemini-2.5-flash-preview-tts" },
+          { name: "publishers/google/models/imagen-4.0" },
+        ],
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        publisherModels: [
+          { name: "publishers/anthropic/models/claude-sonnet-4-5@20250929" },
+          { name: "publishers/anthropic/models/not-claude" },
+        ],
+      }), { status: 200 }));
+
+    await expect(fetchVertexAIModels(credentialsPath)).resolves.toEqual([
+      "vertex/claude-sonnet-4-5@20250929",
+      "vertex/gemini-2.5-flash",
+    ]);
+  });
+});

--- a/source/__tests__/smoke.test.ts
+++ b/source/__tests__/smoke.test.ts
@@ -5,12 +5,16 @@ const skipCli = nodeVersion < 22;
 
 async function runCli(args: string[], env?: NodeJS.ProcessEnv) {
   const { execFile } = await import("node:child_process");
-  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
-    execFile(process.execPath, ["build/cli.js", ...args], {
+  const { resolve } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+  const cliPath = resolve("build/cli.js");
+  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolvePromise) => {
+    execFile(process.execPath, [cliPath, ...args], {
       timeout: 10000,
+      cwd: tmpdir(),
       env: env ? { ...process.env, ...env } : process.env,
     }, (err, stdout, stderr) => {
-      resolve({
+      resolvePromise({
         stdout: (stdout ?? "").trim(),
         stderr: (stderr ?? "").trim(),
         exitCode: err ? 1 : 0,
@@ -44,9 +48,14 @@ describe("CLI boot", () => {
       ANTHROPIC_API_KEY: "",
       OPENAI_API_KEY: "",
       GEMINI_API_KEY: "",
+      VERTEX_AI_CREDENTIALS_PATH: "",
     });
     expect(result.exitCode).toBe(1);
-    expect(`${result.stdout}\n${result.stderr}`).toContain("API key");
+    // Helpful means naming a variable and a command to set it, not just saying
+    // that credentials are missing.
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(output).toContain("no provider credentials found");
+    expect(output).toMatch(/(export|set|\$env:)\s?ANTHROPIC_API_KEY/);
   });
 });
 

--- a/source/__tests__/startup.test.ts
+++ b/source/__tests__/startup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { AgavConfig } from "../config/config.js";
 import {
+  noProviderCredentialsError,
   providerConfigurationError,
   resolveStartupSelection,
   selectConfiguredProvider,
@@ -77,8 +78,31 @@ describe("startup provider and model resolution", () => {
     });
   });
 
+  it("keeps an explicit --model when falling back to another provider", () => {
+    expect(selectConfiguredProvider({ ...base, model: "gpt-4o", openaiApiKey: "key" }, { keepModel: true }))
+      .toMatchObject({ provider: "openai", model: "gpt-4o" });
+  });
+
+  it("enables Vertex AI from the credentials path alone", () => {
+    const config: AgavConfig = { ...base, provider: "vertex-ai", model: "vertex/gemini-3.5-flash" };
+    expect(providerConfigurationError(config)).toContain("VERTEX_AI_CREDENTIALS_PATH");
+    expect(providerConfigurationError({ ...config, vertexAICredentialsPath: "/tmp/sa.json" })).toBeNull();
+  });
+
+  it("names a runnable command for every provider when nothing is configured", () => {
+    const message = noProviderCredentialsError();
+    for (const variable of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "VERTEX_AI_CREDENTIALS_PATH"]) {
+      // The shell-specific prefix is covered by utils.shell-hints; here it only
+      // matters that each variable is shown as a command, not just named.
+      expect(message).toMatch(new RegExp(`(export|set|\\$env:)\\s?${variable}`));
+    }
+    expect(message).toContain("agav --provider ollama");
+  });
+
   it("reports the selected provider's exact missing configuration", () => {
-    expect(providerConfigurationError({ ...base, provider: "vertex-ai", model: "vertex/gemini" }))
-      .toContain("AGAV_USE_VERTEX_AI=true, VERTEX_AI_CREDENTIALS_PATH");
+    expect(providerConfigurationError({ ...base, anthropicApiKey: undefined }))
+      .toContain("ANTHROPIC_API_KEY");
+    expect(providerConfigurationError({ ...base, provider: "openai", openaiApiKey: undefined }))
+      .toContain("OPENAI_API_KEY");
   });
 });

--- a/source/__tests__/startup.test.ts
+++ b/source/__tests__/startup.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { AgavConfig } from "../config/config.js";
+import {
+  providerConfigurationError,
+  resolveStartupSelection,
+  selectConfiguredProvider,
+} from "../config/startup.js";
+
+const base: AgavConfig = {
+  provider: "anthropic",
+  model: "configured-claude",
+  effort: "high",
+  maxTokens: 1024,
+  maxIterations: 10,
+  errorRetries: 1,
+  permissionMode: "ask",
+};
+
+describe("startup provider and model resolution", () => {
+  it("keeps configured selection for plain startup", () => {
+    expect(resolveStartupSelection(base, {})).toMatchObject({
+      provider: "anthropic",
+      model: "configured-claude",
+    });
+  });
+
+  it("uses the selected provider default when --provider changes provider", () => {
+    expect(resolveStartupSelection(base, { cliProvider: "openai" })).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+    });
+  });
+
+  it("restores both provider and model from a resumed session", () => {
+    expect(resolveStartupSelection(base, {
+      session: { provider: "gemini", model: "gemini-session-model" },
+    })).toMatchObject({ provider: "gemini", model: "gemini-session-model" });
+  });
+
+  it("does not combine a CLI provider override with another provider's saved model", () => {
+    expect(resolveStartupSelection(base, {
+      cliProvider: "openai",
+      session: { provider: "anthropic", model: "claude-session-model" },
+    })).toMatchObject({ provider: "openai", model: "gpt-5.4-mini" });
+  });
+
+  it("retains the saved model when the CLI provider matches the session", () => {
+    expect(resolveStartupSelection(base, {
+      cliProvider: "anthropic",
+      session: { provider: "anthropic", model: "claude-session-model" },
+    })).toMatchObject({ provider: "anthropic", model: "claude-session-model" });
+  });
+
+  it("lets an explicit model override every default and saved model", () => {
+    expect(resolveStartupSelection(base, {
+      cliProvider: "openai",
+      cliModel: "custom-openai-model",
+      session: { provider: "anthropic", model: "claude-session-model" },
+    })).toMatchObject({ provider: "openai", model: "custom-openai-model" });
+  });
+
+  it("rejects an unsupported saved provider unless the CLI replaces it", () => {
+    expect(() => resolveStartupSelection(base, {
+      session: { provider: "removed-provider", model: "old-model" },
+    })).toThrow("Saved session uses unsupported provider");
+
+    expect(resolveStartupSelection(base, {
+      cliProvider: "gemini",
+      session: { provider: "removed-provider", model: "old-model" },
+    })).toMatchObject({ provider: "gemini", model: "gemini-3.5-flash-lite" });
+  });
+
+  it("auto-selects an available provider only for an unpinned startup", () => {
+    expect(selectConfiguredProvider({ ...base, openaiApiKey: "key" })).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+    });
+  });
+
+  it("reports the selected provider's exact missing configuration", () => {
+    expect(providerConfigurationError({ ...base, provider: "vertex-ai", model: "vertex/gemini" }))
+      .toContain("AGAV_USE_VERTEX_AI=true, VERTEX_AI_CREDENTIALS_PATH");
+  });
+});

--- a/source/__tests__/utils.shell-hints.test.ts
+++ b/source/__tests__/utils.shell-hints.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { agavHomePath, reinstallHint, setEnvHint } from "../utils/shell-hints.js";
+import { agavHomePath, examplePath, reinstallHint, setEnvHint } from "../utils/shell-hints.js";
 
 const SHELL_VARS = ["PSModulePath", "PROMPT", "MSYSTEM", "SHELL"] as const;
 
@@ -40,6 +40,7 @@ describe("shell hints", () => {
     withShell("linux", {}, () => {
       expect(setEnvHint("GEMINI_API_KEY", "test-key")).toBe('export GEMINI_API_KEY="test-key"');
       expect(agavHomePath("config.json")).toBe("~/.agav/config.json");
+      expect(examplePath("path", "to", "service-account.json")).toBe("/path/to/service-account.json");
       expect(reinstallHint()).toBe("curl -fsSL https://agav.dev/install.sh | bash");
     });
   });
@@ -48,6 +49,7 @@ describe("shell hints", () => {
     withShell("win32", { PSModulePath: PS_MODULE_PATH }, () => {
       expect(setEnvHint("GEMINI_API_KEY", "test-key")).toBe('$env:GEMINI_API_KEY="test-key"');
       expect(agavHomePath("skills/example")).toBe("$HOME\\.agav\\skills\\example");
+      expect(examplePath("path", "to", "service-account.json")).toBe("C:\\path\\to\\service-account.json");
       expect(reinstallHint()).toBe("irm https://agav.dev/install.ps1 | iex");
     });
   });
@@ -56,6 +58,7 @@ describe("shell hints", () => {
     withShell("win32", { PROMPT: "C:\\Users\\x>" }, () => {
       expect(setEnvHint("GEMINI_API_KEY", "test-key")).toBe("set GEMINI_API_KEY=test-key");
       expect(agavHomePath("config.json")).toBe("%USERPROFILE%\\.agav\\config.json");
+      expect(examplePath("path", "to", "service-account.json")).toBe("C:\\path\\to\\service-account.json");
       expect(reinstallHint()).toBe("curl -fsSL https://agav.dev/install.cmd -o install.cmd && install.cmd");
     });
   });

--- a/source/agent/conversation.ts
+++ b/source/agent/conversation.ts
@@ -117,18 +117,36 @@ export class ConversationState {
       }
     }
     return messages.map((msg) => {
-      if (msg.role === "user") {
-        const filtered = msg.content.filter((block) => {
-          if (block.type === "tool_result" && block.toolCallId) {
-            return toolCallIds.has(block.toolCallId);
-          }
-          return true;
-        });
-        if (filtered.length === 0) return null;
-        return { ...msg, content: filtered };
-      }
-      return msg;
+      const filtered = msg.content.filter((block) => {
+        // Providers reject an empty text block outright, so one saved into a
+        // session file would make every later request fail until the session
+        // was abandoned. Drop it here and the session loads clean again.
+        if (block.type === "text" && !block.text?.trim()) return false;
+        if (msg.role === "user" && block.type === "tool_result" && block.toolCallId) {
+          return toolCallIds.has(block.toolCallId);
+        }
+        return true;
+      });
+      if (filtered.length === 0) return null;
+      if (filtered.length === msg.content.length) return msg;
+      return { ...msg, content: filtered };
     }).filter((msg): msg is Message => msg !== null);
+  }
+
+  /**
+   * Walk a split point backwards until it no longer cuts a tool cycle in half.
+   * Both halves are used as standalone conversations — the dropped half is sent
+   * off to be summarized, the kept half becomes the new history — and providers
+   * reject either one if a tool_result has lost its tool_use. Moving the
+   * boundary onto the assistant turn that opened the cycle keeps the pair
+   * together on the same side.
+   */
+  private safeSplitPoint(index: number): number {
+    let split = index;
+    while (split > 0 && this.messages[split]!.content.some((block) => block.type === "tool_result")) {
+      split--;
+    }
+    return split;
   }
 
   private trimToolResults(targetTokens: number, preserveRecent: number): number {
@@ -190,6 +208,7 @@ export class ConversationState {
 
     // Keep at least the last 4 messages
     keepFrom = Math.min(keepFrom, Math.max(0, this.messages.length - 4));
+    keepFrom = this.safeSplitPoint(keepFrom);
 
     if (keepFrom <= 0) {
       return { compacted: false, droppedCount: 0 };
@@ -199,24 +218,28 @@ export class ConversationState {
     const droppedMessages = this.messages.slice(0, keepFrom);
     const userMsgCount = droppedMessages.filter((m) => m.role === "user").length;
 
-    let summaryText: string;
+    const placeholder = `[Earlier conversation (${userMsgCount} exchanges) was compacted to save context. Continue from here.]`;
+    let summaryText = placeholder;
 
     if (summarize) {
       try {
         summaryText = await summarize(droppedMessages);
       } catch {
-        summaryText = `[Earlier conversation (${userMsgCount} exchanges) was compacted to save context. Continue from here.]`;
+        summaryText = placeholder;
       }
-    } else {
-      summaryText = `[Earlier conversation (${userMsgCount} exchanges) was compacted to save context. Continue from here.]`;
     }
+
+    // A blank summary would become an empty text block, which providers reject
+    // outright ("text content blocks must be non-empty") — so every message
+    // sent after the compaction fails, not just this one.
+    if (!summaryText.trim()) summaryText = placeholder;
 
     const summary: Message = {
       role: "user",
       content: [{ type: "text", text: summaryText }],
     };
 
-    this.messages = [summary, ...this.messages.slice(keepFrom)];
+    this.messages = this.sanitizeMessages([summary, ...this.messages.slice(keepFrom)]);
     this._compacted = true;
     this._lastCompactionSummary = summaryText;
 

--- a/source/agent/loop.test.ts
+++ b/source/agent/loop.test.ts
@@ -120,6 +120,39 @@ describe("runAgentLoop", () => {
     expect(provider.stream).toHaveBeenCalledTimes(1);
   });
 
+  it("persists provider metadata returned with a tool call", async () => {
+    const provider = new MockProvider([
+      [
+        { type: "tool_call_start", toolCallId: "call-1", toolName: "lookup" },
+        {
+          type: "tool_call_delta",
+          toolCallId: "call-1",
+          argsJson: "{}",
+          providerMetadata: { vertexAIThoughtSignature: "opaque-signature" },
+        },
+        { type: "tool_call_end", toolCallId: "call-1" },
+        { type: "message_end", stopReason: "tool_calls" },
+      ],
+      [
+        { type: "text_delta", text: "done" },
+        { type: "message_end", stopReason: "stop" },
+      ],
+    ]);
+    const conversation = new ConversationState();
+    conversation.addUserMessage("look it up");
+    const tools = new ToolRegistry();
+    tools.register(createTool("lookup", async () => ({ output: "result", isError: false })));
+
+    await collectEvents(runAgentLoop({ provider, conversation, toolRegistry: tools, model: "m" }));
+
+    const toolUse = conversation.getMessages()[1]?.content[0];
+    expect(toolUse).toMatchObject({
+      type: "tool_use",
+      toolCallId: "call-1",
+      providerMetadata: { vertexAIThoughtSignature: "opaque-signature" },
+    });
+  });
+
   it("executes safe tools and continues into a follow-up provider turn", async () => {
     const execute = vi.fn(async (input: Record<string, unknown>) => ({
       output: `read:${String(input.path)}`,
@@ -382,6 +415,61 @@ describe("runAgentLoop", () => {
       type: "tool_result",
       toolName: "write_file",
       output: "Write operations are denied (--deny-writes mode).",
+      isError: true,
+    });
+  });
+
+  it("denies write tools without confirmation handler in headless mode", async () => {
+    const execute = vi.fn(async () => ({
+      output: "should not run",
+      isError: false,
+    }));
+
+    const provider = new MockProvider([
+      [
+        {
+          type: "tool_call_start",
+          toolCallId: "write-1",
+          toolName: "write_file",
+        },
+        {
+          type: "tool_call_delta",
+          toolCallId: "write-1",
+          argsJson: '{"path":"blocked.txt","content":"x"}',
+        },
+        { type: "message_end", stopReason: "tool_use" },
+      ],
+      [
+        { type: "text_delta", text: "cannot do that" },
+        { type: "message_end", stopReason: "end_turn" },
+      ],
+    ]);
+
+    const conversation = new ConversationState();
+    conversation.setModel("gpt-4");
+    conversation.addUserMessage("write file");
+
+    const toolRegistry = new ToolRegistry();
+    toolRegistry.register(createTool("write_file", execute));
+
+    // No confirmTool provided — simulates headless/pipe mode.
+    // Default permissionMode is "ask", so without a handler there is no way
+    // to approve the tool; it must be denied rather than silently executed.
+    const events = await collectEvents(
+      runAgentLoop({
+        provider,
+        conversation,
+        toolRegistry,
+        model: "gpt-4",
+        // confirmTool intentionally omitted (headless mode)
+      }),
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(events).toContainEqual({
+      type: "tool_result",
+      toolName: "write_file",
+      output: "Tool 'write_file' requires confirmation but no confirmation handler is available (headless mode).",
       isError: true,
     });
   });

--- a/source/agent/loop.test.ts
+++ b/source/agent/loop.test.ts
@@ -474,6 +474,90 @@ describe("runAgentLoop", () => {
     });
   });
 
+  describe("destructive commands in headless mode", () => {
+    const DESTRUCTIVE = "git clean -fdx";
+
+    const runDestructive = async (
+      execute: ReturnType<typeof vi.fn>,
+      params: { allowedTools?: string[]; permissionMode?: "ask" | "auto-accept" | "deny-writes" },
+    ) => {
+      const provider = new MockProvider([
+        [
+          { type: "tool_call_start", toolCallId: "cmd-1", toolName: "run_command" },
+          {
+            type: "tool_call_delta",
+            toolCallId: "cmd-1",
+            argsJson: JSON.stringify({ command: DESTRUCTIVE }),
+          },
+          { type: "message_end", stopReason: "tool_use" },
+        ],
+        [
+          { type: "text_delta", text: "done" },
+          { type: "message_end", stopReason: "end_turn" },
+        ],
+      ]);
+
+      const conversation = new ConversationState();
+      conversation.setModel("gpt-4");
+      conversation.addUserMessage("clean the tree");
+
+      const toolRegistry = new ToolRegistry();
+      toolRegistry.register(createTool("run_command", execute));
+
+      // confirmTool intentionally omitted throughout — this is headless mode.
+      return collectEvents(
+        runAgentLoop({ provider, conversation, toolRegistry, model: "gpt-4", ...params }),
+      );
+    };
+
+    it("runs one when the allowlist names it", async () => {
+      const execute = vi.fn(async () => ({ output: "cleaned", isError: false }));
+
+      await runDestructive(execute, { allowedTools: [`run_command:${DESTRUCTIVE}`] });
+
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("still blocks one behind a blanket run_command grant", async () => {
+      const execute = vi.fn(async () => ({ output: "should not run", isError: false }));
+
+      const events = await runDestructive(execute, { allowedTools: ["run_command"] });
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(events).toContainEqual({
+        type: "tool_result",
+        toolName: "run_command",
+        output: "Tool 'run_command' requires confirmation but no confirmation handler is available (headless mode).",
+        isError: true,
+      });
+    });
+
+    it("still blocks one under --auto-accept", async () => {
+      const execute = vi.fn(async () => ({ output: "should not run", isError: false }));
+
+      await runDestructive(execute, { permissionMode: "auto-accept" });
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("lets --deny-writes outrank a naming allowlist rule", async () => {
+      const execute = vi.fn(async () => ({ output: "should not run", isError: false }));
+
+      const events = await runDestructive(execute, {
+        allowedTools: [`run_command:${DESTRUCTIVE}`],
+        permissionMode: "deny-writes",
+      });
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(events).toContainEqual({
+        type: "tool_result",
+        toolName: "run_command",
+        output: "Write operations are denied (--deny-writes mode).",
+        isError: true,
+      });
+    });
+  });
+
   it("handles invalid tool JSON by passing raw input through to the registry", async () => {
     const execute = vi.fn(async (input: Record<string, unknown>) => ({
       output: JSON.stringify(input),

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -54,7 +54,7 @@ interface LoopParams {
   hooks?: import("../config/config.js").AgavHooks;
 }
 
-const SAFE_TOOLS = new Set(["read_file", "grep_search", "find_files", "list_directory", "web_search", "lsp_query", "read_notebook", "fetch_url", "overview", "activate_skill", "save_memory"]);
+const SAFE_TOOLS = new Set(["read_file", "grep_search", "find_files", "list_directory", "web_search", "lsp_query", "read_notebook", "fetch_url", "overview", "activate_skill", "save_memory", "update_plan"]);
 
 function isAllowed(
   toolName: string,
@@ -165,7 +165,7 @@ export async function* runAgentLoop(
     let textAccum = "";
     const toolCalls = new Map<
       string,
-      { name: string; argsJson: string }
+      { name: string; argsJson: string; providerMetadata?: Record<string, unknown> }
     >();
     let stopReason = "";
 
@@ -210,11 +210,16 @@ export async function* runAgentLoop(
             const call = toolCalls.get(event.toolCallId);
             if (call) {
               call.argsJson += event.argsJson;
-              yield {
-                type: "tool_call_input_delta",
-                toolCallId: event.toolCallId,
-                argsJson: event.argsJson,
-              };
+              if (event.providerMetadata) {
+                call.providerMetadata = { ...call.providerMetadata, ...event.providerMetadata };
+              }
+              if (event.argsJson) {
+                yield {
+                  type: "tool_call_input_delta",
+                  toolCallId: event.toolCallId,
+                  argsJson: event.argsJson,
+                };
+              }
             }
             break;
           }
@@ -269,6 +274,7 @@ export async function* runAgentLoop(
         toolCallId: id,
         toolName: call.name,
         toolInput: input,
+        ...(call.providerMetadata ? { providerMetadata: call.providerMetadata } : {}),
       });
     }
     conversation.addAssistantMessage(assistantContent);
@@ -322,9 +328,12 @@ export async function* runAgentLoop(
         || (!SAFE_TOOLS.has(call.name)
           && permissionMode !== "auto-accept"
           && !isAllowed(call.name, input, params.allowedTools));
-      if (needsConfirm && permissionMode === "deny-writes") {
-        toolResults.push({ type: "tool_result", toolCallId: id, toolResult: "Write operations are denied (--deny-writes mode).", isError: true });
-        yield { type: "tool_result", toolName: call.name, output: "Write operations are denied (--deny-writes mode).", isError: true };
+      if (needsConfirm && (permissionMode === "deny-writes" || !confirmTool)) {
+        const reason = permissionMode === "deny-writes"
+          ? "Write operations are denied (--deny-writes mode)."
+          : `Tool '${call.name}' requires confirmation but no confirmation handler is available (headless mode).`;
+        toolResults.push({ type: "tool_result", toolCallId: id, toolResult: reason, isError: true });
+        yield { type: "tool_result", toolName: call.name, output: reason, isError: true };
         continue;
       }
       if (needsConfirm && confirmTool) {

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -54,12 +54,22 @@ interface LoopParams {
   hooks?: import("../config/config.js").AgavHooks;
 }
 
+// Tools that never need confirmation because they cannot modify the working
+// tree or reach outside the session. `save_memory` and `update_plan` write only
+// to Agav's own state — the plan is in-memory scratch space the model rewrites
+// constantly, so prompting for it would make every turn unusable.
 const SAFE_TOOLS = new Set(["read_file", "grep_search", "find_files", "list_directory", "web_search", "lsp_query", "read_notebook", "fetch_url", "overview", "activate_skill", "save_memory", "update_plan"]);
 
 function isAllowed(
   toolName: string,
   input: Record<string, unknown>,
   allowedTools?: string[],
+  /**
+   * When set, a bare `run_command` rule no longer matches — only a rule that
+   * names the input, such as `run_command:rm -rf build/*`. Used so a blanket
+   * grant cannot quietly authorise a destructive command.
+   */
+  options: { requirePattern?: boolean } = {},
 ): boolean {
   if (!allowedTools || allowedTools.length === 0) return false;
 
@@ -71,7 +81,7 @@ function isAllowed(
 
   for (const rule of allowedTools) {
     if (!rule.includes(":")) {
-      if (rule === toolName) return true;
+      if (!options.requirePattern && rule === toolName) return true;
       continue;
     }
     const colonIdx = rule.indexOf(":");
@@ -335,12 +345,22 @@ export async function* runAgentLoop(
       }
 
       const isDestructive = call.name === "run_command" && isDestructiveCommand(String(input.command ?? ""));
-      const needsConfirm = isDestructive
+      // Escape hatch for headless runs: a destructive command may be run
+      // unattended only when the allowlist names it (`run_command:rm -rf dist`).
+      // --auto-accept and a blanket `run_command` grant deliberately do not
+      // qualify, but without this there was no way to approve one at all and
+      // CI pipelines that legitimately clean a build directory just failed.
+      const destructiveApproved = isDestructive
+        && isAllowed(call.name, input, params.allowedTools, { requirePattern: true });
+      const denyWrites = permissionMode === "deny-writes";
+      const needsConfirm = (isDestructive && !destructiveApproved)
         || (!SAFE_TOOLS.has(call.name)
           && permissionMode !== "auto-accept"
           && !isAllowed(call.name, input, params.allowedTools));
-      if (needsConfirm && (permissionMode === "deny-writes" || !confirmTool)) {
-        const reason = permissionMode === "deny-writes"
+      // --deny-writes outranks the allowlist: the escape hatch must not be able
+      // to punch a destructive command through an explicit "no writes" run.
+      if ((denyWrites && isDestructive) || (needsConfirm && (denyWrites || !confirmTool))) {
+        const reason = denyWrites
           ? "Write operations are denied (--deny-writes mode)."
           : `Tool '${call.name}' requires confirmation but no confirmation handler is available (headless mode).`;
         toolResults.push({ type: "tool_result", toolCallId: id, toolResult: reason, isError: true });

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -64,10 +64,10 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   const [config, setConfig] = useState(initialConfig);
   const activeProvider = useMemo<LLMProvider | null>(() => {
     try { return createProvider(config); } catch { return null; }
-  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.AGAV_USE_VERTEX_AI, config.VERTEX_AI_CREDENTIALS_PATH, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
+  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.vertexAICredentialsPath, config.vertexAILocation, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
   const activeSideProvider = useMemo<LLMProvider | null>(() => {
     try { return createProvider(config); } catch { return null; }
-  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.AGAV_USE_VERTEX_AI, config.VERTEX_AI_CREDENTIALS_PATH, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
+  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.vertexAICredentialsPath, config.vertexAILocation, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
   const [showToolDetail, setShowToolDetail] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [focusedSubagentId, setFocusedSubagentId] = useState<string | null>(null);

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -62,10 +62,10 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   const [config, setConfig] = useState(initialConfig);
   const activeProvider = useMemo<LLMProvider | null>(() => {
     try { return createProvider(config); } catch { return null; }
-  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
+  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.AGAV_USE_VERTEX_AI, config.VERTEX_AI_CREDENTIALS_PATH, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
   const activeSideProvider = useMemo<LLMProvider | null>(() => {
     try { return createProvider(config); } catch { return null; }
-  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
+  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.AGAV_USE_VERTEX_AI, config.VERTEX_AI_CREDENTIALS_PATH, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
   const [showToolDetail, setShowToolDetail] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [focusedSubagentId, setFocusedSubagentId] = useState<string | null>(null);
@@ -180,7 +180,38 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
     setPsLoading(true);
     setPsResponse(undefined);
     try {
-      const historyMessages = conversation.getMessages();
+      // Strip any trailing incomplete tool-use turns from the history snapshot.
+      // When /ps is issued while the agent is running, the conversation may
+      // contain an in-progress assistant message with tool_use blocks whose
+      // tool_result blocks have not been added yet. Sending such a sequence to
+      // Vertex AI Claude (and the Anthropic API) violates the protocol rule
+      // "each tool_use must be immediately followed by a tool_result", causing
+      // a 400 error. Walk backwards and drop any trailing assistant message
+      // whose tool_use IDs are not answered by the very next user message.
+      const rawHistory = conversation.getMessages();
+      const answeredToolIds = new Set<string>();
+      for (const msg of rawHistory) {
+        if (msg.role === "user") {
+          for (const block of msg.content) {
+            if (block.type === "tool_result" && block.toolCallId) {
+              answeredToolIds.add(block.toolCallId);
+            }
+          }
+        }
+      }
+      // If the last assistant message has unanswered tool_use blocks (in-flight
+      // tool calls), drop it and everything after it before sending as context.
+      let historyMessages = rawHistory;
+      for (let i = rawHistory.length - 1; i >= 0; i--) {
+        const msg = rawHistory[i]!;
+        if (msg.role === "assistant") {
+          const hasUnanswered = msg.content.some(
+            (block) => block.type === "tool_use" && block.toolCallId && !answeredToolIds.has(block.toolCallId),
+          );
+          if (hasUnanswered) historyMessages = rawHistory.slice(0, i);
+          break;
+        }
+      }
       const psQuestion: Message = { role: "user", content: [{ type: "text", text: `[SIDE QUESTION — answer ONLY this, do not continue the main conversation]\n${query.text}` }, ...query.blocks] };
       let response = "";
       for await (const event of activeSideProvider.stream({

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -9,4 +9,10 @@ if ("Bun" in globalThis) {
 
 import { main } from "./main.js";
 
-await main();
+try {
+  await main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`\n  Agav — startup failed: ${message}\n\n`);
+  process.exitCode = 1;
+}

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -7,12 +7,15 @@ if ("Bun" in globalThis) {
   process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
 }
 
-import { main } from "./main.js";
+import { hasStartupFinished, main } from "./main.js";
 
 try {
   await main();
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`\n  Agav — startup failed: ${message}\n\n`);
+  // Anything thrown after startup is a session failure; calling it a startup
+  // failure sent people off auditing their config for unrelated crashes.
+  const stage = hasStartupFinished() ? "failed" : "startup failed";
+  process.stderr.write(`\n  Agav — ${stage}: ${message}\n\n`);
   process.exitCode = 1;
 }

--- a/source/commands/compact.ts
+++ b/source/commands/compact.ts
@@ -11,6 +11,10 @@ export const compactCommand: SlashCommand = {
     context.showStatus("Compacting conversation...");
 
     let summarize: ((msgs: import("../providers/types.js").Message[]) => Promise<string>) | undefined;
+    // Why the summary is missing, when it is. Compaction still succeeds with a
+    // placeholder, but silently discarding the history the user asked to have
+    // summarized is worth saying out loud.
+    let summarizeError: string | undefined;
 
     if (context.provider) {
       const provider = context.provider;
@@ -42,10 +46,15 @@ export const compactCommand: SlashCommand = {
               });
             }
           }
-        } catch {
-          return "";
+        } catch (error) {
+          summarizeError = error instanceof Error ? error.message : String(error);
+          throw error;
         }
-        return result || "";
+        if (!result.trim()) {
+          summarizeError = "the model returned an empty summary";
+          throw new Error(summarizeError);
+        }
+        return result;
       };
     }
 
@@ -62,6 +71,15 @@ export const compactCommand: SlashCommand = {
     context.refreshDisplay();
 
     const after = context.conversation.tokenCount;
+
+    if (summarizeError) {
+      return {
+        type: "message",
+        text: `\x1b[33mCompacted ${droppedCount} messages without a summary (${summarizeError}). `
+          + `Those messages are gone from context — ~${before} → ~${after} tokens.\x1b[0m`,
+      };
+    }
+
     return {
       type: "message",
       text: `\x1b[2mCompacted: ${droppedCount} messages summarized, ~${before} → ~${after} tokens (Ctrl+O to see full summary)\x1b[0m`,

--- a/source/commands/history.ts
+++ b/source/commands/history.ts
@@ -1,5 +1,6 @@
 import type { SlashCommand, CommandResult, CommandContext } from "./types.js";
 import { listSessions, loadSession } from "../config/history.js";
+import { isProviderName } from "../config/startup.js";
 
 /** List saved sessions or load one into the active conversation. */
 export const historyCommand: SlashCommand = {
@@ -24,7 +25,7 @@ export const historyCommand: SlashCommand = {
       }
       context.loadSession(loaded);
       context.setModel(loaded.model || context.config.model);
-      if (loaded.provider === "anthropic" || loaded.provider === "openai" || loaded.provider === "ollama" || loaded.provider === "gemini" || loaded.provider === "vertex-ai") {
+      if (isProviderName(loaded.provider)) {
         context.setProvider(loaded.provider);
       }
       return {

--- a/source/commands/history.ts
+++ b/source/commands/history.ts
@@ -24,7 +24,7 @@ export const historyCommand: SlashCommand = {
       }
       context.loadSession(loaded);
       context.setModel(loaded.model || context.config.model);
-      if (loaded.provider === "anthropic" || loaded.provider === "openai" || loaded.provider === "ollama") {
+      if (loaded.provider === "anthropic" || loaded.provider === "openai" || loaded.provider === "ollama" || loaded.provider === "gemini" || loaded.provider === "vertex-ai") {
         context.setProvider(loaded.provider);
       }
       return {

--- a/source/commands/model-routing.ts
+++ b/source/commands/model-routing.ts
@@ -5,6 +5,7 @@ const FAST_MODELS: Record<string, string> = {
   anthropic: "claude-haiku-4-5-20251001",
   openai: "gpt-4o-mini",
   gemini: "gemini-3.5-flash-lite",
+  "vertex-ai": "vertex/gemini-3.7-flash",
 }
 
 /** Default deep-model choices keyed by provider name. */
@@ -12,6 +13,7 @@ const DEEP_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-20250514",
   openai: "gpt-4o",
   gemini: "gemini-3.5-pro",
+  "vertex-ai": "vertex/gemini-3.1-pro",
 }
 
 /** Switch to the configured fast model for the active provider. */

--- a/source/commands/model-routing.ts
+++ b/source/commands/model-routing.ts
@@ -5,7 +5,7 @@ const FAST_MODELS: Record<string, string> = {
   anthropic: "claude-haiku-4-5-20251001",
   openai: "gpt-4o-mini",
   gemini: "gemini-3.5-flash-lite",
-  "vertex-ai": "vertex/gemini-3.7-flash",
+  "vertex-ai": "vertex/gemini-3.5-flash-lite",
 }
 
 /** Default deep-model choices keyed by provider name. */
@@ -13,7 +13,7 @@ const DEEP_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-20250514",
   openai: "gpt-4o",
   gemini: "gemini-3.5-pro",
-  "vertex-ai": "vertex/gemini-3.1-pro",
+  "vertex-ai": "vertex/gemini-3.5-pro",
 }
 
 /** Switch to the configured fast model for the active provider. */

--- a/source/commands/model.ts
+++ b/source/commands/model.ts
@@ -1,4 +1,5 @@
 import type { SlashCommand, CommandResult, CommandContext } from "./types.js"
+import { fetchVertexAIModels } from "../providers/vertex-ai.js";
 
 interface FetchedModel {
   id: string;
@@ -68,6 +69,14 @@ async function fetchGeminiModels(apiKey: string): Promise<FetchedModel[]> {
       .filter((m) => m.supportedGenerationMethods?.includes("generateContent"))
       .map((m) => ({ id: m.name.replace("models/", ""), provider: "gemini" }))
       .sort((a, b) => a.id.localeCompare(b.id));
+  } catch {
+    return [];
+  }
+}
+
+async function fetchVertexModels(credentialsPath: string): Promise<FetchedModel[]> {
+  try {
+    return (await fetchVertexAIModels(credentialsPath)).map((id) => ({ id, provider: "vertex-ai" }));
   } catch {
     return [];
   }
@@ -230,6 +239,9 @@ export const modelCommand: SlashCommand = {
       if (context.config.anthropicApiKey) fetches.push(fetchAnthropicModels(context.config.anthropicApiKey));
       if (context.config.openaiApiKey) fetches.push(fetchOpenAIModels(context.config.openaiApiKey));
       if (context.config.geminiApiKey) fetches.push(fetchGeminiModels(context.config.geminiApiKey));
+      if (context.config.AGAV_USE_VERTEX_AI && context.config.VERTEX_AI_CREDENTIALS_PATH) {
+        fetches.push(fetchVertexModels(context.config.VERTEX_AI_CREDENTIALS_PATH));
+      }
       const ollamaBase = context.config.ollamaEndpoint ?? `http://${context.config.ollamaHost ?? "localhost"}:${context.config.ollamaPort ?? 11434}`;
       fetches.push(fetchOllamaModels(ollamaBase));
 
@@ -267,6 +279,9 @@ export const modelCommand: SlashCommand = {
     if (context.config.geminiApiKey) {
       fetches.push(fetchGeminiModels(context.config.geminiApiKey));
     }
+    if (context.config.AGAV_USE_VERTEX_AI && context.config.VERTEX_AI_CREDENTIALS_PATH) {
+      fetches.push(fetchVertexModels(context.config.VERTEX_AI_CREDENTIALS_PATH));
+    }
 
     const ollamaBase = context.config.ollamaEndpoint ??
       `http://${context.config.ollamaHost ?? "localhost"}:${context.config.ollamaPort ?? 11434}`;
@@ -278,7 +293,7 @@ export const modelCommand: SlashCommand = {
     if (allModels.length === 0) {
       return {
         type: "message",
-        text: `Current: ${currentModel} (${currentProvider})\n\nNo providers reachable. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, or start Ollama.`,
+        text: `Current: ${currentModel} (${currentProvider})\n\nNo providers reachable. Set an API key, configure Vertex AI, or start Ollama.`,
       };
     }
 

--- a/source/commands/model.ts
+++ b/source/commands/model.ts
@@ -1,4 +1,6 @@
 import type { SlashCommand, CommandResult, CommandContext } from "./types.js"
+import type { AgavConfig } from "../config/config.js";
+import { providerSetupHints } from "../config/startup.js";
 import { fetchVertexAIModels } from "../providers/vertex-ai.js";
 
 interface FetchedModel {
@@ -74,12 +76,52 @@ async function fetchGeminiModels(apiKey: string): Promise<FetchedModel[]> {
   }
 }
 
-async function fetchVertexModels(credentialsPath: string): Promise<FetchedModel[]> {
+async function fetchVertexModels(
+  credentialsPath: string,
+  location: string | undefined,
+  warnings: string[],
+): Promise<FetchedModel[]> {
   try {
-    return (await fetchVertexAIModels(credentialsPath)).map((id) => ({ id, provider: "vertex-ai" }));
-  } catch {
+    return (await fetchVertexAIModels(credentialsPath, location)).map((id) => ({ id, provider: "vertex-ai" }));
+  } catch (error) {
+    // Unlike the API-key providers, Vertex fails for reasons the user can act
+    // on — an unreadable key file, a wrong region, a project without model
+    // access. Swallowing that just shows a picker with no Vertex entries, which
+    // reads as "this provider has no models" rather than "it is misconfigured".
+    warnings.push(`Vertex AI models unavailable: ${error instanceof Error ? error.message : String(error)}`);
     return [];
   }
+}
+
+interface FetchAllResult {
+  models: FetchedModel[];
+  /** Actionable problems to append to whatever the command reports back. */
+  warnings: string[];
+}
+
+/** Query every configured provider at once, in the order they appear in the picker. */
+async function fetchAllModels(config: AgavConfig): Promise<FetchAllResult> {
+  const warnings: string[] = [];
+  const fetches: Promise<FetchedModel[]>[] = [];
+
+  if (config.anthropicApiKey) fetches.push(fetchAnthropicModels(config.anthropicApiKey));
+  if (config.openaiApiKey) fetches.push(fetchOpenAIModels(config.openaiApiKey));
+  if (config.geminiApiKey) fetches.push(fetchGeminiModels(config.geminiApiKey));
+  if (config.vertexAICredentialsPath) {
+    fetches.push(fetchVertexModels(config.vertexAICredentialsPath, config.vertexAILocation, warnings));
+  }
+
+  const ollamaBase = config.ollamaEndpoint ??
+    `http://${config.ollamaHost ?? "localhost"}:${config.ollamaPort ?? 11434}`;
+  fetches.push(fetchOllamaModels(ollamaBase));
+
+  const results = await Promise.all(fetches);
+  return { models: results.flat(), warnings };
+}
+
+/** Render warnings as a trailing block, or nothing at all when there are none. */
+function warningSuffix(warnings: string[]): string {
+  return warnings.length > 0 ? `\n\n${warnings.join("\n")}` : "";
 }
 
 function pickModel(
@@ -235,24 +277,18 @@ export const modelCommand: SlashCommand = {
 
     if (model) {
       context.showStatus(`Validating model: ${model}...`);
-      const fetches: Promise<FetchedModel[]>[] = [];
-      if (context.config.anthropicApiKey) fetches.push(fetchAnthropicModels(context.config.anthropicApiKey));
-      if (context.config.openaiApiKey) fetches.push(fetchOpenAIModels(context.config.openaiApiKey));
-      if (context.config.geminiApiKey) fetches.push(fetchGeminiModels(context.config.geminiApiKey));
-      if (context.config.AGAV_USE_VERTEX_AI && context.config.VERTEX_AI_CREDENTIALS_PATH) {
-        fetches.push(fetchVertexModels(context.config.VERTEX_AI_CREDENTIALS_PATH));
-      }
-      const ollamaBase = context.config.ollamaEndpoint ?? `http://${context.config.ollamaHost ?? "localhost"}:${context.config.ollamaPort ?? 11434}`;
-      fetches.push(fetchOllamaModels(ollamaBase));
-
-      const results = await Promise.all(fetches);
-      const allModels = results.flat();
+      const { models: allModels, warnings } = await fetchAllModels(context.config);
       const match = allModels.find((m) => m.id === model);
 
       if (!match && allModels.length > 0) {
         const close = allModels.filter((m) => m.id.includes(model) || model.includes(m.id)).slice(0, 3);
         const hint = close.length > 0 ? `\nDid you mean: ${close.map((m) => m.id).join(", ")}?` : "";
-        return { type: "message", text: `Model '${model}' not found.${hint}\nUse /model to browse available models.` };
+        // The warnings matter most here: a Vertex model looks "not found" when
+        // the listing that would have contained it never came back.
+        return {
+          type: "message",
+          text: `Model '${model}' not found.${hint}\nUse /model to browse available models.${warningSuffix(warnings)}`,
+        };
       }
 
       context.setModel(model);
@@ -268,32 +304,12 @@ export const modelCommand: SlashCommand = {
     const currentModel = context.config.model;
     const currentProvider = context.config.provider;
 
-    const fetches: Promise<FetchedModel[]>[] = [];
-
-    if (context.config.anthropicApiKey) {
-      fetches.push(fetchAnthropicModels(context.config.anthropicApiKey));
-    }
-    if (context.config.openaiApiKey) {
-      fetches.push(fetchOpenAIModels(context.config.openaiApiKey));
-    }
-    if (context.config.geminiApiKey) {
-      fetches.push(fetchGeminiModels(context.config.geminiApiKey));
-    }
-    if (context.config.AGAV_USE_VERTEX_AI && context.config.VERTEX_AI_CREDENTIALS_PATH) {
-      fetches.push(fetchVertexModels(context.config.VERTEX_AI_CREDENTIALS_PATH));
-    }
-
-    const ollamaBase = context.config.ollamaEndpoint ??
-      `http://${context.config.ollamaHost ?? "localhost"}:${context.config.ollamaPort ?? 11434}`;
-    fetches.push(fetchOllamaModels(ollamaBase));
-
-    const results = await Promise.all(fetches);
-    const allModels = results.flat();
+    const { models: allModels, warnings } = await fetchAllModels(context.config);
 
     if (allModels.length === 0) {
       return {
         type: "message",
-        text: `Current: ${currentModel} (${currentProvider})\n\nNo providers reachable. Set an API key, configure Vertex AI, or start Ollama.`,
+        text: `Current: ${currentModel} (${currentProvider})\n\nNo providers reachable.\n${providerSetupHints()}${warningSuffix(warnings)}`,
       };
     }
 
@@ -303,11 +319,11 @@ export const modelCommand: SlashCommand = {
     context.refreshDisplay();
 
     if (!picked) {
-      return { type: "message", text: `Kept model as ${currentModel}` };
+      return { type: "message", text: `Kept model as ${currentModel}${warningSuffix(warnings)}` };
     }
 
     context.setModel(picked.id);
-    context.setProvider(picked.provider as import("../config/config.js").AgavConfig["provider"]);
-    return { type: "message", text: `Model changed to: ${picked.id} (${picked.provider})` };
+    context.setProvider(picked.provider as AgavConfig["provider"]);
+    return { type: "message", text: `Model changed to: ${picked.id} (${picked.provider})${warningSuffix(warnings)}` };
   },
 };

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -29,8 +29,8 @@ export interface AgavConfig {
   openaiApiKey?: string;
   openaiApi?: "chat" | "responses";
   geminiApiKey?: string;
-  AGAV_USE_VERTEX_AI?: boolean;
-  VERTEX_AI_CREDENTIALS_PATH?: string;
+  vertexAICredentialsPath?: string;
+  vertexAILocation?: string;
   ollamaEndpoint?: string;  // e.g. "http://192.168.1.5:11434" — takes precedence over host+port
   ollamaHost?: string;
   ollamaPort?: number;
@@ -50,6 +50,18 @@ export interface AgavConfig {
 
 const AGAV_DIR = join(homedir(), ".agav");
 const CONFIG_PATH = join(AGAV_DIR, "config.json");
+
+/**
+ * Expand a leading `~` to the home directory. Users naturally write `~/...` for
+ * a file path in config.json, but no shell is involved when we read it back, so
+ * without this Node tries to open a directory literally named "~" and fails
+ * with ENOENT.
+ */
+export function expandHome(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/") || path.startsWith("~\\")) return join(homedir(), path.slice(2));
+  return path;
+}
 
 const PROJECT_CONFIG_TEMPLATE = {
   provider: {
@@ -120,15 +132,15 @@ const PROJECT_CONFIG_TEMPLATE = {
     type: "string",
     eg: "set-via-GEMINI_API_KEY",
   },
-  AGAV_USE_VERTEX_AI: {
-    description: "Enable the Vertex AI provider. Can also be set with the AGAV_USE_VERTEX_AI environment variable.",
-    type: "boolean",
-    eg: true,
-  },
-  VERTEX_AI_CREDENTIALS_PATH: {
-    description: "Path to a Google Cloud service-account JSON file used by Vertex AI.",
+  vertexAICredentialsPath: {
+    description: "Path to a Google Cloud service-account JSON file used by Vertex AI. Setting it enables the provider. Prefer the VERTEX_AI_CREDENTIALS_PATH environment variable.",
     type: "string",
     eg: "/path/to/service-account.json",
+  },
+  vertexAILocation: {
+    description: "Vertex AI region, or \"global\" for the multi-region endpoint. Can also be set with VERTEX_AI_LOCATION.",
+    type: "string",
+    eg: "global",
   },
   ollamaEndpoint: {
     description: "Complete Ollama API base URL; overrides ollamaHost and ollamaPort.",
@@ -278,12 +290,18 @@ export async function loadConfig(): Promise<AgavConfig> {
     DEFAULT_CONFIG.geminiApiKey ?? "",
   ) || undefined;
 
-  const vertexEnabled = process.env["AGAV_USE_VERTEX_AI"];
-  if (vertexEnabled !== undefined) {
-    merged.AGAV_USE_VERTEX_AI = /^(?:1|true|yes|on)$/i.test(vertexEnabled);
-  }
+  // Vertex AI — the credentials path alone enables the provider; there is no
+  // separate on/off flag to keep in sync with it.
   if (process.env["VERTEX_AI_CREDENTIALS_PATH"]) {
-    merged.VERTEX_AI_CREDENTIALS_PATH = process.env["VERTEX_AI_CREDENTIALS_PATH"];
+    merged.vertexAICredentialsPath = process.env["VERTEX_AI_CREDENTIALS_PATH"];
+  }
+  if (process.env["VERTEX_AI_LOCATION"]) {
+    merged.vertexAILocation = process.env["VERTEX_AI_LOCATION"];
+  }
+  // Applied after the env override so a tilde resolves whichever source the
+  // path came from: environment, project config, or global config.
+  if (merged.vertexAICredentialsPath) {
+    merged.vertexAICredentialsPath = expandHome(merged.vertexAICredentialsPath);
   }
 
   // Ollama — env vars take precedence over config file

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -23,12 +23,14 @@ export interface AgavHooks {
 }
 
 export interface AgavConfig {
-  provider: "anthropic" | "openai" | "ollama" | "gemini";
+  provider: "anthropic" | "openai" | "ollama" | "gemini" | "vertex-ai";
   model: string;
   anthropicApiKey?: string;
   openaiApiKey?: string;
   openaiApi?: "chat" | "responses";
   geminiApiKey?: string;
+  AGAV_USE_VERTEX_AI?: boolean;
+  VERTEX_AI_CREDENTIALS_PATH?: string;
   ollamaEndpoint?: string;  // e.g. "http://192.168.1.5:11434" — takes precedence over host+port
   ollamaHost?: string;
   ollamaPort?: number;
@@ -52,7 +54,7 @@ const CONFIG_PATH = join(AGAV_DIR, "config.json");
 const PROJECT_CONFIG_TEMPLATE = {
   provider: {
     description: "LLM provider used for new sessions.",
-    enum: ["openai", "ollama", "anthropic", "gemini"],
+    enum: ["openai", "ollama", "anthropic", "gemini", "vertex-ai"],
     type: "string",
     eg: "openai",
   },
@@ -117,6 +119,16 @@ const PROJECT_CONFIG_TEMPLATE = {
     description: "Google Gemini API key. Prefer the GEMINI_API_KEY environment variable for secrets.",
     type: "string",
     eg: "set-via-GEMINI_API_KEY",
+  },
+  AGAV_USE_VERTEX_AI: {
+    description: "Enable the Vertex AI provider. Can also be set with the AGAV_USE_VERTEX_AI environment variable.",
+    type: "boolean",
+    eg: true,
+  },
+  VERTEX_AI_CREDENTIALS_PATH: {
+    description: "Path to a Google Cloud service-account JSON file used by Vertex AI.",
+    type: "string",
+    eg: "/path/to/service-account.json",
   },
   ollamaEndpoint: {
     description: "Complete Ollama API base URL; overrides ollamaHost and ollamaPort.",
@@ -249,19 +261,30 @@ export async function loadConfig(): Promise<AgavConfig> {
 
   merged.anthropicApiKey = decrypt(
     process.env["ANTHROPIC_API_KEY"] ??
+    projectConfig.anthropicApiKey ??
     globalConfig.anthropicApiKey ??
     DEFAULT_CONFIG.anthropicApiKey ?? "",
   ) || undefined;
   merged.openaiApiKey = decrypt(
     process.env["OPENAI_API_KEY"] ??
+    projectConfig.openaiApiKey ??
     globalConfig.openaiApiKey ??
     DEFAULT_CONFIG.openaiApiKey ?? "",
   ) || undefined;
   merged.geminiApiKey = decrypt(
     process.env["GEMINI_API_KEY"] ??
+    projectConfig.geminiApiKey ??
     globalConfig.geminiApiKey ??
     DEFAULT_CONFIG.geminiApiKey ?? "",
   ) || undefined;
+
+  const vertexEnabled = process.env["AGAV_USE_VERTEX_AI"];
+  if (vertexEnabled !== undefined) {
+    merged.AGAV_USE_VERTEX_AI = /^(?:1|true|yes|on)$/i.test(vertexEnabled);
+  }
+  if (process.env["VERTEX_AI_CREDENTIALS_PATH"]) {
+    merged.VERTEX_AI_CREDENTIALS_PATH = process.env["VERTEX_AI_CREDENTIALS_PATH"];
+  }
 
   // Ollama — env vars take precedence over config file
   if (process.env["OLLAMA_ENDPOINT"]) {
@@ -276,8 +299,8 @@ export async function loadConfig(): Promise<AgavConfig> {
   }
   merged.ollamaApiKey = decrypt(
     process.env["OLLAMA_API_KEY"] ??
-    globalConfig.ollamaApiKey ??
     projectConfig.ollamaApiKey ??
+    globalConfig.ollamaApiKey ??
     DEFAULT_CONFIG.ollamaApiKey ?? "",
   ) || undefined;
 

--- a/source/config/startup.ts
+++ b/source/config/startup.ts
@@ -1,0 +1,119 @@
+import type { AgavConfig } from "./config.js";
+import type { SessionRecord } from "./history.js";
+import { agavHomePath } from "../utils/shell-hints.js";
+
+export type ProviderName = AgavConfig["provider"];
+
+export const PROVIDERS: readonly ProviderName[] = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "vertex-ai",
+  "ollama",
+];
+
+const DEFAULT_MODELS: Record<ProviderName, string> = {
+  anthropic: "claude-sonnet-4-20250514",
+  openai: "gpt-5.4-mini",
+  gemini: "gemini-3.5-flash-lite",
+  "vertex-ai": "vertex/gemini-3.5-flash",
+  ollama: "",
+};
+
+export function isProviderName(value: unknown): value is ProviderName {
+  return typeof value === "string" && PROVIDERS.includes(value as ProviderName);
+}
+
+export function defaultModelForProvider(provider: ProviderName): string {
+  return DEFAULT_MODELS[provider];
+}
+
+interface StartupSelectionOptions {
+  cliProvider?: ProviderName;
+  cliModel?: string;
+  session?: Pick<SessionRecord, "provider" | "model">;
+}
+
+/** Resolve provider/model precedence before validating any provider credentials. */
+export function resolveStartupSelection(
+  config: AgavConfig,
+  options: StartupSelectionOptions,
+): AgavConfig {
+  const result = { ...config };
+  const sessionProvider = isProviderName(options.session?.provider)
+    ? options.session.provider
+    : undefined;
+
+  if (options.session && !sessionProvider && !options.cliProvider) {
+    throw new Error(
+      `Saved session uses unsupported provider ${JSON.stringify(options.session.provider)}. ` +
+      "Resume it with --provider <provider> to choose a supported provider.",
+    );
+  }
+
+  if (options.cliProvider) {
+    const providerChanged = options.cliProvider !== result.provider;
+    result.provider = options.cliProvider;
+
+    if (options.cliModel !== undefined) {
+      result.model = options.cliModel;
+    } else if (options.session) {
+      // Reuse the saved model only when it belongs to the selected provider.
+      result.model = sessionProvider === options.cliProvider
+        ? options.session.model || defaultModelForProvider(options.cliProvider)
+        : defaultModelForProvider(options.cliProvider);
+    } else if (providerChanged) {
+      result.model = defaultModelForProvider(options.cliProvider);
+    }
+  } else if (options.session && sessionProvider) {
+    result.provider = sessionProvider;
+    result.model = options.cliModel ?? (options.session.model || defaultModelForProvider(sessionProvider));
+  } else if (options.cliModel !== undefined) {
+    result.model = options.cliModel;
+  }
+
+  return result;
+}
+
+export function hasProviderConfiguration(config: AgavConfig, provider: ProviderName): boolean {
+  switch (provider) {
+    case "anthropic": return Boolean(config.anthropicApiKey);
+    case "openai": return Boolean(config.openaiApiKey);
+    case "gemini": return Boolean(config.geminiApiKey);
+    case "vertex-ai": return Boolean(config.AGAV_USE_VERTEX_AI && config.VERTEX_AI_CREDENTIALS_PATH);
+    case "ollama": return true;
+  }
+}
+
+/** For an unpinned plain start, select the first configured cloud provider. */
+export function selectConfiguredProvider(config: AgavConfig): AgavConfig | null {
+  if (hasProviderConfiguration(config, config.provider)) return { ...config };
+
+  for (const provider of PROVIDERS) {
+    if (provider === "ollama" || !hasProviderConfiguration(config, provider)) continue;
+    return { ...config, provider, model: defaultModelForProvider(provider) };
+  }
+  return null;
+}
+
+export function providerConfigurationError(config: AgavConfig): string | null {
+  switch (config.provider) {
+    case "anthropic":
+      return config.anthropicApiKey ? null
+        : `Anthropic API key not found. Set ANTHROPIC_API_KEY or add it to ${agavHomePath("config.json")}`;
+    case "openai":
+      return config.openaiApiKey ? null
+        : `OpenAI API key not found. Set OPENAI_API_KEY or add it to ${agavHomePath("config.json")}`;
+    case "gemini":
+      return config.geminiApiKey ? null
+        : `Gemini API key not found. Set GEMINI_API_KEY or add it to ${agavHomePath("config.json")}`;
+    case "vertex-ai": {
+      const missing: string[] = [];
+      if (!config.AGAV_USE_VERTEX_AI) missing.push("AGAV_USE_VERTEX_AI=true");
+      if (!config.VERTEX_AI_CREDENTIALS_PATH) missing.push("VERTEX_AI_CREDENTIALS_PATH");
+      return missing.length === 0 ? null
+        : `Vertex AI configuration is incomplete. Missing: ${missing.join(", ")}. Add it to the environment or ${agavHomePath("config.json")}`;
+    }
+    case "ollama": return null;
+  }
+}

--- a/source/config/startup.ts
+++ b/source/config/startup.ts
@@ -1,6 +1,6 @@
 import type { AgavConfig } from "./config.js";
 import type { SessionRecord } from "./history.js";
-import { agavHomePath } from "../utils/shell-hints.js";
+import { agavHomePath, examplePath, setEnvHint } from "../utils/shell-hints.js";
 
 export type ProviderName = AgavConfig["provider"];
 
@@ -80,40 +80,72 @@ export function hasProviderConfiguration(config: AgavConfig, provider: ProviderN
     case "anthropic": return Boolean(config.anthropicApiKey);
     case "openai": return Boolean(config.openaiApiKey);
     case "gemini": return Boolean(config.geminiApiKey);
-    case "vertex-ai": return Boolean(config.AGAV_USE_VERTEX_AI && config.VERTEX_AI_CREDENTIALS_PATH);
+    case "vertex-ai": return Boolean(config.vertexAICredentialsPath);
     case "ollama": return true;
   }
 }
 
+interface SelectProviderOptions {
+  /**
+   * Keep `config.model` as-is instead of substituting the newly selected
+   * provider's default. Set when the user named a model explicitly.
+   */
+  keepModel?: boolean;
+}
+
 /** For an unpinned plain start, select the first configured cloud provider. */
-export function selectConfiguredProvider(config: AgavConfig): AgavConfig | null {
+export function selectConfiguredProvider(
+  config: AgavConfig,
+  options: SelectProviderOptions = {},
+): AgavConfig | null {
   if (hasProviderConfiguration(config, config.provider)) return { ...config };
 
   for (const provider of PROVIDERS) {
     if (provider === "ollama" || !hasProviderConfiguration(config, provider)) continue;
+    // An explicit --model is a deliberate choice, so only fall back to the
+    // provider default when the user did not name a model themselves.
+    if (options.keepModel) return { ...config, provider };
     return { ...config, provider, model: defaultModelForProvider(provider) };
   }
   return null;
+}
+
+/**
+ * The set-up commands for every provider, spelled out for the caller's shell
+ * rather than telling them to "set an API key" and leaving them to work out the
+ * syntax. Shared so a caller with its own lead-in sentence does not have to
+ * restate them.
+ */
+export function providerSetupHints(): string {
+  return [
+    "  Set one of:",
+    `    ${setEnvHint("ANTHROPIC_API_KEY", "sk-ant-...")}`,
+    `    ${setEnvHint("OPENAI_API_KEY", "sk-...")}`,
+    `    ${setEnvHint("GEMINI_API_KEY", "...")}`,
+    `    ${setEnvHint("VERTEX_AI_CREDENTIALS_PATH", examplePath("path", "to", "service-account.json"))}`,
+    "  Or start Ollama: agav --provider ollama",
+  ].join("\n");
+}
+
+/** Guidance for a plain start with nothing configured at all. */
+export function noProviderCredentialsError(): string {
+  return `no provider credentials found.\n${providerSetupHints()}`;
 }
 
 export function providerConfigurationError(config: AgavConfig): string | null {
   switch (config.provider) {
     case "anthropic":
       return config.anthropicApiKey ? null
-        : `Anthropic API key not found. Set ANTHROPIC_API_KEY or add it to ${agavHomePath("config.json")}`;
+        : `Anthropic API key not found. Run ${setEnvHint("ANTHROPIC_API_KEY", "sk-ant-...")} or add it to ${agavHomePath("config.json")}`;
     case "openai":
       return config.openaiApiKey ? null
-        : `OpenAI API key not found. Set OPENAI_API_KEY or add it to ${agavHomePath("config.json")}`;
+        : `OpenAI API key not found. Run ${setEnvHint("OPENAI_API_KEY", "sk-...")} or add it to ${agavHomePath("config.json")}`;
     case "gemini":
       return config.geminiApiKey ? null
-        : `Gemini API key not found. Set GEMINI_API_KEY or add it to ${agavHomePath("config.json")}`;
-    case "vertex-ai": {
-      const missing: string[] = [];
-      if (!config.AGAV_USE_VERTEX_AI) missing.push("AGAV_USE_VERTEX_AI=true");
-      if (!config.VERTEX_AI_CREDENTIALS_PATH) missing.push("VERTEX_AI_CREDENTIALS_PATH");
-      return missing.length === 0 ? null
-        : `Vertex AI configuration is incomplete. Missing: ${missing.join(", ")}. Add it to the environment or ${agavHomePath("config.json")}`;
-    }
+        : `Gemini API key not found. Run ${setEnvHint("GEMINI_API_KEY", "...")} or add it to ${agavHomePath("config.json")}`;
+    case "vertex-ai":
+      return config.vertexAICredentialsPath ? null
+        : `Vertex AI service account credentials not found. Run ${setEnvHint("VERTEX_AI_CREDENTIALS_PATH", examplePath("path", "to", "service-account.json"))} or add it to ${agavHomePath("config.json")}`;
     case "ollama": return null;
   }
 }

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -24,6 +24,7 @@ import {
 import {
   defaultModelForProvider,
   isProviderName,
+  noProviderCredentialsError,
   providerConfigurationError,
   resolveStartupSelection,
   selectConfiguredProvider,
@@ -328,6 +329,16 @@ export async function runPipeMode(
   return result.exitCode;
 }
 
+let startupFinished = false;
+
+/**
+ * Whether provider/model resolution finished. Lets the top-level handler in
+ * cli.tsx avoid blaming a mid-session crash on startup.
+ */
+export function hasStartupFinished(): boolean {
+  return startupFinished;
+}
+
 export async function main() {
   const flags = parseArgs(process.argv.slice(2));
 
@@ -364,7 +375,7 @@ export async function main() {
   Examples
     $ agav
     $ agav --provider openai --model gpt-4o
-    $ agav --provider vertex-ai --model vertex/gemini-2.5-flash
+    $ agav --provider vertex-ai --model vertex/gemini-3.5-flash
     $ agav run "review the code in src/"
     $ agav run --permission '{"bash":"deny"}' "check for security issues"
     $ agav -P "what does this project do?"
@@ -524,9 +535,13 @@ export async function main() {
   // Plain `agav` may fall back to another configured provider. Explicit and
   // resumed selections are pinned and must report their own missing settings.
   if (!cliProvider && !resumeSelection) {
-    const selected = selectConfiguredProvider(config);
+    // Keep an explicit --model: falling back to a different provider should not
+    // silently discard the model the user asked for.
+    const selected = selectConfiguredProvider(config, {
+      keepModel: typeof flags.model === "string",
+    });
     if (!selected) {
-      process.stderr.write("\n  Agav — no provider credentials found.\n  Set an API key, configure Vertex AI, or start Ollama.\n");
+      process.stderr.write(`\n  Agav — ${noProviderCredentialsError()}\n\n`);
       process.exit(1);
     }
     Object.assign(config, selected);
@@ -554,7 +569,16 @@ export async function main() {
       process.exit(1);
     }
     config.model = models[0] ?? defaultModelForProvider("ollama");
+    // Auto-picking the first installed model is a guess, so name the others —
+    // otherwise there is no hint that --model would have chosen differently.
+    process.stderr.write(
+      `\n  Agav — using Ollama model ${config.model}.`
+      + (models.length > 1 ? ` Also installed: ${models.slice(1).join(", ")}.` : "")
+      + "\n\n",
+    );
   }
+
+  startupFinished = true;
 
   // Short-circuit into non-interactive mode before the Ink UI is rendered.
   if (flags.print) {

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -14,7 +14,6 @@ import { createToolRegistry } from "./tools/registry-factory.js";
 import { getToolLabel } from "./utils/tool-labels.js";
 import { loadKeybindings } from "./config/keybindings.js";
 import { dim, icons } from "./utils/color.js";
-import { setEnvHint } from "./utils/shell-hints.js";
 import {
   createOutputValidator,
   formatValidationErrors,
@@ -22,7 +21,14 @@ import {
   validateOutput,
   type OutputSchema,
 } from "./utils/output-schema.js";
-import { fetchVertexAIModels } from "./providers/vertex-ai.js";
+import {
+  defaultModelForProvider,
+  isProviderName,
+  providerConfigurationError,
+  resolveStartupSelection,
+  selectConfiguredProvider,
+  type ProviderName,
+} from "./config/startup.js";
 
 const KNOWN_FLAGS = [
   "--help", "-h", "--version", "-v", "--provider", "-p", "--model", "-m",
@@ -405,21 +411,14 @@ export async function main() {
   const config = await loadConfig();
   const keybindings = await loadKeybindings();
 
+  let cliProvider: ProviderName | undefined;
   if (typeof flags.provider === "string") {
     const p = flags.provider;
-    if (p !== "anthropic" && p !== "openai" && p !== "ollama" && p !== "gemini" && p !== "vertex-ai") {
+    if (!isProviderName(p)) {
       console.error(`Unknown provider: ${p}. Use "anthropic", "openai", "gemini", "vertex-ai", or "ollama".`);
       process.exit(1);
     }
-    const providerChanged = p !== config.provider;
-    config.provider = p;
-    if (providerChanged && typeof flags.model !== "string") {
-      if (p === "openai") config.model = "gpt-5.4-mini";
-      else if (p === "gemini") config.model = "gemini-3.5-flash-lite";
-      else if (p === "vertex-ai") config.model = "vertex/gemini-3.5-flash";
-      else if (p === "ollama") config.model = "";
-      else config.model = "claude-sonnet-4-20250514";
-    }
+    cliProvider = p;
   }
 
   // Apply explicit CLI connection overrides last so they win over config and environment defaults.
@@ -439,42 +438,12 @@ export async function main() {
   if (typeof flags.ollamaApiKey === "string" && flags.ollamaApiKey) {
     config.ollamaApiKey = flags.ollamaApiKey as string;
   }
-  if (typeof flags.model === "string") {
-    config.model = flags.model;
-  }
   if (typeof flags.effort === "string") {
     if (!isEffortLevel(flags.effort)) {
       console.error(`Unknown effort level: ${flags.effort}. Use "low", "medium", "high", or "max".`);
       process.exit(1);
     }
     config.effort = flags.effort;
-  }
-
-  // If Ollama is selected without a model, query the local server and prompt the user to choose one.
-  if (config.provider === "ollama" && typeof flags.model !== "string") {
-    const ollamaBase =
-      config.ollamaEndpoint ??
-      `http://${config.ollamaHost ?? "localhost"}:${config.ollamaPort ?? 11434}`;
-    let models: string[] = [];
-    try {
-      const res = await fetch(`${ollamaBase}/api/tags`);
-      if (res.ok) {
-        const data = await res.json() as { models?: { name: string }[] };
-        models = (data.models ?? []).map((m) => m.name).filter(Boolean);
-      }
-    } catch {}
-
-    if (models.length > 0) {
-      process.stdout.write("\n  Available Ollama models:\n");
-      models.forEach((name, i) => process.stdout.write(`    ${i + 1}. ${name}\n`));
-      process.stdout.write(`\n  Starting with: ${models[0]}\n  Use /model to switch.\n\n`);
-      config.model = models[0]!;
-    } else {
-      console.error("\n  No Ollama models found. Specify a model:\n");
-      console.error("    agav --provider ollama --model llama3.2\n");
-      console.error("  Or pull one first: ollama pull llama3.2\n");
-      process.exit(1);
-    }
   }
 
   if (!config.systemPrompt) {
@@ -495,6 +464,7 @@ export async function main() {
   let resumeTokenUsage: import("./config/history.js").SessionTokenUsage | undefined;
   let resumeCompacted: boolean | undefined;
   let resumeSessionName: string | undefined;
+  let resumeSelection: Pick<import("./config/history.js").SessionRecord, "provider" | "model"> | undefined;
 
   if (flags.resume) {
     const { listSessions, loadSession } = await import("./config/history.js");
@@ -521,12 +491,7 @@ export async function main() {
       resumeTokenUsage = session.tokenUsage;
       resumeCompacted = session.compacted;
       resumeSessionName = session.name;
-      if (typeof flags.model !== "string") {
-        config.model = session.model || config.model;
-      }
-      if (typeof flags.provider !== "string" && (session.provider === "anthropic" || session.provider === "openai" || session.provider === "ollama" || session.provider === "gemini" || session.provider === "vertex-ai")) {
-        config.provider = session.provider;
-      }
+      resumeSelection = session;
     } else {
       // ID prefix given — find matching session
       const prefix = String(flags.resume);
@@ -546,63 +511,49 @@ export async function main() {
       resumeTokenUsage = session.tokenUsage;
       resumeCompacted = session.compacted;
       resumeSessionName = session.name;
-      if (typeof flags.model !== "string") {
-        config.model = session.model || config.model;
-      }
-      if (typeof flags.provider !== "string" && (session.provider === "anthropic" || session.provider === "openai" || session.provider === "ollama" || session.provider === "gemini" || session.provider === "vertex-ai")) {
-        config.provider = session.provider;
-      }
+      resumeSelection = session;
     }
   }
 
-  if (config.provider === "vertex-ai") {
-    if (!config.AGAV_USE_VERTEX_AI || !config.VERTEX_AI_CREDENTIALS_PATH) {
-      const message = `\n  Agav — Vertex AI configuration is incomplete.\n  Set both:\n    ${setEnvHint("AGAV_USE_VERTEX_AI", "true")}\n    ${setEnvHint("VERTEX_AI_CREDENTIALS_PATH", "/path/to/service-account.json")}\n`;
-      process.stderr.write(message);
+  Object.assign(config, resolveStartupSelection(config, {
+    cliProvider,
+    cliModel: typeof flags.model === "string" ? flags.model : undefined,
+    session: resumeSelection,
+  }));
+
+  // Plain `agav` may fall back to another configured provider. Explicit and
+  // resumed selections are pinned and must report their own missing settings.
+  if (!cliProvider && !resumeSelection) {
+    const selected = selectConfiguredProvider(config);
+    if (!selected) {
+      process.stderr.write("\n  Agav — no provider credentials found.\n  Set an API key, configure Vertex AI, or start Ollama.\n");
       process.exit(1);
     }
+    Object.assign(config, selected);
+  }
 
-    const models = await fetchVertexAIModels(config.VERTEX_AI_CREDENTIALS_PATH)
-  } else if (config.provider !== "ollama") {
-    const keyMap: Record<string, keyof AgavConfig> = {
-      anthropic: "anthropicApiKey",
-      openai: "openaiApiKey",
-      gemini: "geminiApiKey",
-    };
-    const finalKey = keyMap[config.provider] ?? "anthropicApiKey";
-    if (!config[finalKey]) {
-      const explicitProvider = typeof flags.provider === "string";
-      if (!explicitProvider) {
-        // Auto-switch to whichever provider has a key
-        if (config.anthropicApiKey) {
-          config.provider = "anthropic";
-          config.model = "claude-sonnet-4-20250514";
-        } else if (config.openaiApiKey) {
-          config.provider = "openai";
-          config.model = "gpt-5.4-mini";
-        } else if (config.geminiApiKey) {
-          config.provider = "gemini";
-          config.model = "gemini-3.5-flash-lite";
-        } else if (config.AGAV_USE_VERTEX_AI && config.VERTEX_AI_CREDENTIALS_PATH) {
-          config.provider = "vertex-ai";
-          config.model = "vertex/gemini-3.5-flash";
-        } else {
-          const message = `\n  Agav — no provider credentials found.\n  Set an API key, configure Vertex AI, or start Ollama.\n`;
-          process.stderr.write(message);
-          process.exit(1);
-        }
-      } else {
-        const envMap: Record<string, string> = {
-          anthropic: "ANTHROPIC_API_KEY",
-          openai: "OPENAI_API_KEY",
-          gemini: "GEMINI_API_KEY",
-        };
-        const keyName = envMap[config.provider] ?? "API_KEY";
-        const message = `\n  Agav — ${keyName} not set.\n  Set it:  ${setEnvHint(keyName, "your-key")}\n`;
-        process.stderr.write(message);
-        process.exit(1);
+  const configurationError = providerConfigurationError(config);
+  if (configurationError) {
+    process.stderr.write(`\n  Agav — ${configurationError}\n\n`);
+    process.exit(1);
+  }
+
+  // If Ollama is selected without a model, query the local server and choose one.
+  if (config.provider === "ollama" && !config.model) {
+    const ollamaBase = config.ollamaEndpoint ?? `http://${config.ollamaHost ?? "localhost"}:${config.ollamaPort ?? 11434}`;
+    let models: string[] = [];
+    try {
+      const res = await fetch(`${ollamaBase}/api/tags`);
+      if (res.ok) {
+        const data = await res.json() as { models?: { name: string }[] };
+        models = (data.models ?? []).map((model) => model.name).filter(Boolean);
       }
+    } catch {}
+    if (models.length === 0) {
+      process.stderr.write("\n  Agav — no Ollama models found. Specify --model or run `ollama pull <model>`.\n\n");
+      process.exit(1);
     }
+    config.model = models[0] ?? defaultModelForProvider("ollama");
   }
 
   // Short-circuit into non-interactive mode before the Ink UI is rendered.

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -22,6 +22,7 @@ import {
   validateOutput,
   type OutputSchema,
 } from "./utils/output-schema.js";
+import { fetchVertexAIModels } from "./providers/vertex-ai.js";
 
 const KNOWN_FLAGS = [
   "--help", "-h", "--version", "-v", "--provider", "-p", "--model", "-m",
@@ -336,7 +337,7 @@ export async function main() {
     $ cat file | agav -P "explain this"
 
   Options
-    --provider, -p       LLM provider: anthropic, openai, gemini, or ollama (default: anthropic)
+    --provider, -p       LLM provider: anthropic, openai, gemini, vertex-ai, or ollama (default: anthropic)
     --model, -m          Model name (default: claude-sonnet-4-20250514 / gpt-4o / llama3.2)
     --effort             Reasoning effort: low, medium, high, or max (default: high)
     --ollama-host        Ollama host (default: localhost)
@@ -357,6 +358,7 @@ export async function main() {
   Examples
     $ agav
     $ agav --provider openai --model gpt-4o
+    $ agav --provider vertex-ai --model vertex/gemini-2.5-flash
     $ agav run "review the code in src/"
     $ agav run --permission '{"bash":"deny"}' "check for security issues"
     $ agav -P "what does this project do?"
@@ -405,8 +407,8 @@ export async function main() {
 
   if (typeof flags.provider === "string") {
     const p = flags.provider;
-    if (p !== "anthropic" && p !== "openai" && p !== "ollama" && p !== "gemini") {
-      console.error(`Unknown provider: ${p}. Use "anthropic", "openai", "gemini", or "ollama".`);
+    if (p !== "anthropic" && p !== "openai" && p !== "ollama" && p !== "gemini" && p !== "vertex-ai") {
+      console.error(`Unknown provider: ${p}. Use "anthropic", "openai", "gemini", "vertex-ai", or "ollama".`);
       process.exit(1);
     }
     const providerChanged = p !== config.provider;
@@ -414,6 +416,7 @@ export async function main() {
     if (providerChanged && typeof flags.model !== "string") {
       if (p === "openai") config.model = "gpt-5.4-mini";
       else if (p === "gemini") config.model = "gemini-3.5-flash-lite";
+      else if (p === "vertex-ai") config.model = "vertex/gemini-3.5-flash";
       else if (p === "ollama") config.model = "";
       else config.model = "claude-sonnet-4-20250514";
     }
@@ -521,7 +524,7 @@ export async function main() {
       if (typeof flags.model !== "string") {
         config.model = session.model || config.model;
       }
-      if (typeof flags.provider !== "string" && (session.provider === "anthropic" || session.provider === "openai" || session.provider === "ollama" || session.provider === "gemini")) {
+      if (typeof flags.provider !== "string" && (session.provider === "anthropic" || session.provider === "openai" || session.provider === "ollama" || session.provider === "gemini" || session.provider === "vertex-ai")) {
         config.provider = session.provider;
       }
     } else {
@@ -546,13 +549,21 @@ export async function main() {
       if (typeof flags.model !== "string") {
         config.model = session.model || config.model;
       }
-      if (typeof flags.provider !== "string" && (session.provider === "anthropic" || session.provider === "openai" || session.provider === "ollama" || session.provider === "gemini")) {
+      if (typeof flags.provider !== "string" && (session.provider === "anthropic" || session.provider === "openai" || session.provider === "ollama" || session.provider === "gemini" || session.provider === "vertex-ai")) {
         config.provider = session.provider;
       }
     }
   }
 
-  if (config.provider !== "ollama") {
+  if (config.provider === "vertex-ai") {
+    if (!config.AGAV_USE_VERTEX_AI || !config.VERTEX_AI_CREDENTIALS_PATH) {
+      const message = `\n  Agav — Vertex AI configuration is incomplete.\n  Set both:\n    ${setEnvHint("AGAV_USE_VERTEX_AI", "true")}\n    ${setEnvHint("VERTEX_AI_CREDENTIALS_PATH", "/path/to/service-account.json")}\n`;
+      process.stderr.write(message);
+      process.exit(1);
+    }
+
+    const models = await fetchVertexAIModels(config.VERTEX_AI_CREDENTIALS_PATH)
+  } else if (config.provider !== "ollama") {
     const keyMap: Record<string, keyof AgavConfig> = {
       anthropic: "anthropicApiKey",
       openai: "openaiApiKey",
@@ -572,8 +583,11 @@ export async function main() {
         } else if (config.geminiApiKey) {
           config.provider = "gemini";
           config.model = "gemini-3.5-flash-lite";
+        } else if (config.AGAV_USE_VERTEX_AI && config.VERTEX_AI_CREDENTIALS_PATH) {
+          config.provider = "vertex-ai";
+          config.model = "vertex/gemini-3.5-flash";
         } else {
-          const message = `\n  Agav — no API key found.\n  Set one of:\n    ${setEnvHint("ANTHROPIC_API_KEY", "sk-ant-...")}\n    ${setEnvHint("OPENAI_API_KEY", "sk-...")}\n    ${setEnvHint("GEMINI_API_KEY", "...")}\n  Or start Ollama: agav --provider ollama\n`;
+          const message = `\n  Agav — no provider credentials found.\n  Set an API key, configure Vertex AI, or start Ollama.\n`;
           process.stderr.write(message);
           process.exit(1);
         }

--- a/source/providers/effort.ts
+++ b/source/providers/effort.ts
@@ -39,12 +39,12 @@ export function supportsNativeEffort(provider: string, model: string): boolean {
 
   if (provider === "anthropic") {
     // Anthropic added effort controls to the newer 4.5+ model generation.
-    return /^claude-(?:opus|sonnet)-4-[5-9](?:-|$)/.test(normalized)
-      || /^claude-(?:fable|mythos)-5(?:-|$)/.test(normalized);
+    return /^claude-(?:opus|sonnet)-4-[5-9](?:[-@]|$)/.test(normalized)
+      || /^claude-(?:fable|mythos)-5(?:[-@]|$)/.test(normalized);
   }
 
-  if (provider === "gemini") {
-    return /^gemini-[23]\.5/.test(normalized);
+  if (provider === "gemini" || provider === "vertex-ai") {
+    return /^(?:google\/)?gemini-[23]\.5/.test(normalized);
   }
 
   return false;

--- a/source/providers/registry.ts
+++ b/source/providers/registry.ts
@@ -6,29 +6,22 @@ import { OllamaProvider } from "./ollama.js";
 import { GeminiProvider } from "./gemini.js";
 import { VertexAIProvider } from "./vertex-ai.js";
 import { RetryProvider } from "./retry.js";
-import { agavHomePath } from "../utils/shell-hints.js";
+import { providerConfigurationError } from "../config/startup.js";
 
 export function createProvider(config: AgavConfig): LLMProvider {
+  const configurationError = providerConfigurationError(config);
+  if (configurationError) throw new Error(configurationError);
+
   let provider: LLMProvider;
 
   switch (config.provider) {
     case "anthropic": {
-      const key = config.anthropicApiKey;
-      if (!key) {
-        throw new Error(
-          `Anthropic API key not found. Set ANTHROPIC_API_KEY or add it to ${agavHomePath("config.json")}`,
-        );
-      }
+      const key = config.anthropicApiKey!;
       provider = new AnthropicProvider(key);
       break;
     }
     case "openai": {
-      const key = config.openaiApiKey;
-      if (!key) {
-        throw new Error(
-          `OpenAI API key not found. Set OPENAI_API_KEY or add it to ${agavHomePath("config.json")}`,
-        );
-      }
+      const key = config.openaiApiKey!;
       provider = new OpenAIProvider(key, config.openaiApi ?? "responses");
       break;
     }
@@ -40,27 +33,12 @@ export function createProvider(config: AgavConfig): LLMProvider {
       break;
     }
     case "gemini": {
-      const key = config.geminiApiKey;
-      if (!key) {
-        throw new Error(
-          `Gemini API key not found. Set GEMINI_API_KEY or add it to ${agavHomePath("config.json")}`,
-        );
-      }
+      const key = config.geminiApiKey!;
       provider = new GeminiProvider(key);
       break;
     }
     case "vertex-ai": {
-      if (!config.AGAV_USE_VERTEX_AI) {
-        throw new Error(
-          `Vertex AI is not enabled. Set AGAV_USE_VERTEX_AI=true or add it to ${agavHomePath("config.json")}`,
-        );
-      }
-      if (!config.VERTEX_AI_CREDENTIALS_PATH) {
-        throw new Error(
-          `Vertex AI credentials path not found. Set VERTEX_AI_CREDENTIALS_PATH or add it to ${agavHomePath("config.json")}`,
-        );
-      }
-      provider = new VertexAIProvider(config.VERTEX_AI_CREDENTIALS_PATH);
+      provider = new VertexAIProvider(config.VERTEX_AI_CREDENTIALS_PATH!);
       break;
     }
     default:

--- a/source/providers/registry.ts
+++ b/source/providers/registry.ts
@@ -4,6 +4,7 @@ import { AnthropicProvider } from "./anthropic.js";
 import { OpenAIProvider } from "./openai.js";
 import { OllamaProvider } from "./ollama.js";
 import { GeminiProvider } from "./gemini.js";
+import { VertexAIProvider } from "./vertex-ai.js";
 import { RetryProvider } from "./retry.js";
 import { agavHomePath } from "../utils/shell-hints.js";
 
@@ -46,6 +47,20 @@ export function createProvider(config: AgavConfig): LLMProvider {
         );
       }
       provider = new GeminiProvider(key);
+      break;
+    }
+    case "vertex-ai": {
+      if (!config.AGAV_USE_VERTEX_AI) {
+        throw new Error(
+          `Vertex AI is not enabled. Set AGAV_USE_VERTEX_AI=true or add it to ${agavHomePath("config.json")}`,
+        );
+      }
+      if (!config.VERTEX_AI_CREDENTIALS_PATH) {
+        throw new Error(
+          `Vertex AI credentials path not found. Set VERTEX_AI_CREDENTIALS_PATH or add it to ${agavHomePath("config.json")}`,
+        );
+      }
+      provider = new VertexAIProvider(config.VERTEX_AI_CREDENTIALS_PATH);
       break;
     }
     default:

--- a/source/providers/registry.ts
+++ b/source/providers/registry.ts
@@ -8,6 +8,17 @@ import { VertexAIProvider } from "./vertex-ai.js";
 import { RetryProvider } from "./retry.js";
 import { providerConfigurationError } from "../config/startup.js";
 
+/**
+ * `providerConfigurationError` has already rejected a config that is missing
+ * the credential for its provider, so these should never fire — but a plain
+ * check beats a non-null assertion that silently hands `undefined` to a
+ * provider constructor if the two ever drift apart.
+ */
+function required(value: string | undefined, description: string): string {
+  if (!value) throw new Error(`${description} is missing from the resolved configuration`);
+  return value;
+}
+
 export function createProvider(config: AgavConfig): LLMProvider {
   const configurationError = providerConfigurationError(config);
   if (configurationError) throw new Error(configurationError);
@@ -16,12 +27,12 @@ export function createProvider(config: AgavConfig): LLMProvider {
 
   switch (config.provider) {
     case "anthropic": {
-      const key = config.anthropicApiKey!;
+      const key = required(config.anthropicApiKey, "Anthropic API key");
       provider = new AnthropicProvider(key);
       break;
     }
     case "openai": {
-      const key = config.openaiApiKey!;
+      const key = required(config.openaiApiKey, "OpenAI API key");
       provider = new OpenAIProvider(key, config.openaiApi ?? "responses");
       break;
     }
@@ -33,12 +44,13 @@ export function createProvider(config: AgavConfig): LLMProvider {
       break;
     }
     case "gemini": {
-      const key = config.geminiApiKey!;
+      const key = required(config.geminiApiKey, "Gemini API key");
       provider = new GeminiProvider(key);
       break;
     }
     case "vertex-ai": {
-      provider = new VertexAIProvider(config.VERTEX_AI_CREDENTIALS_PATH!);
+      const credentialsPath = required(config.vertexAICredentialsPath, "Vertex AI credentials path");
+      provider = new VertexAIProvider(credentialsPath, config.vertexAILocation);
       break;
     }
     default:

--- a/source/providers/types.ts
+++ b/source/providers/types.ts
@@ -19,6 +19,8 @@ export interface ContentBlock {
   imageMediaType?: string;
   imageWidth?: number;
   imageHeight?: number;
+  /** Provider-specific opaque state that must survive history persistence. */
+  providerMetadata?: Record<string, unknown>;
 }
 
 export interface Message {
@@ -33,7 +35,7 @@ export type StreamEvent =
   | { type: "thinking_delta"; text: string }
   | { type: "text_delta"; text: string }
   | { type: "tool_call_start"; toolCallId: string; toolName: string }
-  | { type: "tool_call_delta"; toolCallId: string; argsJson: string }
+  | { type: "tool_call_delta"; toolCallId: string; argsJson: string; providerMetadata?: Record<string, unknown> }
   | { type: "tool_call_end"; toolCallId: string }
   | { type: "message_start" }
   | { type: "message_end"; stopReason: string }

--- a/source/providers/vertex-ai.ts
+++ b/source/providers/vertex-ai.ts
@@ -4,7 +4,7 @@ import { applyEffortPrompt, mapOpenAIEffort, supportsNativeEffort } from "./effo
 import type { ContentBlock, LLMProvider, Message, StreamEvent, StreamParams, ToolSchema } from "./types.js";
 
 const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
-const VERTEX_LOCATION = "global";
+const DEFAULT_VERTEX_LOCATION = "global";
 const THOUGHT_SIGNATURE_KEY = "vertexAIThoughtSignature";
 const SKIP_THOUGHT_SIGNATURE_VALIDATOR = "skip_thought_signature_validator";
 
@@ -29,6 +29,7 @@ function base64Url(value: string): string {
 export class VertexAIAuth {
   private credentials?: ServiceAccountCredentials;
   private token?: AccessToken;
+  private pendingToken?: Promise<string>;
 
   constructor(private readonly credentialsPath: string) {}
 
@@ -39,6 +40,15 @@ export class VertexAIAuth {
   async getAccessToken(): Promise<string> {
     if (this.token && this.token.expiresAt > Date.now() + 60_000) return this.token.value;
 
+    // Parallel callers (subagents, concurrent tool turns) share one in-flight
+    // mint instead of each signing a JWT and racing to overwrite this.token.
+    this.pendingToken ??= this.mintAccessToken().finally(() => {
+      this.pendingToken = undefined;
+    });
+    return this.pendingToken;
+  }
+
+  private async mintAccessToken(): Promise<string> {
     const credentials = await this.loadCredentials();
     const now = Math.floor(Date.now() / 1000);
     const tokenUri = credentials.token_uri ?? "https://oauth2.googleapis.com/token";
@@ -109,8 +119,18 @@ export class VertexAIAuth {
   }
 }
 
-function vertexBaseUrl(projectId: string): string {
-  return `https://aiplatform.googleapis.com/v1beta1/projects/${encodeURIComponent(projectId)}/locations/${VERTEX_LOCATION}/endpoints/openapi`;
+/**
+ * The multi-region "global" endpoint lives on the bare host; every other
+ * location is served from its own regional host.
+ */
+function vertexHost(location: string): string {
+  return location === DEFAULT_VERTEX_LOCATION
+    ? "https://aiplatform.googleapis.com"
+    : `https://${encodeURIComponent(location)}-aiplatform.googleapis.com`;
+}
+
+function vertexBaseUrl(projectId: string, location: string): string {
+  return `${vertexHost(location)}/v1beta1/projects/${encodeURIComponent(projectId)}/locations/${encodeURIComponent(location)}/endpoints/openapi`;
 }
 
 function vertexModelName(model: string): string {
@@ -129,8 +149,8 @@ function vertexClaudeModelName(model: string): string {
     .replace(/^publishers\/anthropic\/models\//i, "");
 }
 
-function vertexClaudeUrl(projectId: string, model: string): string {
-  return `https://aiplatform.googleapis.com/v1/projects/${encodeURIComponent(projectId)}/locations/${VERTEX_LOCATION}/publishers/anthropic/models/${encodeURIComponent(vertexClaudeModelName(model))}:streamRawPredict`;
+function vertexClaudeUrl(projectId: string, model: string, location: string): string {
+  return `${vertexHost(location)}/v1/projects/${encodeURIComponent(projectId)}/locations/${encodeURIComponent(location)}/publishers/anthropic/models/${encodeURIComponent(vertexClaudeModelName(model))}:streamRawPredict`;
 }
 
 function extractThoughtSignature(value: any): string | undefined {
@@ -163,9 +183,11 @@ function addMissingThoughtSignatureSentinels(body: Record<string, unknown>): Rec
 export class VertexAIProvider implements LLMProvider {
   readonly name = "vertex-ai";
   private readonly auth: VertexAIAuth;
+  private readonly location: string;
 
-  constructor(credentialsPath: string) {
+  constructor(credentialsPath: string, location?: string) {
     this.auth = new VertexAIAuth(credentialsPath);
+    this.location = location || DEFAULT_VERTEX_LOCATION;
   }
 
   async *stream(params: StreamParams): AsyncIterable<StreamEvent> {
@@ -197,7 +219,7 @@ export class VertexAIProvider implements LLMProvider {
     // Vertex AI implicit prompt caching is enabled automatically. Keeping the
     // system prompt, tools, and message history in a stable prefix lets repeat
     // turns reuse it without creating and managing explicit cache resources.
-    const requestUrl = `${vertexBaseUrl(projectId)}/chat/completions`;
+    const requestUrl = `${vertexBaseUrl(projectId, this.location)}/chat/completions`;
     const send = (requestBody: Record<string, unknown>) => fetch(requestUrl, {
       method: "POST",
       headers: {
@@ -225,6 +247,7 @@ export class VertexAIProvider implements LLMProvider {
     yield { type: "message_start" };
     const activeCalls = new Map<number, { id: string; name: string }>();
     const pendingSignatures = new Map<number, string>();
+    let lastToolCallIndex: number | undefined;
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
@@ -251,12 +274,21 @@ export class VertexAIProvider implements LLMProvider {
       if (!choice) return;
       const delta = choice.delta ?? {};
       const messageSignature = extractThoughtSignature(delta) ?? extractThoughtSignature(choice);
-      if (messageSignature) pendingSignatures.set(0, messageSignature);
       const thought = delta.reasoning_content ?? delta.reasoning;
       if (typeof thought === "string" && thought) yield { type: "thinking_delta", text: thought };
       if (typeof delta.content === "string" && delta.content) yield { type: "text_delta", text: delta.content };
+      // A message-level signature carries no index of its own. Attribute it to
+      // a tool call in the same delta when there is one, otherwise to the call
+      // that is currently streaming — assuming index 0 misfiles the signature
+      // whenever the model emits parallel tool calls.
+      if (messageSignature) {
+        const sameDeltaIndex = delta.tool_calls?.[0]?.index;
+        const target = sameDeltaIndex ?? lastToolCallIndex ?? 0;
+        if (!pendingSignatures.has(target)) pendingSignatures.set(target, messageSignature);
+      }
       for (const call of delta.tool_calls ?? []) {
         const index = call.index ?? 0;
+        lastToolCallIndex = index;
         const thoughtSignature = extractThoughtSignature(call) ?? extractThoughtSignature(call.function);
         if (thoughtSignature) pendingSignatures.set(index, thoughtSignature);
         if (call.function?.name) {
@@ -332,7 +364,7 @@ export class VertexAIProvider implements LLMProvider {
       ...(tools?.length ? { tools } : {}),
       ...(nativeEffort ? { output_config: { effort: nativeEffort } } : {}),
     };
-    const response = await fetch(vertexClaudeUrl(projectId, model), {
+    const response = await fetch(vertexClaudeUrl(projectId, model, this.location), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -522,14 +554,15 @@ export class VertexAIProvider implements LLMProvider {
 }
 
 /** List Gemini and Claude publisher models that can be selected for Vertex AI chat. */
-export async function fetchVertexAIModels(credentialsPath: string): Promise<string[]> {
+export async function fetchVertexAIModels(credentialsPath: string, location?: string): Promise<string[]> {
   const auth = new VertexAIAuth(credentialsPath);
   const token = await auth.getAccessToken();
+  const host = vertexHost(location || DEFAULT_VERTEX_LOCATION);
   const fetchPublisher = async (publisher: "google" | "anthropic"): Promise<string[]> => {
     const models: string[] = [];
     let pageToken: string | undefined;
     do {
-      const url = new URL(`https://aiplatform.googleapis.com/v1beta1/publishers/${publisher}/models`);
+      const url = new URL(`${host}/v1beta1/publishers/${publisher}/models`);
       url.searchParams.set("pageSize", "100");
       if (publisher === "anthropic") url.searchParams.set("listAllVersions", "true");
       if (pageToken) url.searchParams.set("pageToken", pageToken);
@@ -555,9 +588,13 @@ export async function fetchVertexAIModels(credentialsPath: string): Promise<stri
 
   const results = await Promise.allSettled([fetchPublisher("google"), fetchPublisher("anthropic")]);
   const models = results.flatMap((result) => result.status === "fulfilled" ? result.value : []);
-  if (models.length === 0 && results.every((result) => result.status === "rejected")) {
+  const failures = results.filter((result) => result.status === "rejected");
+  // Surface the failure whenever it left us with nothing to show. Requiring
+  // *every* publisher to fail hid the case where one errored and the other
+  // legitimately returned an empty list, which looked like "no models exist".
+  if (models.length === 0 && failures.length > 0) {
     throw new AggregateError(
-      results.map((result) => result.status === "rejected" ? result.reason : undefined),
+      failures.map((result) => result.reason),
       "Unable to list Vertex AI Gemini or Claude models",
     );
   }

--- a/source/providers/vertex-ai.ts
+++ b/source/providers/vertex-ai.ts
@@ -1,0 +1,565 @@
+import { createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { applyEffortPrompt, mapOpenAIEffort, supportsNativeEffort } from "./effort.js";
+import type { ContentBlock, LLMProvider, Message, StreamEvent, StreamParams, ToolSchema } from "./types.js";
+
+const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+const VERTEX_LOCATION = "global";
+const THOUGHT_SIGNATURE_KEY = "vertexAIThoughtSignature";
+const SKIP_THOUGHT_SIGNATURE_VALIDATOR = "skip_thought_signature_validator";
+
+interface ServiceAccountCredentials {
+  type: "service_account";
+  project_id: string;
+  private_key: string;
+  client_email: string;
+  token_uri?: string;
+}
+
+interface AccessToken {
+  value: string;
+  expiresAt: number;
+}
+
+function base64Url(value: string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+/** Load a service-account file and mint short-lived OAuth access tokens. */
+export class VertexAIAuth {
+  private credentials?: ServiceAccountCredentials;
+  private token?: AccessToken;
+
+  constructor(private readonly credentialsPath: string) {}
+
+  async getProjectId(): Promise<string> {
+    return (await this.loadCredentials()).project_id;
+  }
+
+  async getAccessToken(): Promise<string> {
+    if (this.token && this.token.expiresAt > Date.now() + 60_000) return this.token.value;
+
+    const credentials = await this.loadCredentials();
+    const now = Math.floor(Date.now() / 1000);
+    const tokenUri = credentials.token_uri ?? "https://oauth2.googleapis.com/token";
+    const header = base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+    const claims = base64Url(JSON.stringify({
+      iss: credentials.client_email,
+      scope: CLOUD_PLATFORM_SCOPE,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    }));
+    const unsigned = `${header}.${claims}`;
+    const signer = createSign("RSA-SHA256");
+    signer.update(unsigned);
+    signer.end();
+    const assertion = `${unsigned}.${signer.sign(credentials.private_key, "base64url")}`;
+
+    const response = await fetch(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion,
+      }),
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(`Vertex AI authentication failed (${response.status}): ${detail}`);
+    }
+    const result = await response.json() as { access_token?: string; expires_in?: number };
+    if (!result.access_token) throw new Error("Vertex AI authentication response did not include an access token");
+    this.token = {
+      value: result.access_token,
+      expiresAt: Date.now() + (result.expires_in ?? 3600) * 1000,
+    };
+    return this.token.value;
+  }
+
+  private async loadCredentials(): Promise<ServiceAccountCredentials> {
+    if (this.credentials) return this.credentials;
+    let parsed: Partial<ServiceAccountCredentials>;
+    try {
+      parsed = JSON.parse(await readFile(this.credentialsPath, "utf8")) as Partial<ServiceAccountCredentials>;
+    } catch (error) {
+      throw new Error(`Unable to read Vertex AI credentials from ${this.credentialsPath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`Invalid Vertex AI service-account JSON at ${this.credentialsPath}: expected a JSON object`);
+    }
+
+    const requiredKeys = ["type", "project_id", "private_key", "client_email"] as const;
+    const missingKeys = requiredKeys.filter((key) => {
+      const value = parsed[key];
+      return typeof value !== "string" || value.trim().length === 0;
+    });
+    if (missingKeys.length > 0) {
+      throw new Error(
+        `Invalid Vertex AI service-account JSON at ${this.credentialsPath}: missing required key${missingKeys.length === 1 ? "" : "s"}: ${missingKeys.join(", ")}`,
+      );
+    }
+    if (parsed.type !== "service_account") {
+      throw new Error(
+        `Invalid Vertex AI service-account JSON at ${this.credentialsPath}: key "type" must be "service_account" (received ${JSON.stringify(parsed.type)})`,
+      );
+    }
+    this.credentials = parsed as ServiceAccountCredentials;
+    return this.credentials;
+  }
+}
+
+function vertexBaseUrl(projectId: string): string {
+  return `https://aiplatform.googleapis.com/v1beta1/projects/${encodeURIComponent(projectId)}/locations/${VERTEX_LOCATION}/endpoints/openapi`;
+}
+
+function vertexModelName(model: string): string {
+  if (model.startsWith("vertex/")) return `google/${model.slice("vertex/".length)}`;
+  return model.includes("/") ? model : `google/${model}`;
+}
+
+function isClaudeModel(model: string): boolean {
+  return /(?:^|\/)claude-/i.test(model);
+}
+
+function vertexClaudeModelName(model: string): string {
+  return model
+    .replace(/^vertex\//i, "")
+    .replace(/^anthropic\//i, "")
+    .replace(/^publishers\/anthropic\/models\//i, "");
+}
+
+function vertexClaudeUrl(projectId: string, model: string): string {
+  return `https://aiplatform.googleapis.com/v1/projects/${encodeURIComponent(projectId)}/locations/${VERTEX_LOCATION}/publishers/anthropic/models/${encodeURIComponent(vertexClaudeModelName(model))}:streamRawPredict`;
+}
+
+function extractThoughtSignature(value: any): string | undefined {
+  const signature = value?.extra_content?.google?.thought_signature
+    ?? value?.extraContent?.google?.thoughtSignature
+    ?? value?.thought_signature
+    ?? value?.thoughtSignature;
+  return typeof signature === "string" && signature ? signature : undefined;
+}
+
+function addMissingThoughtSignatureSentinels(body: Record<string, unknown>): Record<string, unknown> {
+  const repaired = structuredClone(body) as any;
+  for (const message of repaired.messages ?? []) {
+    if (message?.role !== "assistant") continue;
+    for (const call of message.tool_calls ?? []) {
+      if (!extractThoughtSignature(call)) {
+        call.extra_content = {
+          ...(call.extra_content ?? {}),
+          google: {
+            ...(call.extra_content?.google ?? {}),
+            thought_signature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+          },
+        };
+      }
+    }
+  }
+  return repaired;
+}
+
+export class VertexAIProvider implements LLMProvider {
+  readonly name = "vertex-ai";
+  private readonly auth: VertexAIAuth;
+
+  constructor(credentialsPath: string) {
+    this.auth = new VertexAIAuth(credentialsPath);
+  }
+
+  async *stream(params: StreamParams): AsyncIterable<StreamEvent> {
+    if (isClaudeModel(params.model)) {
+      yield* this.streamClaude(params);
+      return;
+    }
+    if (!/(?:^|\/)gemini-/i.test(params.model)) {
+      throw new Error(`Unsupported Vertex AI model "${params.model}". Agav supports Gemini and Claude models through Vertex AI.`);
+    }
+    yield* this.streamGemini(params);
+  }
+
+  private async *streamGemini(params: StreamParams): AsyncIterable<StreamEvent> {
+    const projectId = await this.auth.getProjectId();
+    const accessToken = await this.auth.getAccessToken();
+    const systemPrompt = params.systemPrompt;
+    const body: Record<string, unknown> = {
+      model: vertexModelName(params.model),
+      messages: this.toMessages(params.messages, systemPrompt, true),
+      tools: params.tools?.length ? params.tools.map((tool) => this.toTool(tool)) : undefined,
+      tool_choice: params.tools?.length ? "auto" : undefined,
+      max_tokens: params.maxTokens ?? 16384,
+      stream: true,
+      stream_options: { include_usage: true },
+      ...(params.effort ? { reasoning_effort: params.effort === "max" ? "high" : mapOpenAIEffort(params.effort) } : {}),
+    };
+
+    // Vertex AI implicit prompt caching is enabled automatically. Keeping the
+    // system prompt, tools, and message history in a stable prefix lets repeat
+    // turns reuse it without creating and managing explicit cache resources.
+    const requestUrl = `${vertexBaseUrl(projectId)}/chat/completions`;
+    const send = (requestBody: Record<string, unknown>) => fetch(requestUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+      signal: params.signal,
+    });
+    let response = await send(body);
+    if (!response.ok && response.status === 400) {
+      const detail = await response.text().catch(() => "");
+      if (/missing a thought_signature|thought signature.*required/i.test(detail)) {
+        response = await send(addMissingThoughtSignatureSentinels(body));
+      } else {
+        throw new Error(`Vertex AI API error ${response.status}: ${detail}`);
+      }
+    }
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(`Vertex AI API error ${response.status}: ${detail}`);
+    }
+    if (!response.body) throw new Error("Vertex AI response did not include a body");
+
+    yield { type: "message_start" };
+    const activeCalls = new Map<number, { id: string; name: string }>();
+    const pendingSignatures = new Map<number, string>();
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    const parseLine = function* (line: string): Generator<StreamEvent> {
+      if (!line.startsWith("data:")) return;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") return;
+      let chunk: any;
+      try { chunk = JSON.parse(payload); } catch { return; }
+      if (chunk.error) {
+        yield { type: "error", error: new Error(chunk.error.message ?? JSON.stringify(chunk.error)) };
+        return;
+      }
+      if (chunk.usage) {
+        yield {
+          type: "usage",
+          inputTokens: chunk.usage.prompt_tokens ?? 0,
+          outputTokens: chunk.usage.completion_tokens ?? 0,
+          cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens ?? 0,
+        };
+      }
+      const choice = chunk.choices?.[0];
+      if (!choice) return;
+      const delta = choice.delta ?? {};
+      const messageSignature = extractThoughtSignature(delta) ?? extractThoughtSignature(choice);
+      if (messageSignature) pendingSignatures.set(0, messageSignature);
+      const thought = delta.reasoning_content ?? delta.reasoning;
+      if (typeof thought === "string" && thought) yield { type: "thinking_delta", text: thought };
+      if (typeof delta.content === "string" && delta.content) yield { type: "text_delta", text: delta.content };
+      for (const call of delta.tool_calls ?? []) {
+        const index = call.index ?? 0;
+        const thoughtSignature = extractThoughtSignature(call) ?? extractThoughtSignature(call.function);
+        if (thoughtSignature) pendingSignatures.set(index, thoughtSignature);
+        if (call.function?.name) {
+          const id = call.id ?? `vertex_call_${index}`;
+          activeCalls.set(index, { id, name: call.function.name });
+          yield { type: "tool_call_start", toolCallId: id, toolName: call.function.name };
+        }
+        const active = activeCalls.get(index);
+        if (active && (call.function?.arguments || pendingSignatures.has(index))) {
+          const signature = pendingSignatures.get(index);
+          yield {
+            type: "tool_call_delta",
+            toolCallId: active.id,
+            argsJson: call.function?.arguments ?? "",
+            ...(signature ? { providerMetadata: { [THOUGHT_SIGNATURE_KEY]: signature } } : {}),
+          };
+          pendingSignatures.delete(index);
+        }
+      }
+      // Some Vertex streaming versions emit the signature as assistant-delta
+      // metadata after the tool-call delta rather than inside tool_calls[].
+      for (const [index, signature] of pendingSignatures) {
+        const active = activeCalls.get(index);
+        if (!active) continue;
+        yield {
+          type: "tool_call_delta",
+          toolCallId: active.id,
+          argsJson: "",
+          providerMetadata: { [THOUGHT_SIGNATURE_KEY]: signature },
+        };
+        pendingSignatures.delete(index);
+      }
+      if (choice.finish_reason) {
+        for (const active of activeCalls.values()) yield { type: "tool_call_end", toolCallId: active.id };
+        activeCalls.clear();
+        yield { type: "message_end", stopReason: choice.finish_reason };
+      }
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) yield* parseLine(line);
+      if (done) break;
+    }
+    if (buffer.trim()) yield* parseLine(buffer.trim());
+  }
+
+  private async *streamClaude(params: StreamParams): AsyncIterable<StreamEvent> {
+    const projectId = await this.auth.getProjectId();
+    const accessToken = await this.auth.getAccessToken();
+    const model = vertexClaudeModelName(params.model);
+    const nativeEffort = params.effort && supportsNativeEffort("anthropic", model)
+      ? params.effort
+      : undefined;
+    const systemPrompt = nativeEffort
+      ? params.systemPrompt
+      : applyEffortPrompt(params.systemPrompt, params.effort ?? "medium");
+    const tools = params.tools?.map((tool, index, all) => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: tool.inputSchema,
+      ...(index === all.length - 1 ? { cache_control: { type: "ephemeral" } } : {}),
+    }));
+    const body: Record<string, unknown> = {
+      anthropic_version: "vertex-2023-10-16",
+      messages: this.toClaudeMessages(params.messages),
+      max_tokens: params.maxTokens ?? 16384,
+      stream: true,
+      ...(systemPrompt ? { system: [{ type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } }] } : {}),
+      ...(tools?.length ? { tools } : {}),
+      ...(nativeEffort ? { output_config: { effort: nativeEffort } } : {}),
+    };
+    const response = await fetch(vertexClaudeUrl(projectId, model), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: params.signal,
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(`Vertex AI Claude API error ${response.status}: ${detail}`);
+    }
+    if (!response.body) throw new Error("Vertex AI Claude response did not include a body");
+
+    yield { type: "message_start" };
+    const blockToolIds = new Map<number, string>();
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    const parseLine = function* (line: string): Generator<StreamEvent> {
+      if (!line.startsWith("data:")) return;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") return;
+      let event: any;
+      try { event = JSON.parse(payload); } catch { return; }
+      if (event.type === "error") {
+        yield { type: "error", error: new Error(event.error?.message ?? JSON.stringify(event.error ?? event)) };
+      } else if (event.type === "message_start") {
+        const usage = event.message?.usage;
+        if (usage) {
+          yield {
+            type: "usage",
+            inputTokens: usage.input_tokens ?? 0,
+            outputTokens: 0,
+            cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+            cacheWriteTokens: usage.cache_creation_input_tokens ?? 0,
+          };
+        }
+      } else if (event.type === "content_block_start") {
+        if (event.content_block?.type === "tool_use") {
+          blockToolIds.set(event.index, event.content_block.id);
+          yield {
+            type: "tool_call_start",
+            toolCallId: event.content_block.id,
+            toolName: event.content_block.name,
+          };
+        }
+      } else if (event.type === "content_block_delta") {
+        if (event.delta?.type === "thinking_delta" && event.delta.thinking) {
+          yield { type: "thinking_delta", text: event.delta.thinking };
+        } else if (event.delta?.type === "text_delta" && event.delta.text) {
+          yield { type: "text_delta", text: event.delta.text };
+        } else if (event.delta?.type === "input_json_delta") {
+          const toolCallId = blockToolIds.get(event.index);
+          if (toolCallId) yield { type: "tool_call_delta", toolCallId, argsJson: event.delta.partial_json ?? "" };
+        }
+      } else if (event.type === "content_block_stop") {
+        const toolCallId = blockToolIds.get(event.index);
+        if (toolCallId) {
+          yield { type: "tool_call_end", toolCallId };
+          blockToolIds.delete(event.index);
+        }
+      } else if (event.type === "message_delta") {
+        const outputTokens = event.usage?.output_tokens ?? 0;
+        if (outputTokens > 0) yield { type: "usage", inputTokens: 0, outputTokens };
+        yield { type: "message_end", stopReason: event.delta?.stop_reason ?? "end_turn" };
+      }
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) yield* parseLine(line);
+      if (done) break;
+    }
+    if (buffer.trim()) yield* parseLine(buffer.trim());
+  }
+
+  private toClaudeMessages(messages: Message[]): Record<string, unknown>[] {
+    return messages.map((message) => ({
+      role: message.role,
+      content: message.content.map((block) => this.toClaudeContentBlock(block)),
+    }));
+  }
+
+  private toClaudeContentBlock(block: ContentBlock): Record<string, unknown> {
+    if (block.type === "text") return { type: "text", text: block.text ?? "" };
+    if (block.type === "tool_use") {
+      return { type: "tool_use", id: block.toolCallId, name: block.toolName, input: block.toolInput ?? {} };
+    }
+    if (block.type === "tool_result") {
+      const nested = block.toolResultContent
+        ?.filter((item) => item.type === "text" || (item.type === "image" && item.imageData))
+        .map((item) => item.type === "image"
+          ? {
+              type: "image",
+              source: { type: "base64", media_type: item.imageMediaType ?? "image/jpeg", data: item.imageData },
+            }
+          : { type: "text", text: item.text ?? "" });
+      return {
+        type: "tool_result",
+        tool_use_id: block.toolCallId,
+        content: nested?.length ? nested : block.toolResult ?? "",
+        ...(block.isError !== undefined ? { is_error: block.isError } : {}),
+      };
+    }
+    if (block.type === "image" && block.imageData) {
+      return {
+        type: "image",
+        source: { type: "base64", media_type: block.imageMediaType ?? "image/png", data: block.imageData },
+      };
+    }
+    return { type: "text", text: block.text ?? "" };
+  }
+
+  private toMessages(messages: Message[], systemPrompt?: string, requiresThoughtSignatures = false): Record<string, unknown>[] {
+    const result: Record<string, unknown>[] = [];
+    const toolNames = new Map<string, string>();
+    if (systemPrompt) result.push({ role: "system", content: systemPrompt });
+    for (const message of messages) {
+      if (message.role === "user") {
+        const toolResults = message.content.filter((block) => block.type === "tool_result");
+        if (toolResults.length) {
+          for (const block of toolResults) {
+            result.push({
+              role: "tool",
+              tool_call_id: block.toolCallId,
+              name: block.toolCallId ? toolNames.get(block.toolCallId) : undefined,
+              content: block.toolResult ?? "",
+            });
+          }
+          const images = toolResults.flatMap((block) => block.toolResultContent ?? []).filter((block) => block.type === "image" && block.imageData);
+          if (images.length) result.push({ role: "user", content: this.imageParts(images, "Visual previews returned by the preceding tool results.") });
+        } else {
+          const images = message.content.filter((block) => block.type === "image" && block.imageData);
+          if (images.length) result.push({ role: "user", content: this.contentParts(message.content) });
+          else result.push({ role: "user", content: message.content.filter((block) => block.type === "text").map((block) => block.text).join("\n") });
+        }
+      } else {
+        const content = message.content.filter((block) => block.type === "text").map((block) => block.text).join("");
+        const toolBlocks = message.content.filter((block) => block.type === "tool_use");
+        for (const block of toolBlocks) {
+          if (block.toolCallId && block.toolName) toolNames.set(block.toolCallId, block.toolName);
+        }
+        const hasStoredSignature = toolBlocks.some((block) => typeof block.providerMetadata?.[THOUGHT_SIGNATURE_KEY] === "string");
+        const toolCalls = toolBlocks.map((block, index) => {
+          const storedSignature = block.providerMetadata?.[THOUGHT_SIGNATURE_KEY];
+          // Sessions created before signature persistence have no opaque state
+          // to replay. Vertex documents this sentinel for externally-created
+          // function calls; use it only on the first call in that old turn.
+          const thoughtSignature = typeof storedSignature === "string"
+            ? storedSignature
+            : requiresThoughtSignatures && !hasStoredSignature && index === 0
+              ? SKIP_THOUGHT_SIGNATURE_VALIDATOR
+              : undefined;
+          return {
+            id: block.toolCallId,
+            type: "function",
+            function: { name: block.toolName, arguments: JSON.stringify(block.toolInput ?? {}) },
+            ...(thoughtSignature ? { extra_content: { google: { thought_signature: thoughtSignature } } } : {}),
+          };
+        });
+        result.push({ role: "assistant", content, ...(toolCalls.length ? { tool_calls: toolCalls } : {}) });
+      }
+    }
+    return result;
+  }
+
+  private contentParts(content: ContentBlock[]): Record<string, unknown>[] {
+    return content.flatMap((block): Record<string, unknown>[] => {
+      if (block.type === "text" && block.text) return [{ type: "text", text: block.text }];
+      if (block.type === "image" && block.imageData) return [{ type: "image_url", image_url: { url: `data:${block.imageMediaType ?? "image/png"};base64,${block.imageData}` } }];
+      return [];
+    });
+  }
+
+  private imageParts(images: ContentBlock[], intro: string): Record<string, unknown>[] {
+    return [{ type: "text", text: intro }, ...this.contentParts(images)];
+  }
+
+  private toTool(schema: ToolSchema): Record<string, unknown> {
+    return { type: "function", function: { name: schema.name, description: schema.description, parameters: schema.inputSchema } };
+  }
+}
+
+/** List Gemini and Claude publisher models that can be selected for Vertex AI chat. */
+export async function fetchVertexAIModels(credentialsPath: string): Promise<string[]> {
+  const auth = new VertexAIAuth(credentialsPath);
+  const token = await auth.getAccessToken();
+  const fetchPublisher = async (publisher: "google" | "anthropic"): Promise<string[]> => {
+    const models: string[] = [];
+    let pageToken: string | undefined;
+    do {
+      const url = new URL(`https://aiplatform.googleapis.com/v1beta1/publishers/${publisher}/models`);
+      url.searchParams.set("pageSize", "100");
+      if (publisher === "anthropic") url.searchParams.set("listAllVersions", "true");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!response.ok) throw new Error(`Vertex AI ${publisher} models API error ${response.status}`);
+      const data = await response.json() as { publisherModels?: { name?: string }[]; nextPageToken?: string };
+      for (const model of data.publisherModels ?? []) {
+        const pattern = publisher === "google"
+          ? /publishers\/google\/models\/(gemini-[^@/]+)/
+          : /publishers\/anthropic\/models\/(claude-[^/]+)/;
+        const match = pattern.exec(model.name ?? "");
+        if (!match) continue;
+        if (publisher === "google" && /tts/i.test(match[1]!)) continue;
+        models.push(`vertex/${match[1]}`);
+      }
+      pageToken = data.nextPageToken;
+    } while (pageToken);
+    return models;
+  };
+
+  const results = await Promise.allSettled([fetchPublisher("google"), fetchPublisher("anthropic")]);
+  const models = results.flatMap((result) => result.status === "fulfilled" ? result.value : []);
+  if (models.length === 0 && results.every((result) => result.status === "rejected")) {
+    throw new AggregateError(
+      results.map((result) => result.status === "rejected" ? result.reason : undefined),
+      "Unable to list Vertex AI Gemini or Claude models",
+    );
+  }
+  return [...new Set(models)].sort((a, b) => a.localeCompare(b));
+}

--- a/source/utils/file-context.ts
+++ b/source/utils/file-context.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { basename, extname, join, relative, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import type { ContentBlock } from "../providers/types.js";
+import { setEnvHint } from "./shell-hints.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -379,6 +380,19 @@ async function detectLibreOffice(): Promise<string | null> {
   return null;
 }
 
+/**
+ * Where LibreOffice conventionally installs on this platform. The layout
+ * differs by more than the path separator, so this cannot come from the
+ * generic `examplePath` helper.
+ */
+function libreOfficeExamplePath(): string {
+  switch (process.platform) {
+    case "darwin": return "/Applications/LibreOffice.app/Contents/MacOS/soffice";
+    case "win32": return "C:\\Program Files\\LibreOffice\\program\\soffice.exe";
+    default: return "/usr/bin/soffice";
+  }
+}
+
 function findLibreOffice(): Promise<string | null> {
   libreOfficePromise ??= detectLibreOffice();
   return libreOfficePromise;
@@ -415,7 +429,10 @@ async function readOfficeContext(path: string, size: number, options: FileContex
 
   const extension = extname(path).toLowerCase();
   if (!MODERN_OFFICE_EXTENSIONS.has(extension)) {
-    throw new Error(`LibreOffice is required to read legacy ${extension} files. Install LibreOffice or set LIBREOFFICE_PATH.`);
+    throw new Error(
+      `LibreOffice is required to read legacy ${extension} files. Install LibreOffice, `
+      + `or point Agav at an existing install with ${setEnvHint("LIBREOFFICE_PATH", libreOfficeExamplePath())}`,
+    );
   }
   if (options.startLine !== undefined || options.endLine !== undefined) {
     throw new Error("Line ranges cannot be used with Office documents");

--- a/source/utils/shell-hints.ts
+++ b/source/utils/shell-hints.ts
@@ -39,6 +39,21 @@ export function agavHomePath(relativePath = ""): string {
   }
 }
 
+/**
+ * A sample absolute path written in the local platform's convention, so a
+ * Windows user is not shown `/path/to/file.json` next to a `%USERPROFILE%\…`
+ * path in the same message.
+ */
+export function examplePath(...segments: string[]): string {
+  switch (detectShell()) {
+    case "powershell":
+    case "cmd":
+      return `C:\\${segments.join("\\")}`;
+    default:
+      return `/${segments.join("/")}`;
+  }
+}
+
 export function reinstallHint(): string {
   switch (detectShell()) {
     case "powershell":


### PR DESCRIPTION
## Summary

- Adds support of vertex-ai provider using the json credentials file. 
- Fixes startup provider/model resolution across normal, explicit-provider, and resumed-session flows.
- Prevents `--resume --provider <provider>` from combining the overridden provider with an incompatible saved model.


## Changes

- Added centralized startup provider and model resolution.
- Restored both the saved provider and model for plain `--resume`.
- Made explicit `--provider` and `--model` flags override saved session values.
- Uses the selected provider’s default model when overriding a session from another provider.
- Validates credentials only after determining the final provider.


## Related Issues

Fixes #51 

## Type

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

- [x] `npx tsc --noEmit` passes
- [x] Manually tested in terminal
- [x] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [x] Tested with `--provider vertex-ai`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

Additional validation:

- Tested normal conversation, parallel sub-agents and /ps command.
- `npm run build` passes.
- 28 focused startup, Vertex AI, and CLI smoke tests pass.

