### PR TITLE
fix(windows): PowerShell installer 308 and false 'replace error' on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,14 @@ curl -fsSL https://agav.dev/install.sh | bash
 For Windows PowerShell:
 
 ```powershell
-irm https://agav.dev/install.ps1 | iex
+irm https://www.agav.dev/install.ps1 | iex
 ```
+
+> [!NOTE]
+> The `www.` is deliberate. `agav.dev` redirects with a 308, and Windows
+> PowerShell 5.1 cannot follow that status — it fails with
+> `(308) Permanent Redirect`. `curl` follows it fine, so the other commands
+> here use the short host.
 
 For Windows Command Prompt (`cmd.exe`):
 
@@ -76,7 +82,7 @@ curl -fsSL https://agav.dev/install.sh | bash -s -- --uninstall
 **Windows PowerShell:**
 
 ```powershell
-& ([scriptblock]::Create((irm https://agav.dev/install.ps1))) --uninstall
+& ([scriptblock]::Create((irm https://www.agav.dev/install.ps1))) --uninstall
 ```
 
 **Windows Command Prompt (`cmd.exe`):**

--- a/source/__tests__/utils.auto-update-install.test.ts
+++ b/source/__tests__/utils.auto-update-install.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, readFile, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Only `rm` is faked — everything else runs against a real temp directory, so
+// the rename/copy behaviour under test is the real thing.
+const rmMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return { ...actual, default: actual, rm: rmMock };
+});
+
+const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+const { installUpdate, cleanupStaleBackups } = await import("../utils/auto-update.js");
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "agav-update-"));
+  rmMock.mockReset();
+  rmMock.mockImplementation((...args: any[]) => (actualFs.rm as any)(...args));
+});
+
+afterEach(async () => {
+  await actualFs.rm(dir, { recursive: true, force: true });
+});
+
+async function seedInstall(): Promise<{ binaryPath: string; downloadPath: string }> {
+  const binaryPath = join(dir, "agav.exe");
+  const downloadPath = join(dir, "agav-update-v0.1.7");
+  await writeFile(binaryPath, "old binary");
+  await writeFile(downloadPath, "new binary");
+  return { binaryPath, downloadPath };
+}
+
+describe("installUpdate on a plain binary install", () => {
+  it("puts the downloaded binary in place and clears the backup", async () => {
+    const { binaryPath, downloadPath } = await seedInstall();
+
+    await installUpdate(downloadPath, "v0.1.7", binaryPath);
+
+    expect(await readFile(binaryPath, "utf8")).toBe("new binary");
+    expect((await readdir(dir)).filter((f) => f.endsWith(".bak"))).toEqual([]);
+  });
+
+  // Windows refuses to delete the executable of a running process, so the very
+  // last step of an otherwise successful update used to throw and get reported
+  // as "failed (replace error)" — while the new binary was already installed.
+  it("still succeeds when the backup cannot be deleted", async () => {
+    const { binaryPath, downloadPath } = await seedInstall();
+    rmMock.mockImplementation(async (target: any) => {
+      if (String(target).endsWith(".bak")) {
+        throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+      }
+      return (actualFs.rm as any)(target, { force: true });
+    });
+
+    await expect(installUpdate(downloadPath, "v0.1.7", binaryPath)).resolves.toBeUndefined();
+    expect(await readFile(binaryPath, "utf8")).toBe("new binary");
+  });
+
+  // Two agav processes updating in turn must not collide on one backup name:
+  // the first one's backup is still locked when the second one renames.
+  it("names the backup per process so a locked leftover cannot block it", async () => {
+    const { binaryPath, downloadPath } = await seedInstall();
+    await writeFile(join(dir, "agav.exe.99999.bak"), "someone else's locked backup");
+    rmMock.mockImplementation(async (target: any) => {
+      if (String(target).endsWith(".bak")) throw new Error("EPERM");
+      return (actualFs.rm as any)(target, { force: true });
+    });
+
+    await installUpdate(downloadPath, "v0.1.7", binaryPath);
+
+    const backups = (await readdir(dir)).filter((f) => f.endsWith(".bak")).sort();
+    expect(backups).toContain("agav.exe.99999.bak");
+    expect(backups).toContain(`agav.exe.${process.pid}.bak`);
+  });
+});
+
+describe("cleanupStaleBackups", () => {
+  it("removes leftovers from earlier updates and leaves everything else alone", async () => {
+    const binaryPath = join(dir, "agav.exe");
+    await writeFile(binaryPath, "binary");
+    await writeFile(join(dir, "agav.exe.123.bak"), "old");
+    await writeFile(join(dir, "agav.exe.456.bak"), "older");
+    await writeFile(join(dir, "notes.txt"), "keep me");
+
+    await cleanupStaleBackups(binaryPath);
+
+    expect((await readdir(dir)).sort()).toEqual(["agav.exe", "notes.txt"]);
+  });
+
+  it("never throws when a backup is still locked", async () => {
+    const binaryPath = join(dir, "agav.exe");
+    await writeFile(binaryPath, "binary");
+    await writeFile(join(dir, "agav.exe.123.bak"), "locked");
+    rmMock.mockRejectedValue(Object.assign(new Error("EBUSY"), { code: "EBUSY" }));
+
+    await expect(cleanupStaleBackups(binaryPath)).resolves.toBeUndefined();
+  });
+
+  it("never throws when the directory does not exist", async () => {
+    await expect(cleanupStaleBackups(join(dir, "gone", "agav.exe"))).resolves.toBeUndefined();
+  });
+});

