### PR TITLE
fix: make Shift+Enter insert a newline, with universal fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,44 @@ git clone https://github.com/prapaa-ai/agav && cd agav && pnpm install --frozen-
 git clone https://github.com/prapaa-ai/agav; cd agav; pnpm install --frozen-lockfile; pnpm build; pnpm start
 ```
 
+## Multi-line input
+
+Press **Shift+Enter** to insert a newline instead of sending the message.
+
+This requires the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) — without it your terminal transmits the exact same byte for Shift+Enter and Enter, so the modifier is lost before Agav ever sees it. Agav asks the terminal on startup and adapts: Kitty, Ghostty, WezTerm, foot, Alacritty and recent iTerm2 support it, and terminals that don't are left untouched.
+
+`Ctrl+J` inserts a newline on **every terminal and every platform**, with no configuration. It is the fallback to reach for when Shift+Enter does nothing.
+
+`Alt+Enter` (`Option+Enter` on macOS) also works, but only where the terminal sends Option as Meta.
+
+The prompt footer only advertises the bindings your terminal can actually send, so whatever it shows will work.
+
+### macOS Terminal.app
+
+Terminal.app implements neither the Kitty protocol nor CSI-u, and ships with Option-as-Meta **off**, so out of the box `Ctrl+J` is the only newline key. You can verify the limitation yourself — Enter and Shift+Enter both emit a single `0d` byte:
+
+```bash
+# press Enter, then Shift+Enter, then Ctrl+C to quit
+( trap 'stty sane' EXIT INT; stty -icanon -echo; cat -v )
+```
+
+Both print `^M`. In a terminal that supports the protocol, Shift+Enter prints `^[[13;2u` instead.
+
+Either of these recovers a dedicated key:
+
+- **Option+Enter** — Settings → Profiles → **Keyboard** → check **Use Option as Meta key**.
+- **Shift+Enter** — Settings → Profiles → **Keyboard** → **+** → Key `Return`, Modifier `Shift`, Action `Send Text`, then press the Esc key followed by Return so the field contains `\033\r`. Agav already binds that sequence to `newline`.
+
+For Shift+Enter with no setup at all, use a terminal that implements the protocol: Kitty, Ghostty, WezTerm, foot, Alacritty, or a recent iTerm2.
+
+To bind something else, set `newline` in `~/.agav/keybindings.json` (or `.agav/keybindings.json` in a project):
+
+```json
+{ "newline": ["shift+enter", "meta+enter", "ctrl+o"] }
+```
+
+If a terminal answers the protocol query but handles it badly, set `AGAV_KITTY_KEYBOARD=0` to force the legacy encoding, or `AGAV_KITTY_KEYBOARD=1` to force the protocol on.
+
 ## Documentation
 
 Detailed CLI documentation can be found [here](https://docs.agav.dev).

--- a/source/__tests__/config-keybindings.test.ts
+++ b/source/__tests__/config-keybindings.test.ts
@@ -97,3 +97,89 @@ describe("keybindings", () => {
     expect(resolver.feed("w", { ctrl: true, meta: false, shift: false, return: false, escape: false, tab: false, upArrow: false, downArrow: false, leftArrow: false, rightArrow: false, backspace: false, delete: false })).toMatchObject({ action: "deleteWordBackward" });
   });
 });
+
+/** A key event with nothing pressed, so each test only states the bits it cares about. */
+const NO_KEY = {
+  upArrow: false, downArrow: false, leftArrow: false, rightArrow: false,
+  return: false, escape: false, ctrl: false, shift: false,
+  tab: false, backspace: false, delete: false, meta: false,
+};
+
+describe("newline keybinding", () => {
+  /** Feed one event through the resolver the input prompt uses. */
+  async function resolveNewline(input: string, key: Partial<typeof NO_KEY>) {
+    const mod = await import("../config/keybindings.js");
+    const resolver = new mod.KeybindingResolver(mod.DEFAULT_KEYBINDINGS, ["newline", "submit"]);
+    const normalized = mod.normalizeKeyEvent(input, { ...NO_KEY, ...key });
+    return { ...resolver.feed(normalized.input, normalized.key), normalized };
+  }
+
+  // The regression this guards: Shift+Enter used to resolve to "enter" because the
+  // legacy encoding drops the modifier, so it submitted instead of inserting.
+  it("resolves shift+enter to newline", async () => {
+    expect(await resolveNewline("", { return: true, shift: true })).toMatchObject({ action: "newline" });
+  });
+
+  it("still resolves a plain enter to submit", async () => {
+    expect(await resolveNewline("", { return: true })).toMatchObject({ action: "submit" });
+  });
+
+  it("keeps meta+enter bound to newline for terminals without the protocol", async () => {
+    expect(await resolveNewline("", { return: true, meta: true })).toMatchObject({ action: "newline" });
+  });
+
+  // Ctrl+J sends a bare linefeed on every terminal and platform, which Ink names
+  // "enter" with no modifiers — it would otherwise be inserted as a raw byte.
+  it("resolves a bare linefeed to newline as ctrl+j", async () => {
+    const result = await resolveNewline("\n", {});
+    expect(result.normalized).toMatchObject({ input: "j", key: expect.objectContaining({ ctrl: true }) });
+    expect(result).toMatchObject({ action: "newline" });
+  });
+
+  // xterm and older iTerm2 send modifyOtherKeys=2 sequences that Ink does not
+  // parse, so the escape sequence used to land in the prompt as literal text.
+  it("decodes the xterm modifyOtherKeys form of shift+enter", async () => {
+    const result = await resolveNewline("[27;2;13~", {});
+    expect(result.normalized.input).toBe("");
+    expect(result.normalized.key).toMatchObject({ return: true, shift: true, ctrl: false, meta: false });
+    expect(result).toMatchObject({ action: "newline" });
+  });
+
+  it("decodes modifyOtherKeys sequences that still carry their escape prefix", async () => {
+    const mod = await import("../config/keybindings.js");
+    expect(mod.normalizeKeyEvent("\x1b[27;5;9~", NO_KEY).key).toMatchObject({ tab: true, ctrl: true });
+    expect(mod.normalizeKeyEvent("\x1b[27;3;27~", NO_KEY).key).toMatchObject({ escape: true, meta: true });
+    expect(mod.normalizeKeyEvent("\x1b[27;5;97~", NO_KEY)).toMatchObject({ input: "a", key: expect.objectContaining({ ctrl: true }) });
+  });
+
+  it("leaves ordinary input untouched", async () => {
+    const mod = await import("../config/keybindings.js");
+    expect(mod.normalizeKeyEvent("a", NO_KEY)).toEqual({ input: "a", key: NO_KEY });
+    expect(mod.normalizeKeyEvent("\r", { ...NO_KEY, return: true })).toEqual({ input: "\r", key: { ...NO_KEY, return: true } });
+  });
+
+  it("only advertises newline bindings the terminal can send", async () => {
+    const mod = await import("../config/keybindings.js");
+    const withProtocol = mod.formatUsableKeybinding(mod.DEFAULT_KEYBINDINGS, "newline", true);
+    const withoutProtocol = mod.formatUsableKeybinding(mod.DEFAULT_KEYBINDINGS, "newline", false);
+
+    expect(withProtocol).toContain("Shift+");
+    expect(withoutProtocol).not.toContain("Shift+");
+    expect(withoutProtocol).toContain("Ctrl+J");
+  });
+
+  it("falls back to the full list rather than advertising nothing", async () => {
+    const mod = await import("../config/keybindings.js");
+    const bindings = { ...mod.DEFAULT_KEYBINDINGS, newline: ["shift+enter"] };
+    expect(mod.formatUsableKeybinding(bindings, "newline", false)).toContain("Shift+");
+  });
+
+  it("treats only strokes the legacy encoding cannot carry as protocol-only", async () => {
+    const mod = await import("../config/keybindings.js");
+    expect(mod.requiresEnhancedKeyboard("shift+enter")).toBe(true);
+    expect(mod.requiresEnhancedKeyboard("ctrl+enter")).toBe(true);
+    expect(mod.requiresEnhancedKeyboard("meta+enter")).toBe(false);
+    expect(mod.requiresEnhancedKeyboard("ctrl+j")).toBe(false);
+    expect(mod.requiresEnhancedKeyboard("ctrl+k shift+enter")).toBe(true);
+  });
+});

--- a/source/__tests__/utils.terminal-keyboard.test.ts
+++ b/source/__tests__/utils.terminal-keyboard.test.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+import { detectKittyKeyboard } from "../utils/terminal-keyboard.js";
+
+/** Minimal stand-in for a raw-mode TTY stdin, recording what the probe does to it. */
+class FakeStdin extends EventEmitter {
+  isTTY = true;
+  isRaw = false;
+  paused = true;
+  unshifted: Buffer[] = [];
+  rawModeCalls: boolean[] = [];
+
+  setRawMode(value: boolean): this {
+    this.rawModeCalls.push(value);
+    this.isRaw = value;
+    return this;
+  }
+
+  isPaused(): boolean {
+    return this.paused;
+  }
+
+  pause(): this {
+    this.paused = true;
+    return this;
+  }
+
+  resume(): this {
+    this.paused = false;
+    return this;
+  }
+
+  override on(event: string, listener: (...args: any[]) => void): this {
+    if (event === "data") this.paused = false;
+    return super.on(event, listener);
+  }
+
+  unshift(chunk: Buffer): void {
+    this.unshifted.push(chunk);
+  }
+}
+
+function fakeStdout() {
+  return { isTTY: true, write: vi.fn() };
+}
+
+/** Run a probe against a fresh fake terminal, optionally replying to the query. */
+function probe(reply?: (stdin: FakeStdin) => void, env: NodeJS.ProcessEnv = {}) {
+  const stdin = new FakeStdin();
+  const stdout = fakeStdout();
+  const result = detectKittyKeyboard({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    timeoutMs: 20,
+    env,
+  });
+  reply?.(stdin);
+  return { stdin, stdout, result };
+}
+
+describe("detectKittyKeyboard", () => {
+  it("reports support when the terminal answers the query", async () => {
+    const { stdout, result } = probe((stdin) => stdin.emit("data", Buffer.from("\x1b[?1u")));
+    await expect(result).resolves.toBe(true);
+    expect(stdout.write).toHaveBeenCalledWith("\x1b[?u");
+  });
+
+  // A terminal without support never answers at all, so the timeout is the answer.
+  it("reports no support when the terminal stays silent", async () => {
+    const { result } = probe();
+    await expect(result).resolves.toBe(false);
+  });
+
+  it("restores raw mode and the paused state it found", async () => {
+    const { stdin, result } = probe((s) => s.emit("data", Buffer.from("\x1b[?0u")));
+    await result;
+    expect(stdin.rawModeCalls).toEqual([true, false]);
+    expect(stdin.isRaw).toBe(false);
+    expect(stdin.paused).toBe(true);
+  });
+
+  it("leaves an already-flowing stdin flowing", async () => {
+    const stdin = new FakeStdin();
+    stdin.paused = false;
+    stdin.isRaw = true;
+    const result = detectKittyKeyboard({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: fakeStdout() as unknown as NodeJS.WriteStream,
+      timeoutMs: 20,
+      env: {},
+    });
+    stdin.emit("data", Buffer.from("\x1b[?1u"));
+
+    await result;
+    expect(stdin.paused).toBe(false);
+    // Already raw, so the probe must not have toggled raw mode at all.
+    expect(stdin.rawModeCalls).toEqual([]);
+  });
+
+  // Anything the user typed during the probe has to go back into the stream, or
+  // the first keystroke after startup silently disappears.
+  it("returns keystrokes that arrived alongside the reply", async () => {
+    const { stdin, result } = probe((s) => s.emit("data", Buffer.from("\x1b[?1uhello")));
+    await expect(result).resolves.toBe(true);
+    expect(Buffer.concat(stdin.unshifted).toString("latin1")).toBe("hello");
+  });
+
+  it("drops a reply that was still arriving when the timeout fired", async () => {
+    const { stdin, result } = probe((s) => s.emit("data", Buffer.from("x\x1b[?1")));
+    await expect(result).resolves.toBe(false);
+    expect(Buffer.concat(stdin.unshifted).toString("latin1")).toBe("x");
+  });
+
+  it("skips the probe entirely when stdin is not a TTY", async () => {
+    const stdin = new FakeStdin();
+    stdin.isTTY = false;
+    const stdout = fakeStdout();
+
+    await expect(detectKittyKeyboard({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      env: {},
+    })).resolves.toBe(false);
+    expect(stdout.write).not.toHaveBeenCalled();
+  });
+
+  it("skips the probe on CI and dumb terminals", async () => {
+    await expect(probe(undefined, { CI: "true" }).result).resolves.toBe(false);
+    await expect(probe(undefined, { TERM: "dumb" }).result).resolves.toBe(false);
+  });
+
+  it("honours the AGAV_KITTY_KEYBOARD override in both directions", async () => {
+    // Forced on, with a stdin that would never have answered.
+    const forcedOn = probe(undefined, { AGAV_KITTY_KEYBOARD: "1" });
+    await expect(forcedOn.result).resolves.toBe(true);
+    expect(forcedOn.stdout.write).not.toHaveBeenCalled();
+
+    // Forced off, with a stdin that would have answered.
+    const forcedOff = probe((s) => s.emit("data", Buffer.from("\x1b[?1u")), { AGAV_KITTY_KEYBOARD: "off" });
+    await expect(forcedOff.result).resolves.toBe(false);
+  });
+
+  it("ignores an unrecognised override value and probes anyway", async () => {
+    const { stdout, result } = probe(
+      (s) => s.emit("data", Buffer.from("\x1b[?1u")),
+      { AGAV_KITTY_KEYBOARD: "maybe" },
+    );
+    await expect(result).resolves.toBe(true);
+    expect(stdout.write).toHaveBeenCalledWith("\x1b[?u");
+  });
+
+  it("resolves false instead of throwing when the terminal rejects raw mode", async () => {
+    const stdin = new FakeStdin();
+    stdin.setRawMode = () => { throw new Error("no raw mode"); };
+
+    await expect(detectKittyKeyboard({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: fakeStdout() as unknown as NodeJS.WriteStream,
+      timeoutMs: 20,
+      env: {},
+    })).resolves.toBe(false);
+  });
+});

--- a/source/__tests__/utils.wrap-text.test.ts
+++ b/source/__tests__/utils.wrap-text.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { stripAnsi, visualLen, wrapToWidth } from "../utils/wrap-text.js";
+
+/** The invariant the padded background band depends on. */
+function fitsOnOneRow(lines: string[], width: number): boolean {
+  return lines.every((line) => visualLen(line) <= width && !/[\r\n]/.test(line));
+}
+
+describe("wrapToWidth", () => {
+  it("leaves text that already fits on one line", () => {
+    expect(wrapToWidth("hello there", 40)).toEqual(["hello there"]);
+  });
+
+  // The bug behind the torn message band: a newline inside the content used to
+  // survive into a rendered line and move the cursor to column 0 mid-row.
+  it("splits on hard line breaks instead of emitting a newline inside a line", () => {
+    expect(wrapToWidth("yo\nyo", 40)).toEqual(["yo", "yo"]);
+    expect(wrapToWidth("a\r\nb\rc", 40)).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps a blank line blank rather than collapsing it", () => {
+    expect(wrapToWidth("one\n\ntwo", 40)).toEqual(["one", "", "two"]);
+  });
+
+  it("wraps each hard line independently", () => {
+    expect(wrapToWidth("aaa bbb ccc\nddd eee fff", 7)).toEqual(["aaa bbb", "ccc", "ddd eee", "fff"]);
+  });
+
+  it("cuts a word wider than the row instead of letting it overflow", () => {
+    const lines = wrapToWidth("x".repeat(11), 4);
+    expect(lines).toEqual(["xxxx", "xxxx", "xxx"]);
+    expect(fitsOnOneRow(lines, 4)).toBe(true);
+  });
+
+  it("cuts an overlong word that follows text on the same line", () => {
+    const lines = wrapToWidth("hi " + "y".repeat(9), 4);
+    expect(lines).toEqual(["hi", "yyyy", "yyyy", "y"]);
+    expect(fitsOnOneRow(lines, 4)).toBe(true);
+  });
+
+  it("measures width in visible characters, ignoring ANSI codes", () => {
+    const colored = "\x1b[31mredtext\x1b[39m";
+    expect(wrapToWidth(colored, 7)).toEqual([colored]);
+  });
+
+  it("always returns at least one line", () => {
+    expect(wrapToWidth("", 40)).toEqual([""]);
+  });
+
+  // A zero or negative width would otherwise spin forever in the cut loop.
+  it("terminates on a non-positive width", () => {
+    expect(wrapToWidth("abc", 0)).toEqual(["a", "b", "c"]);
+    expect(wrapToWidth("abc", -5)).toEqual(["a", "b", "c"]);
+  });
+
+  it("never emits a line the terminal would have to wrap", () => {
+    const content = "short\n\n" + "z".repeat(200) + "\nsome ordinary trailing words here";
+    expect(fitsOnOneRow(wrapToWidth(content, 30), 30)).toBe(true);
+  });
+});
+
+describe("stripAnsi", () => {
+  it("removes SGR sequences and OSC-8 hyperlinks", () => {
+    expect(stripAnsi("\x1b[1mbold\x1b[22m")).toBe("bold");
+    expect(visualLen("\x1b]8;;https://example.com\x1b\\link")).toBe(4);
+  });
+});

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -27,7 +27,7 @@ import { getRandomHint } from "./utils/hints.js";
 import { fileLink } from "./utils/hyperlink.js";
 import { getClipboardImage, type ClipboardImage } from "./utils/clipboard-image.js";
 import { useClipboardImageDetector } from "./hooks/use-paste-handler.js";
-import { KeybindingResolver, formatKeybinding, formatKeybindings, type Keybindings } from "./config/keybindings.js";
+import { KeybindingResolver, formatKeybinding, formatKeybindings, normalizeKeyEvent, type Keybindings } from "./config/keybindings.js";
 import { getLoopStatus, stopActiveLoop } from "./commands/loop.js";
 import { loadScheduledTasks, cronMatches, markTaskRun } from "./config/scheduler.js";
 import { getSandboxName } from "./utils/sandbox.js";
@@ -45,6 +45,8 @@ interface Props {
   resumeCompacted?: boolean;
   resumeSessionName?: string;
   repoBranch?: string;
+  /** Whether the terminal negotiated an enhanced keyboard protocol (Shift+Enter is legible). */
+  enhancedKeyboard?: boolean;
 }
 
 const BANNER: DisplayMessage = {
@@ -56,7 +58,7 @@ const BANNER: DisplayMessage = {
 let sysMessageId = 0;
 
 /** Render the interactive terminal UI and coordinate command, tool, and subagent views. */
-export default function App({ config: initialConfig, keybindings, resumeMessages, resumeSessionId, resumeTokenUsage, resumeCompacted, resumeSessionName, repoBranch }: Props) {
+export default function App({ config: initialConfig, keybindings, resumeMessages, resumeSessionId, resumeTokenUsage, resumeCompacted, resumeSessionName, repoBranch, enhancedKeyboard = false }: Props) {
 
   const [input, setInput] = useState("");
   const [config, setConfig] = useState(initialConfig);
@@ -264,8 +266,9 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   }, [focusedSubagentId, isLoading]);
 
   /** Reserve a few global shortcuts for cancellation and tool/subagent inspection. */
-  useInput((char, key) => {
+  useInput((rawChar, rawKey) => {
     if (pickerActive) return;
+    const { input: char, key } = normalizeKeyEvent(rawChar, rawKey);
     const match = keyResolverRef.current.feed(char, key);
     if (match.action === "interrupt" && isLoading && !pendingConfirmation) {
       cancel();
@@ -626,6 +629,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
             ...commandRegistryRef.current.list().map((c) => ({ name: c.name, description: c.description })),
           ]}
           keybindings={keybindings}
+          enhancedKeyboard={enhancedKeyboard}
           resumeUserMessages={resumeUserMessages}
         /></Box>
       )}
@@ -639,7 +643,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
         outputTokens={tokenUsage.outputTokens}
         cacheReadTokens={tokenUsage.cacheReadTokens}
         cacheWriteTokens={tokenUsage.cacheWriteTokens}
-        hint={useMemo(() => getRandomHint(keybindings), [messages.length, keybindings])}
+        hint={useMemo(() => getRandomHint(keybindings, enhancedKeyboard), [messages.length, keybindings, enhancedKeyboard])}
         psResponse={psResponse}
         psLoading={psLoading}
         loopStatus={(() => { const ls = getLoopStatus(); return ls ? `⟳ Loop: "${ls.prompt}" every ${ls.interval} (tick #${ls.tickCount})` : undefined; })()}

--- a/source/components/input-prompt.tsx
+++ b/source/components/input-prompt.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Box, Text, useInput, useStdin } from "ink";
-import { KeybindingResolver, formatKeybinding, type Keybindings } from "../config/keybindings.js";
+import { KeybindingResolver, formatKeybinding, formatUsableKeybinding, normalizeKeyEvent, type Keybindings } from "../config/keybindings.js";
 import { loadPromptHistory, savePromptHistory } from "../config/prompt-history.js";
 import { readdir, realpath } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
@@ -22,6 +22,8 @@ interface Props {
   disabled?: boolean;
   commands?: CommandInfo[];
   keybindings: Keybindings;
+  /** Whether the terminal negotiated an enhanced keyboard protocol (Shift+Enter is legible). */
+  enhancedKeyboard?: boolean;
   resumeUserMessages?: string[];
 }
 
@@ -73,7 +75,7 @@ function isWithinRoot(root: string, candidate: string): boolean {
 }
 
 /** Renders the interactive prompt with history, completion, and paste handling. */
-export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemoveAttachment, onClearAttachments, onRegisterInsert, disabled, commands = [], keybindings, resumeUserMessages }: Props) {
+export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemoveAttachment, onClearAttachments, onRegisterInsert, disabled, commands = [], keybindings, enhancedKeyboard = false, resumeUserMessages }: Props) {
   const { isRawModeSupported } = useStdin();
   const [cursorPos, setCursorPos] = useState(0);
   const historyRef = useRef<string[]>([]);
@@ -181,8 +183,9 @@ export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemo
   }, [activeFileToken?.query]);
 
   useInput(
-    (input, key) => {
+    (rawInput, rawKey) => {
       if (disabled) return;
+      const { input, key } = normalizeKeyEvent(rawInput, rawKey);
       const match = keyResolverRef.current.feed(input, key);
       if (match.pending) return;
 
@@ -491,7 +494,7 @@ export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemo
       )}
       {isMultiline && (
         <Box marginTop={1}>
-          <Text dimColor>  {formatKeybinding(keybindings, "submit")} to send · {formatKeybinding(keybindings, "newline")} for newline</Text>
+          <Text dimColor>  {formatKeybinding(keybindings, "submit")} to send · {formatUsableKeybinding(keybindings, "newline", enhancedKeyboard)} for newline</Text>
         </Box>
       )}
     </Box>

--- a/source/components/message-list.tsx
+++ b/source/components/message-list.tsx
@@ -7,6 +7,7 @@ import { fileLink } from "../utils/hyperlink.js";
 import type { DiffLine } from "../utils/diff.js";
 import type { InvocationReason } from "../providers/types.js";
 import { projectRelativePath, terminalRelativePaths, toolPathValues } from "../utils/display-path.js";
+import { visualLen, wrapToWidth } from "../utils/wrap-text.js";
 import { VERSION } from "../version.js";
 
 /** Normalized message shape used for terminal rendering. */
@@ -178,24 +179,9 @@ function MessageBubble({ message, prevRole, toolDetailKey }: { message: DisplayM
 
   if (message.role === "user") {
     const cols = process.stdout.columns || 80;
-    const usable = cols - 2;
-    // Strip ANSI escape codes for visual width measurement
-    const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\]8;[^]*?\x1b\\/g, "");
-    const visualLen = (s: string) => stripAnsi(s).length;
-
-    const words = message.content.split(" ");
-    const lines: string[] = [];
-    let current = "";
-    for (const word of words) {
-      const test = current ? `${current} ${word}` : word;
-      if (visualLen(test) > usable && current) {
-        lines.push(current);
-        current = word;
-      } else {
-        current = test;
-      }
-    }
-    if (current) lines.push(current);
+    // Every line is padded out to the full width below, which only paints a clean
+    // band while each one fits on a single row. `wrapToWidth` guarantees that.
+    const lines = wrapToWidth(message.content, cols - 2);
 
     const emptyLine = " ".repeat(cols);
     const invocationText = message.invocationReason

--- a/source/components/tool-confirm.tsx
+++ b/source/components/tool-confirm.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { getToolLabel, getToolSummary } from "../utils/tool-labels.js";
 import type { DiffLine } from "../utils/diff.js";
 import { getTheme } from "../config/theme.js";
-import { KeybindingResolver, type Keybindings } from "../config/keybindings.js";
+import { KeybindingResolver, normalizeKeyEvent, type Keybindings } from "../config/keybindings.js";
 import { terminalToolValue } from "../utils/display-path.js";
 
 /** Represents the user's approval decision for a tool request. */
@@ -21,7 +21,8 @@ interface Props {
 /** Prompts the user to approve or reject a pending tool action. */
 export default function ToolConfirm({ toolName, input, diffLines, onConfirm, subagentTask, keybindings }: Props) {
   const keyResolver = React.useRef(new KeybindingResolver(keybindings, ["cancel", "submit"]));
-  useInput((char, key) => {
+  useInput((rawChar, rawKey) => {
+    const { input: char, key } = normalizeKeyEvent(rawChar, rawKey);
     const match = keyResolver.current.feed(char, key);
     if (char === "y" || char === "Y" || match.action === "submit") {
       onConfirm("yes");

--- a/source/config/keybindings.ts
+++ b/source/config/keybindings.ts
@@ -45,7 +45,9 @@ export const DEFAULT_KEYBINDINGS: Keybindings = {
   cancel: ["escape"],
   toggleToolDetail: ["ctrl+d"],
   cycleSubagents: ["tab"],
-  newline: ["shift+enter", "meta+enter"],
+  // Shift+Enter only survives an enhanced keyboard protocol; the other two are
+  // the fallbacks every terminal can send. See normalizeKeyEvent below.
+  newline: ["shift+enter", "meta+enter", "ctrl+j"],
   submit: ["enter"],
   historyUp: ["up"],
   historyDown: ["down"],
@@ -122,6 +124,67 @@ interface InkKey {
   meta: boolean;
 }
 
+/** `CSI 27 ; modifiers ; codepoint ~` — xterm's `modifyOtherKeys=2` encoding. */
+const XTERM_OTHER_KEY_RE = /^\x1b?\[27;(\d+);(\d+)~$/;
+
+/** Overlay `patch` on an Ink key event without losing fields Ink adds beyond InkKey. */
+function patchKey<K extends InkKey>(key: K, patch: Partial<InkKey>): K {
+  return { ...key, ...patch } as K;
+}
+
+/**
+ * Fold terminal-specific encodings of a key into the shape Ink reports for its
+ * Kitty-protocol equivalent, so a binding resolves the same way everywhere.
+ *
+ * Ink negotiates the Kitty protocol and parses CSI-u, which covers the modern
+ * terminals. Two encodings fall outside that and reach us raw:
+ *
+ *   - Linefeed (`\n`). Ctrl+J sends it on every terminal and every platform, and
+ *     several terminals send it for Ctrl+Enter. Ink names it `enter` rather than
+ *     `return`, so no key flag and no modifier is set and the byte would be
+ *     inserted as text. Reported as Ctrl+J, the stroke that produces it.
+ *   - xterm's `modifyOtherKeys=2` form, used by xterm and older iTerm2 builds.
+ *     Ink does not parse it at all, so the escape sequence leaked into the prompt
+ *     as literal text.
+ */
+export function normalizeKeyEvent<K extends InkKey>(input: string, key: K): { input: string; key: K } {
+  if (input === "\n") return { input: "j", key: patchKey(key, { ctrl: true }) };
+
+  const otherKey = XTERM_OTHER_KEY_RE.exec(input);
+  if (!otherKey) return { input, key };
+
+  // The protocol sends modifiers biased by one; bits are shift/alt/ctrl.
+  const modifiers = Math.max(0, Number(otherKey[1]) - 1);
+  const codepoint = Number(otherKey[2]);
+  const decoded: Partial<InkKey> = {
+    shift: (modifiers & 1) !== 0,
+    meta: (modifiers & 2) !== 0,
+    ctrl: (modifiers & 4) !== 0,
+  };
+
+  if (codepoint === 13) return { input: "", key: patchKey(key, { ...decoded, return: true }) };
+  if (codepoint === 9) return { input: "", key: patchKey(key, { ...decoded, tab: true }) };
+  if (codepoint === 27) return { input: "", key: patchKey(key, { ...decoded, escape: true }) };
+  if (codepoint === 127 || codepoint === 8) return { input: "", key: patchKey(key, { ...decoded, backspace: true }) };
+  // Anything else is a printable key carrying modifiers. Drop it when the
+  // codepoint is out of range rather than letting fromCodePoint throw.
+  if (!Number.isInteger(codepoint) || codepoint < 32 || codepoint > 0x10_ffff) {
+    return { input: "", key: patchKey(key, decoded) };
+  }
+  return { input: String.fromCodePoint(codepoint), key: patchKey(key, decoded) };
+}
+
+/**
+ * Strokes the legacy terminal encoding cannot represent: it folds Shift+Enter and
+ * Ctrl+Enter into the same bare `\r` a plain Enter sends, so the modifier is
+ * unrecoverable. They only arrive when an enhanced keyboard protocol is active.
+ */
+const ENHANCED_ONLY_STROKES = new Set(["shift+enter", "ctrl+enter", "ctrl+shift+enter", "shift+escape", "ctrl+escape"]);
+
+export function requiresEnhancedKeyboard(binding: string): boolean {
+  return binding.split(" ").some((stroke) => ENHANCED_ONLY_STROKES.has(stroke));
+}
+
 function eventStroke(input: string, key: InkKey): string | null {
   let name: string | null = null;
   if (key.return) name = "enter";
@@ -196,6 +259,23 @@ export function formatKeybinding(bindings: Keybindings, action: KeybindingAction
     }).join("+"))
     .join(" "))
     .join(" / ");
+}
+
+/**
+ * Format only the bindings for `action` this terminal can actually deliver, so a
+ * hint never advertises a key the terminal folds into something else. Falls back
+ * to the full list when every binding needs the protocol — a hint that cannot be
+ * followed still beats no hint at all.
+ */
+export function formatUsableKeybinding(
+  bindings: Keybindings,
+  action: KeybindingAction,
+  enhancedKeyboard: boolean,
+): string {
+  if (enhancedKeyboard) return formatKeybinding(bindings, action);
+  const usable = bindings[action].filter((binding) => !requiresEnhancedKeyboard(binding));
+  if (usable.length === 0) return formatKeybinding(bindings, action);
+  return formatKeybinding({ ...bindings, [action]: usable }, action);
 }
 
 export function formatKeybindings(bindings: Keybindings): string {

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -685,9 +685,18 @@ export async function main() {
   });
 
   const { getGitContext } = await import("./utils/git.js");
-  const gitContext = await getGitContext();
-  const { waitUntilExit } = render(<App config={config} keybindings={keybindings} resumeMessages={resumeMessages} resumeSessionId={resumeSessionId} resumeTokenUsage={resumeTokenUsage} resumeCompacted={resumeCompacted} resumeSessionName={resumeSessionName} repoBranch={gitContext?.branch} />, {
+  const { detectKittyKeyboard } = await import("./utils/terminal-keyboard.js");
+  // The keyboard probe waits on the terminal, so overlap it with the git lookup
+  // rather than adding its timeout to startup. Both settle rather than reject.
+  const [gitContext, enhancedKeyboard] = await Promise.all([getGitContext(), detectKittyKeyboard()]);
+
+  const { waitUntilExit } = render(<App config={config} keybindings={keybindings} resumeMessages={resumeMessages} resumeSessionId={resumeSessionId} resumeTokenUsage={resumeTokenUsage} resumeCompacted={resumeCompacted} resumeSessionName={resumeSessionName} repoBranch={gitContext?.branch} enhancedKeyboard={enhancedKeyboard} />, {
     exitOnCtrlC: true,
+    // Detection already happened, so pin the mode instead of letting Ink query a
+    // second time. `disambiguateEscapeCodes` alone is deliberate: it is what makes
+    // Shift+Enter distinguishable, and it avoids the key-release events that the
+    // reportEventTypes flag would deliver as phantom presses.
+    kittyKeyboard: { mode: enhancedKeyboard ? "enabled" : "disabled", flags: ["disambiguateEscapeCodes"] },
   });
 
   await waitUntilExit();

--- a/source/utils/hints.ts
+++ b/source/utils/hints.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_KEYBINDINGS, formatKeybinding, type Keybindings } from "../config/keybindings.js";
+import { DEFAULT_KEYBINDINGS, formatKeybinding, formatUsableKeybinding, type Keybindings } from "../config/keybindings.js";
 import { agavHomePath } from "./shell-hints.js";
 import { detectSandboxBackend, getSandboxName } from "./sandbox.js";
 
@@ -55,9 +55,11 @@ const HINTS = [
 
 let lastIndex = -1;
 
-export function getRandomHint(keybindings: Keybindings = DEFAULT_KEYBINDINGS): string {
+export function getRandomHint(keybindings: Keybindings = DEFAULT_KEYBINDINGS, enhancedKeyboard = false): string {
   const dynamicHints = [
-    `${formatKeybinding(keybindings, "newline")} for multiline input`,
+    // Terminals without an enhanced keyboard protocol cannot send Shift+Enter, so
+    // hinting it there would send the user chasing a key that does nothing.
+    `${formatUsableKeybinding(keybindings, "newline", enhancedKeyboard)} for multiline input`,
     `${formatKeybinding(keybindings, "historyUp")}/${formatKeybinding(keybindings, "historyDown")} to recall previous messages`,
     `${formatKeybinding(keybindings, "toggleToolDetail")} expands tool output details`,
     `${formatKeybinding(keybindings, "cancel")} cancels a streaming response`,

--- a/source/utils/terminal-keyboard.ts
+++ b/source/utils/terminal-keyboard.ts
@@ -1,0 +1,115 @@
+/**
+ * Runtime detection for the Kitty keyboard protocol.
+ *
+ * Without it, Shift+Enter is indistinguishable from Enter: the legacy encoding
+ * transmits a bare `\r` for both. Ink can negotiate the protocol, but only tells
+ * the terminal — it never reports back whether the terminal agreed, and the UI
+ * needs to know so it does not advertise a key that cannot work here.
+ *
+ * So we run the query ourselves before Ink starts, then hand Ink the answer as an
+ * explicit `enabled`/`disabled` mode instead of letting it probe a second time.
+ *
+ * @see https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+ */
+
+/** `CSI ? <flags> u` — a terminal that speaks the protocol answers the query with this. */
+const REPLY_RE = /\x1b\[\?\d*u/;
+
+/** A reply still arriving when the timeout fires. Dropped rather than replayed as input. */
+const PARTIAL_REPLY_RE = /\x1b(?:\[(?:\?[\d;]*)?)?$/;
+
+const ENV_FLAG = "AGAV_KITTY_KEYBOARD";
+
+export interface DetectKittyKeyboardOptions {
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+  /** How long to wait for a reply. Terminals without support simply never answer. */
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+/** Read the escape hatch for terminals that answer the query but mishandle the protocol. */
+function readOverride(env: NodeJS.ProcessEnv): boolean | undefined {
+  const raw = env[ENV_FLAG]?.trim().toLowerCase();
+  if (!raw) return undefined;
+  if (["0", "false", "off", "no"].includes(raw)) return false;
+  if (["1", "true", "on", "yes"].includes(raw)) return true;
+  return undefined;
+}
+
+/**
+ * Ask the terminal whether it supports the Kitty keyboard protocol.
+ *
+ * Resolves `false` for anything that cannot answer — a pipe, a CI runner, a dumb
+ * terminal — rather than stalling for the timeout. Never throws, never leaves the
+ * terminal in a different state than it found it, and unshifts anything the user
+ * typed during the probe so no keystroke is swallowed.
+ */
+export async function detectKittyKeyboard(options: DetectKittyKeyboardOptions = {}): Promise<boolean> {
+  const env = options.env ?? process.env;
+  const override = readOverride(env);
+  if (override !== undefined) return override;
+
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+  const timeoutMs = options.timeoutMs ?? 200;
+
+  // Probing a stream that cannot reply just writes the query somewhere it will be
+  // echoed back at the user as text.
+  if (!stdin.isTTY || !stdout.isTTY) return false;
+  if (typeof stdin.setRawMode !== "function") return false;
+  if (env["CI"]) return false;
+  if (env["TERM"] === "dumb") return false;
+
+  return await new Promise<boolean>((resolve) => {
+    const wasRaw = stdin.isRaw === true;
+    const wasPaused = stdin.isPaused();
+    const chunks: Buffer[] = [];
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    // latin1 round-trips arbitrary bytes through a string losslessly, which lets
+    // the reply be matched and stripped without corrupting real keystrokes.
+    const onData = (data: Buffer | string): void => {
+      chunks.push(typeof data === "string" ? Buffer.from(data, "latin1") : data);
+      if (REPLY_RE.test(Buffer.concat(chunks).toString("latin1"))) finish(true);
+    };
+
+    const finish = (supported: boolean): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      stdin.removeListener("data", onData);
+
+      try {
+        const leftover = Buffer.concat(chunks)
+          .toString("latin1")
+          .replace(REPLY_RE, "")
+          .replace(PARTIAL_REPLY_RE, "");
+        // Stop the flow before putting bytes back. Attaching the listener resumed
+        // the stream, and an unshift into a flowing stream with no listener left on
+        // it is discarded rather than buffered.
+        stdin.pause();
+        if (leftover.length > 0) stdin.unshift(Buffer.from(leftover, "latin1"));
+        if (!wasRaw) stdin.setRawMode(false);
+        if (!wasPaused) stdin.resume();
+      } catch {
+        // Restoring is best effort — a failure here must not take down startup.
+      }
+
+      resolve(supported);
+    };
+
+    try {
+      if (!wasRaw) stdin.setRawMode(true);
+      // Attach before writing so an immediate reply is not missed.
+      stdin.on("data", onData);
+      // Deliberately not unref'd: the timer is the only thing that ends the probe,
+      // and letting the loop drain out from under it would strand the promise.
+      timer = setTimeout(() => finish(false), timeoutMs);
+      stdout.write("\x1b[?u");
+    } catch {
+      finish(false);
+    }
+  });
+}

--- a/source/utils/wrap-text.ts
+++ b/source/utils/wrap-text.ts
@@ -1,0 +1,53 @@
+/**
+ * Line breaking for text drawn inside a padded background band.
+ *
+ * A band is painted by writing the text followed by enough spaces to reach the
+ * right edge. That only holds while every line occupies exactly one row: if the
+ * terminal wraps a line itself, the cursor jumps to column 0 partway through and
+ * the padding — measured for a single row — lands in the wrong place, tearing the
+ * band open. So the caller must never hand the renderer a line the terminal would
+ * have to break, which means newlines and overlong words are resolved here.
+ */
+
+/** Drop SGR and OSC-8 sequences so widths are measured in visible characters. */
+export function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\]8;[^]*?\x1b\\/g, "");
+}
+
+export function visualLen(value: string): number {
+  return stripAnsi(value).length;
+}
+
+/**
+ * Break `content` into lines that each fit within `width` visible columns.
+ *
+ * Hard line breaks in the input are preserved, including blank ones, so a
+ * multi-line message keeps its shape. Words longer than `width` are cut rather
+ * than allowed to overflow. Always returns at least one line.
+ */
+export function wrapToWidth(content: string, width: number): string[] {
+  // A non-positive width would leave the overlong-word loop unable to progress.
+  const usable = Math.max(1, Math.floor(width));
+  const lines: string[] = [];
+
+  for (const paragraph of content.split(/\r\n|\r|\n/)) {
+    let current = "";
+    for (const word of paragraph.split(" ")) {
+      const candidate = current ? `${current} ${word}` : word;
+      if (visualLen(candidate) <= usable) {
+        current = candidate;
+        continue;
+      }
+      if (current) lines.push(current);
+      current = word;
+      while (visualLen(current) > usable) {
+        lines.push(current.slice(0, usable));
+        current = current.slice(usable);
+      }
+    }
+    // Pushed unconditionally so a blank line stays blank instead of collapsing.
+    lines.push(current);
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## Summary

- **Shift+Enter now inserts a newline instead of submitting** (#60). Because the legacy terminal encoding transmits a bare `\r` for both Enter and Shift+Enter, this is only recoverable via an enhanced keyboard protocol — so the fix is layered: negotiate the protocol where it exists, and provide fallbacks that work everywhere else.
- **Universal fallback:** `Ctrl+J` inserts a newline on every terminal and platform with no configuration, and `Alt/Option+Enter` works wherever the terminal sends Option as Meta. The prompt footer only advertises bindings the current terminal can actually deliver, so a hint is never a lie.
- **Fixes two bugs found along the way:** xterm `modifyOtherKeys=2` sequences were being inserted into the prompt as literal text (`[27;2;13~`), and a newline inside a user message tore open the padded background band in the transcript.

## Changes

**Keyboard protocol detection — `source/utils/terminal-keyboard.ts` (new)**
- Queries the terminal with `CSI ? u` before Ink starts and waits up to 200 ms for a `CSI ? <flags> u` reply. Ink can negotiate the protocol but never reports back whether the terminal agreed, and the UI needs that answer.
- Restores raw-mode and paused state exactly as found, and unshifts any keystrokes that arrived during the probe so no input is swallowed. Pauses before unshifting — an unshift into a flowing stream with no listener is discarded, not buffered.
- Short-circuits to `false` for non-TTY, CI, and `TERM=dumb` rather than stalling for the timeout.
- Escape hatch: `AGAV_KITTY_KEYBOARD=0|1` forces the answer either way.

**Encoding normalization — `source/config/keybindings.ts`**
- New `normalizeKeyEvent()` folds two encodings Ink doesn't handle into the shape it reports for their Kitty equivalents:
  - **Linefeed (`\n`)** — Ink names it `enter` rather than `return`, so no key flag or modifier was set and the byte was inserted as raw text. Now reported as `Ctrl+J`.
  - **xterm `modifyOtherKeys=2`** (`CSI 27 ; mods ; codepoint ~`, used by xterm and older iTerm2) — Ink doesn't parse it at all, so the escape sequence leaked into the prompt as literal text.
- New `requiresEnhancedKeyboard()` marks strokes the legacy encoding cannot represent, and `formatUsableKeybinding()` filters hints down to what this terminal can send.
- Default `newline` binding is now `["shift+enter", "meta+enter", "ctrl+j"]`.

**Wiring — `source/main.tsx`, `source/app.tsx`, `source/components/input-prompt.tsx`, `source/components/tool-confirm.tsx`, `source/utils/hints.ts`**
- The probe runs concurrently with the git-context lookup so its timeout doesn't add to startup, then Ink is handed a pinned `enabled`/`disabled` mode instead of querying a second time.
- `disambiguateEscapeCodes` only — deliberately not `reportEventTypes`, which would deliver key *release* events as phantom presses.
- The resolved value flows to the components so footers and hints adapt.

**Transcript rendering — `source/utils/wrap-text.ts` (new), `source/components/message-list.tsx`**
- The user-message band is painted by writing the text and padding out to the right edge, which only holds while every line occupies one row. The wrapper split on `" "` and nothing else, so `"yo\nyo"` was treated as a single 5-character word: the padding was computed for one row, then the embedded newline moved the cursor to column 0 partway through.
- Extracted into `wrapToWidth()`, which splits on hard breaks, preserves blank lines, cuts words wider than the row, and clamps width to ≥1 so the cut loop always progresses. The same defect already affected any long URL or path, independent of #60.

**Docs — `README.md`**
- New **Multi-line input** section covering the protocol requirement, the universal `Ctrl+J` fallback, remapping via `keybindings.json`, and the `AGAV_KITTY_KEYBOARD` override.
- A **macOS Terminal.app** subsection: it implements neither the Kitty protocol nor CSI-u and ships Option-as-Meta off, so `Ctrl+J` is the only newline key out of the box. Includes a self-check command and the two ways to recover a dedicated key.

## Related Issues

Closes #60

## Type

<!-- Check one -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

- [x] `npx tsc --noEmit` passes
- [x] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

**On the unchecked boxes:** these changes are entirely in the input and rendering layers and don't touch provider code, so no provider-specific runs were made. For pipe mode, rather than a live run I verified the property that actually matters — piped output contains **zero** escape bytes, confirming the probe correctly skips a non-TTY stdout and never leaks its query into captured output.

**Automated:** 177 tests across 31 files pass. 22 new tests:
- `source/__tests__/utils.terminal-keyboard.test.ts` (11) — reply/silence/timeout, raw-mode and paused-state restoration, leftover-keystroke replay, partial-reply drop, non-TTY / CI / dumb skips, env override both directions, and `setRawMode` throwing.
- `source/__tests__/utils.wrap-text.test.ts` (11) — hard breaks, blank-line preservation, overlong-word cutting, ANSI-aware width, non-positive width termination.
- `source/__tests__/config-keybindings.test.ts` (+11) — Shift+Enter → newline, plain Enter still submits, linefeed → `Ctrl+J`, `modifyOtherKeys` decoding, and hint filtering.

**Mutation-tested:** each load-bearing change was reverted individually to confirm the tests actually catch it, then restored. Removing the hard-break split fails 4 targeted tests.

**Real pty:** verified end-to-end via `script(1)` with paced keystrokes — protocol-off emits exactly one `CSI ? u` and no stray escapes; protocol-on emits `>1u` on start and `<u` on clean exit; Shift+Enter, `Ctrl+J` and `modifyOtherKeys` all insert newlines; plain Enter still submits; the footer drops `Shift+Return` when the protocol is inactive.

## Screenshots / Terminal Output

The band tear from #60's follow-on bug, rendered in a 60-column pty.

**Before** — padding computed for one row, so the band ends at `yo` and the second line starts at column 0 with a short right edge:

```
                                                            
❯ yo
yo                                                     
                                                            
```

**After** — every line fits one row, continuation lines get the dim indent:

```
                                                            
❯ yo                                                        
  yo                                                        
                                                            
```

A 120-character unbroken token, which was broken before #60 too:

```
❯ wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
  wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
  wwww                                                      
```