--- a/source/__tests__/utils.shell-hints.test.ts
+++ b/source/__tests__/utils.shell-hints.test.ts
@@ -50,7 +50,8 @@ describe("shell hints", () => {
       expect(setEnvHint("GEMINI_API_KEY", "test-key")).toBe('$env:GEMINI_API_KEY="test-key"');
       expect(agavHomePath("skills/example")).toBe("$HOME\\.agav\\skills\\example");
       expect(examplePath("path", "to", "service-account.json")).toBe("C:\\path\\to\\service-account.json");
-      expect(reinstallHint()).toBe("irm https://agav.dev/install.ps1 | iex");
+      // www, not the apex: PowerShell 5.1 cannot follow the apex's 308.
+      expect(reinstallHint()).toBe("irm https://www.agav.dev/install.ps1 | iex");
     });
   });
 

--- a/source/utils/auto-update.ts
+++ b/source/utils/auto-update.ts
@@ -1,6 +1,6 @@
 import { join, sep } from "node:path";
 import { homedir, platform, arch } from "node:os";
-import { readFile, writeFile, rename, chmod, copyFile, unlink, mkdir, symlink, rm } from "node:fs/promises";
+import { readFile, writeFile, rename, chmod, copyFile, unlink, mkdir, readdir, symlink, rm } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { createWriteStream, createReadStream } from "node:fs";
 import { createHash } from "node:crypto";
@@ -233,7 +233,7 @@ async function replaceSymlink(linkPath: string, target: string): Promise<void> {
  * Move a verified download into place. Managed installs get a new versioned
  * release dir plus a symlink swap; a plain binary is replaced in place.
  */
-async function installUpdate(
+export async function installUpdate(
   downloadedPath: string,
   versionTag: string,
   binaryPath: string,
@@ -252,12 +252,39 @@ async function installUpdate(
     return;
   }
 
-  const backupPath = `${binaryPath}.bak`;
+  // Windows will happily rename a running executable but refuses to delete it,
+  // and it keeps the lock for as long as this process lives. The backup name is
+  // therefore per-process: a leftover from an older still-running agav must not
+  // become an undeletable obstacle in the path of the next update's rename.
+  const backupPath = `${binaryPath}.${process.pid}.bak`;
   await safeMove(binaryPath, backupPath);
   await safeMove(downloadedPath, binaryPath);
   await chmod(binaryPath, 0o755);
-  // Don't leave a stale copy of the previous version lying around.
-  await rm(backupPath, { force: true });
+  // Best-effort only. By this point the new binary is already in place, so
+  // failing to delete the old one is untidy, not a failed update — reporting it
+  // as one sent Windows users chasing an update that had actually succeeded.
+  await rm(backupPath, { force: true }).catch(() => {});
+}
+
+/**
+ * Delete backups left behind by earlier updates. On Windows the process that
+ * created one could not delete it while running, so the next launch does it.
+ */
+export async function cleanupStaleBackups(binaryPath: string): Promise<void> {
+  try {
+    const parts = binaryPath.split(sep);
+    const name = parts.pop() ?? "";
+    const dir = parts.join(sep);
+    if (!dir || !name) return;
+    const stale = (await readdir(dir)).filter(
+      (entry) => entry.startsWith(`${name}.`) && entry.endsWith(".bak"),
+    );
+    for (const entry of stale) {
+      await rm(join(dir, entry), { force: true }).catch(() => {});
+    }
+  } catch {
+    // Cleanup is never worth failing a launch over.
+  }
 }
 
 /** Resolve the path the running process should re-exec after an update. */
@@ -381,6 +408,8 @@ export async function forceUpdate(targetVersion?: string): Promise<boolean> {
     return false;
   }
 
+  await cleanupStaleBackups(binaryPath);
+
   process.stderr.write(`  Downloading ${latestTag}...`);
   const downloaded = await downloadBinary(latestTag);
   if (!downloaded) {
@@ -409,8 +438,10 @@ export async function forceUpdate(targetVersion?: string): Promise<boolean> {
 
     process.stderr.write(`\n  Agav updated: v${local} → ${latestTag}\n`);
     return true;
-  } catch {
-    process.stderr.write(` failed (replace error).\n`);
+  } catch (error) {
+    // Name the reason. "replace error" alone gave a Windows user reporting a
+    // locked-file failure nothing to act on.
+    process.stderr.write(` failed (${error instanceof Error ? error.message : String(error)}).\n`);
     return false;
   }
 }
@@ -422,6 +453,11 @@ export async function checkAndUpdate(): Promise<void> {
   if (process.env["CI"] || process.env["AGAV_NO_UPDATE"] === "1" || !process.stdout.isTTY) {
     return;
   }
+
+  // A previous update on Windows could not delete its own backup while it was
+  // still running. This launch is the first moment that lock is gone.
+  const currentBinary = getCurrentBinaryPath();
+  if (currentBinary) await cleanupStaleBackups(currentBinary);
 
   // Check rate limit
   const state = await loadState();
@@ -507,7 +543,8 @@ export async function checkAndUpdate(): Promise<void> {
       process.exit(e.status ?? 0);
     }
     process.exit(0);
-  } catch {
-    process.stderr.write(" failed (replace error). Continuing with current version.\n");
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    process.stderr.write(` failed (${reason}). Continuing with current version.\n`);
   }
 }

--- a/source/utils/shell-hints.ts
+++ b/source/utils/shell-hints.ts
@@ -56,8 +56,12 @@ export function examplePath(...segments: string[]): string {
 
 export function reinstallHint(): string {
   switch (detectShell()) {
+    // The apex domain answers with a 308 to www, and Windows PowerShell 5.1 —
+    // still the default on Windows — cannot follow one: its HttpWebRequest
+    // auto-redirect handles 301/302/303/307 and fails the request outright on
+    // 308. curl follows it fine, so only this line needs the www host.
     case "powershell":
-      return "irm https://agav.dev/install.ps1 | iex";
+      return "irm https://www.agav.dev/install.ps1 | iex";
     case "cmd":
       return "curl -fsSL https://agav.dev/install.cmd -o install.cmd && install.cmd";
     default:


### PR DESCRIPTION
Fixes two Windows-only failures reported from a fresh install on Windows PowerShell 5.1.

```
PS C:\Users\Lenovo> irm https://agav.dev/install.ps1 | iex
irm : The remote server returned an error: (308) Permanent Redirect.

PS C:\Users\Lenovo> agav update
  Current version: 0.1.6
  Target version: v0.1.7
  Downloading v0.1.7... failed (replace error).
```

## 1. PowerShell installer fails with a 308

The apex domain redirects to `www`:

```
https://agav.dev/install.ps1      308 -> https://www.agav.dev/install.ps1
https://www.agav.dev/install.ps1  200
```

Windows PowerShell 5.1 — still the default on Windows — builds `Invoke-RestMethod` on
`HttpWebRequest`, whose auto-redirect handles 301/302/303/307 and fails the request
outright on **308**. `curl` follows 308 without complaint, which is why `install.sh` was
never affected, and `install.cmd` fetches from `raw.githubusercontent.com` anyway.

Only the PowerShell command needs the `www` host. Updated in `reinstallHint()` and in the
README's install and uninstall blocks, with a note explaining why that one line differs.

The alternative is a hosting-side fix (serve the apex directly, or use a 302), which would
let all the commands share the short host.

## 2. `agav update` reports "replace error" after a successful update

For a plain (non-symlinked) install, which is what Windows gets, `installUpdate` did:

| step | operation | Windows |
|---|---|---|
| 1 | rename `agav.exe` -> `agav.exe.bak` | ok, renaming a running image is allowed |
| 2 | rename `<download>` -> `agav.exe` | ok |
| 3 | `chmod` | ok |
| 4 | delete `agav.exe.bak` | **EPERM** — cannot delete a running executable |

Step 4 threw, and the whole update was reported as failed even though the new binary was
already in place. The lock is held for as long as the process lives, so this failed every
single time on Windows.

- Backup removal is now best-effort. The update has already succeeded by that point; an
  undeleted file is untidy, not a failure.
- Backups are named `agav.exe.<pid>.bak`, so a leftover still locked by another running
  agav cannot block the next update's rename.
- New `cleanupStaleBackups()` sweeps leftovers on the next launch — the first moment the
  lock is gone — from both `checkAndUpdate` and `agav update`.
- Both `failed (replace error)` messages now print the underlying error. The vague string
  is the reason this needed a reproduction to diagnose.

## Tests

`installUpdate` is now exported so it can be tested. Six new tests in
`source/__tests__/utils.auto-update-install.test.ts` run against a real temp directory with
only `rm` faked, covering the locked-backup path, per-process backup naming, and the
cleanup sweep. Each was confirmed to fail against the previous code.

`tsc --noEmit` clean, 229/229 tests pass.

## Note

The update fix ships inside the binary, so it only takes effect from the next release
onward — updating *to* that release from an older build will still print the bogus failure.
