### PR TITLE
fix: harden installers and auto-update, add installer test suites

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,6 +19,7 @@ jobs:
       workflows: ${{ steps.diff.outputs.workflows }}
       docs: ${{ steps.diff.outputs.docs }}
       deps: ${{ steps.diff.outputs.deps }}
+      scripts: ${{ steps.diff.outputs.scripts }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,6 +35,7 @@ jobs:
           echo "workflows=false" >> "$GITHUB_OUTPUT"
           echo "docs=false" >> "$GITHUB_OUTPUT"
           echo "deps=false" >> "$GITHUB_OUTPUT"
+          echo "scripts=false" >> "$GITHUB_OUTPUT"
           if echo "$FILES" | grep -qE '^source/'; then
             echo "source=true" >> "$GITHUB_OUTPUT"
           fi
@@ -45,6 +47,9 @@ jobs:
           fi
           if echo "$FILES" | grep -qE '(package\.json|pnpm-lock\.yaml)'; then
             echo "deps=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$FILES" | grep -qE '^scripts/'; then
+            echo "scripts=true" >> "$GITHUB_OUTPUT"
           fi
 
   # --- Core checks (only when source or deps change) ---
@@ -116,6 +121,75 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: npx vitest run --passWithNoTests
+
+  # --- Installer scripts ---
+  # These ship outside the release pipeline (hand-copied to agav.dev), so
+  # nothing else in this workflow would ever look at them.
+  installer-sh:
+    name: Installer Tests (sh)
+    needs: changed
+    if: needs.changed.outputs.scripts == 'true' || needs.changed.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+      - name: ShellCheck
+        run: |
+          shellcheck -s sh \
+            scripts/install.sh \
+            scripts/tests/install-sh.test.sh \
+            scripts/tests/install-sh-path.test.sh \
+            scripts/tests/run-installer-tests.sh
+      - name: Install the other /bin/sh implementations
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends dash busybox
+      - name: Run the suites under every shell
+        # install.sh is `#!/bin/sh`, and which shell that is depends entirely on
+        # the distro: dash on Debian and Ubuntu, bash on Fedora, ash in Alpine.
+        run: |
+          FAIL=0
+          for shell in dash bash "busybox sh"; do
+            echo "::group::$shell"
+            $shell scripts/tests/install-sh.test.sh || FAIL=1
+            $shell scripts/tests/install-sh-path.test.sh || FAIL=1
+            echo "::endgroup::"
+          done
+          if [ "$FAIL" -eq 1 ]; then exit 1; fi
+
+  installer-ps1:
+    name: Installer Tests (PowerShell)
+    needs: changed
+    if: needs.changed.outputs.scripts == 'true' || needs.changed.outputs.workflows == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+      - name: Suites under Windows PowerShell 5.1
+        # This is the host install.cmd actually launches, and the only place the
+        # registry half of the PATH handling runs for real. The suite captures
+        # HKCU\Environment\PATH first and puts it back afterwards.
+        shell: powershell
+        run: |
+          $Fail = 0
+          foreach ($Suite in @("install-ps1.test.ps1", "install-ps1-path.test.ps1")) {
+            Write-Host "::group::5.1 $Suite"
+            & powershell -NoProfile -File "scripts\tests\$Suite"
+            if ($LASTEXITCODE -ne 0) { $Fail = 1 }
+            Write-Host "::endgroup::"
+          }
+          exit $Fail
+      - name: Suites under pwsh 7
+        shell: pwsh
+        run: |
+          $Fail = 0
+          foreach ($Suite in @("install-ps1.test.ps1", "install-ps1-path.test.ps1", "install-ps1-lint.test.ps1")) {
+            Write-Host "::group::pwsh $Suite"
+            & pwsh -NoProfile -File "scripts\tests\$Suite"
+            if ($LASTEXITCODE -ne 0) { $Fail = 1 }
+            Write-Host "::endgroup::"
+          }
+          exit $Fail
 
   # --- Always-run checks ---
   pr-title:
@@ -318,6 +392,8 @@ jobs:
       - typecheck
       - build
       - test
+      - installer-sh
+      - installer-ps1
       - pr-title
       - secret-scan
       - blob-size
@@ -336,6 +412,8 @@ jobs:
             "${{ needs.typecheck.result }}" \
             "${{ needs.build.result }}" \
             "${{ needs.test.result }}" \
+            "${{ needs.installer-sh.result }}" \
+            "${{ needs.installer-ps1.result }}" \
             "${{ needs.pr-title.result }}" \
             "${{ needs.secret-scan.result }}" \
             "${{ needs.blob-size.result }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,43 +218,87 @@ jobs:
 
             ## Installation
 
-            ### macOS
+            Both installers verify the SHA-256 checksum of the download and
+            refuse to install if it does not match.
+
+            ### macOS / Linux
 
             ```bash
-            # Apple Silicon (M1/M2/M3/M4)
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}/agav-darwin-arm64 -o agav
-            chmod +x agav && sudo mv agav /usr/local/bin/
-
-            # Intel
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}/agav-darwin-x64 -o agav
-            chmod +x agav && sudo mv agav /usr/local/bin/
-            ```
-
-            ### Linux
-
-            ```bash
-            # x64
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}/agav-linux-x64 -o agav
-            chmod +x agav && sudo mv agav /usr/local/bin/
-
-            # ARM64
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}/agav-linux-arm64 -o agav
-            chmod +x agav && sudo mv agav /usr/local/bin/
+            curl -fsSL https://agav.dev/install.sh | bash
             ```
 
             ### Windows
 
             ```powershell
-            # Download and install (x64; ARM64 runs this under emulation)
-            New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\agav" | Out-Null
-            Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}/agav-windows-x64.exe" -OutFile "$env:LOCALAPPDATA\agav\agav.exe"
-
-            # Add to PATH (run once)
-            $dir = "$env:LOCALAPPDATA\agav"
-            $path = [Environment]::GetEnvironmentVariable("Path", "User")
-            if ($path -notlike "*$dir*") {
-              [Environment]::SetEnvironmentVariable("Path", "$dir;$path", "User")
-            }
+            irm https://www.agav.dev/install.ps1 | iex
             ```
+
+            The `www.` is deliberate: the apex answers with a 308 and Windows
+            PowerShell 5.1 cannot follow that status.
+
+            <details>
+            <summary>Manual install</summary>
+
+            **macOS / Linux** — pick one of `agav-darwin-arm64`,
+            `agav-darwin-x64`, `agav-linux-x64`, `agav-linux-arm64`.
+
+            ```bash
+            BASE="https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}"
+            ASSET="agav-darwin-arm64"
+
+            curl -fsSL "$BASE/$ASSET" -o agav
+            curl -fsSL "$BASE/$ASSET.sha256" -o agav.sha256
+
+            # Fail closed: install nothing unless the published digest matches.
+            if command -v sha256sum >/dev/null 2>&1; then CHECK="sha256sum -c"; else CHECK="shasum -a 256 -c"; fi
+            if sed "s| $ASSET| agav|" agav.sha256 | $CHECK -; then
+              chmod +x agav && sudo mv agav /usr/local/bin/agav
+            else
+              echo "Checksum mismatch - refusing to install." && rm -f agav
+            fi
+            rm -f agav.sha256
+            ```
+
+            **Windows** — x64 only; ARM64 runs the x64 build under emulation.
+            Close any running agav first: Windows will not let a loaded .exe be
+            overwritten.
+
+            ```powershell
+            $dir = "$env:LOCALAPPDATA\agav"
+            $base = "https://github.com/${{ github.repository }}/releases/download/v${{ needs.check-version.outputs.version }}"
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+
+            # .NET below 4.7 negotiates TLS 1.0, which github.com refuses.
+            # -UseBasicParsing keeps this off the IE engine, absent on Server Core.
+            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+            Invoke-WebRequest -UseBasicParsing -Uri "$base/agav-windows-x64.exe" -OutFile "$dir\agav.exe.tmp"
+
+            # Verify before running it. Fail closed.
+            $expected = (((Invoke-WebRequest -UseBasicParsing -Uri "$base/agav-windows-x64.exe.sha256").Content) -split '\s+')[0]
+            if ((Get-FileHash "$dir\agav.exe.tmp" -Algorithm SHA256).Hash -ne $expected.ToUpperInvariant()) {
+              Remove-Item "$dir\agav.exe.tmp" -Force
+              throw "Checksum mismatch - refusing to install."
+            }
+            Move-Item "$dir\agav.exe.tmp" "$dir\agav.exe" -Force
+
+            # Add to PATH (run once). Write the registry value directly:
+            # [Environment]::GetEnvironmentVariable returns PATH already expanded,
+            # so writing it back bakes every %USERPROFILE%-style entry into a
+            # literal path and flattens a REG_EXPAND_SZ PATH permanently.
+            $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+            $raw = [string]$key.GetValue("PATH", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            $kind = if ($raw) { $key.GetValueKind("PATH") } else { [Microsoft.Win32.RegistryValueKind]::ExpandString }
+            # Compare whole segments. `-like "*$dir*"` treats $dir as a wildcard
+            # pattern and matches substrings, so an unrelated "C:\agav-old"
+            # already on PATH would silently suppress the edit.
+            $onPath = @($raw.Split(';') | Where-Object { $_.Trim().Trim('"').TrimEnd('\') -eq $dir }).Count -gt 0
+            if (-not $onPath) {
+              $key.SetValue("PATH", $(if ($raw) { "$dir;$raw" } else { $dir }), $kind)
+            }
+            $key.Close()
+            $env:PATH = "$dir;$env:PATH"
+            ```
+
+            </details>
           generate_release_notes: true
           files: release/*

--- a/README.md
+++ b/README.md
@@ -71,18 +71,24 @@ Or download a specific platform binary from [Releases](../../releases).
 
 ### Uninstall
 
-Both installers accept `--uninstall`.
+Both installers accept two flags: `--uninstall` removes the binary and takes the `PATH` entry back out, and `--purge` does that *and* deletes your settings and history. `--purge` implies `--uninstall`, so you never need to pass both.
 
 **macOS / Linux:**
 
 ```bash
 curl -fsSL https://agav.dev/install.sh | bash -s -- --uninstall
+
+# ...or, to delete your settings and history too:
+curl -fsSL https://agav.dev/install.sh | bash -s -- --purge
 ```
 
 **Windows PowerShell:**
 
 ```powershell
 & ([scriptblock]::Create((irm https://www.agav.dev/install.ps1))) --uninstall
+
+# ...or, to delete your settings and history too:
+& ([scriptblock]::Create((irm https://www.agav.dev/install.ps1))) --purge
 ```
 
 **Windows Command Prompt (`cmd.exe`):**
@@ -93,32 +99,23 @@ install.cmd --uninstall
 del install.cmd
 ```
 
-If you installed via a package manager instead, remove it the same way:
+#### What each flag removes
 
-```bash
-npm uninstall -g agav-cli    # or: bun remove -g agav-cli
-```
-
-#### What `--uninstall` leaves behind
-
-It removes the binary, but deliberately keeps your settings and does not edit your shell profile:
-
-| | Removed | Left behind |
+| | `--uninstall` | `--purge` adds |
 | --- | --- | --- |
-| macOS / Linux | `~/.local/bin/agav`, `~/.agav/packages/standalone/` | `~/.agav/` config, `PATH` line in your shell profile |
-| Windows | `%LOCALAPPDATA%\agav\agav.exe` | `%USERPROFILE%\.agav\` config, `PATH` entry in your user environment |
+| macOS / Linux | `~/.local/bin/agav`, `~/.agav/packages/standalone/`, the installer's block in your shell profile | `~/.agav/` |
+| Windows | `%LOCALAPPDATA%\agav\agav.exe`, the `PATH` entry in your user environment | `%USERPROFILE%\.agav\` |
 
-To remove your configuration as well — this deletes `config.json` (which holds your **encrypted API keys**), `prompt-history.json`, `keybindings.json`, and any installed `plugins/` and `skills/`:
+`--purge` deletes `config.json` (which holds your **encrypted API keys**), `prompt-history.json`, `keybindings.json`, and any installed `plugins/` and `skills/`. There is no undo.
 
-```bash
-rm -rf ~/.agav                       # macOS / Linux
-```
+Open a new terminal afterwards — the one you ran this in keeps the `PATH` it started with.
 
-```powershell
-Remove-Item -Recurse -Force "$HOME\.agav"    # Windows
-```
+Agav also writes per-project directories inside repositories you've worked in: `.agav/` (cached images) and `.agav-worktrees/`. Uninstalling never touches those; delete them yourself if you want them gone.
 
-To remove the `PATH` entry, delete this block from your shell profile — `~/.zprofile` (macOS + zsh), `~/.bash_profile` (macOS + bash), `~/.zshrc` or `~/.bashrc` (Linux), or `~/.profile`:
+<details>
+<summary>Uninstalled with an older script?</summary>
+
+Versions before 0.1.8 left the `PATH` entry behind. On macOS or Linux, delete this block from your shell profile — `~/.zprofile` (macOS + zsh), `~/.bash_profile` (macOS + bash), `~/.zshrc` or `~/.bashrc` (Linux), or `~/.profile`:
 
 ```bash
 # >>> Agav installer >>>
@@ -128,7 +125,7 @@ export PATH="$HOME/.local/bin:$PATH"
 
 On Windows, remove the Agav entry from your user `PATH` under **Settings → Edit environment variables for your account**.
 
-Agav also writes per-project directories inside repositories you've worked in — `.agav/` (cached images) and `.agav-worktrees/`. Delete those individually if you want them gone.
+</details>
 
 ### Run from source
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A terminal-native environment for running local AI systems",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run source",
     "test:coverage": "vitest run --coverage",
+    "test:installer": "sh scripts/tests/run-installer-tests.sh",
     "build:binary": "bun build source/cli.tsx --compile --outfile dist/agav",
     "build:binary:all": "bash scripts/build-binary.sh all",
     "prepare": "husky"

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -1,7 +1,14 @@
 @echo off
 setlocal
 
-set "INSTALLER_URL=https://raw.githubusercontent.com/prapaa-ai/agav/main/scripts/install.ps1"
+rem Fetch from the release host rather than a raw git branch. Pulling from a
+rem branch meant cmd users always ran whatever was on main instead of the
+rem installer that shipped with a release, so an unrelated commit could break
+rem this path instantly. Set AGAV_INSTALLER_URL to override.
+rem The www host is deliberate: the apex answers with a 308 and Windows
+rem PowerShell 5.1 cannot follow that status.
+if not defined AGAV_INSTALLER_URL set "AGAV_INSTALLER_URL=https://www.agav.dev/install.ps1"
+set "INSTALLER_URL=%AGAV_INSTALLER_URL%"
 set "TMP_PS1=%TEMP%\agav-install-%RANDOM%-%RANDOM%.ps1"
 
 where powershell.exe >nul 2>nul
@@ -11,9 +18,20 @@ if errorlevel 1 (
 )
 
 echo agav ^> Downloading installer...
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri '%INSTALLER_URL%' -OutFile '%TMP_PS1%'"
+rem -UseBasicParsing keeps this off the Internet Explorer engine, which is
+rem absent on Server Core and unconfigured on a fresh profile. Tls12 is forced
+rem because .NET below 4.7 negotiates TLS 1.0 and github.com rejects it.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; try { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 } catch {}; Invoke-WebRequest -UseBasicParsing -Uri '%INSTALLER_URL%' -OutFile '%TMP_PS1%'"
 if errorlevel 1 (
   echo ERROR: Failed to download installer from %INSTALLER_URL%
+  if exist "%TMP_PS1%" del "%TMP_PS1%" >nul 2>nul
+  exit /b 1
+)
+
+rem A proxy or captive portal can answer 200 with an error page; a truncated or
+rem empty script would otherwise be handed straight to PowerShell.
+for %%A in ("%TMP_PS1%") do if %%~zA LSS 1000 (
+  echo ERROR: Downloaded installer looks invalid ^(%%~zA bytes^).
   if exist "%TMP_PS1%" del "%TMP_PS1%" >nul 2>nul
   exit /b 1
 )

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,35 +5,216 @@
 # the whole script fails to parse.
 $ErrorActionPreference = "Stop"
 
+# .NET Framework older than 4.7 negotiates TLS 1.0/1.1 by default, which
+# github.com refuses outright. Additive so we never downgrade a host that
+# already prefers something stronger.
+try {
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {}
+
 $Repo = "prapaa-ai/agav"
 $BinaryName = "agav.exe"
 $Version = if ($env:AGAV_VERSION) { $env:AGAV_VERSION } else { "latest" }
 $InstallDir = if ($env:AGAV_INSTALL_DIR) { $env:AGAV_INSTALL_DIR } else { "$env:LOCALAPPDATA\agav" }
+$SkipChecksum = $env:AGAV_SKIP_CHECKSUM -match '^(1|true|yes)$'
+
+# Windows refuses to delete the image of a running process, so an update
+# renames the old exe aside and deletes it later. Sweep whatever earlier runs
+# could not, before anything else touches the directory. A ~100 MB leftover per
+# interrupted install adds up fast.
+function Remove-StaleArtifacts {
+    param([Parameter(Mandatory = $true)][string]$Dir, [Parameter(Mandatory = $true)][string]$Name)
+
+    if (-not (Test-Path -LiteralPath $Dir)) { return }
+
+    Get-ChildItem -LiteralPath $Dir -Filter "$Name.*" -File -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $Leftover = $_.Name
+            # Both are named "<binary>.<pid>.<ext>"; the legacy installer wrote a
+            # plain "<binary>.tmp" with no pid, which nothing produces any more.
+            if ($Leftover -eq "$Name.tmp") {
+                Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
+                return
+            }
+            if ($Leftover -notmatch "^$([regex]::Escape($Name))\.(\d+)\.(bak|tmp)$") { return }
+            $OwnerPid = [int]$Matches[1]
+            $Kind = $Matches[2]
+            # A .tmp belonging to a live process is a download in flight for a
+            # second installer. Locked .bak files just fail to delete, harmlessly.
+            if ($Kind -eq "tmp" -and (Get-Process -Id $OwnerPid -ErrorAction SilentlyContinue)) { return }
+            Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
+        }
+}
+
+# Does this one PATH segment name that directory?
+#
+# Compares whole segments. `-like "*$Dir*"` treated the directory as a wildcard
+# pattern and matched substrings, so an unrelated "C:\agav-old" already on PATH
+# looked like a hit and suppressed the edit.
+#
+# Install and uninstall both go through here so the two can never disagree
+# about what counts as "already on PATH".
+function Test-PathSegment {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Segment,
+          [Parameter(Mandatory = $true)][string]$Needle)
+
+    $Candidate = $Segment.Trim().Trim('"').TrimEnd('\')
+    if ($Candidate.Length -eq 0) { return $false }
+    if ($Candidate -eq $Needle) { return $true }
+    # The stored value may still hold %VARS%; the expanded form is what the
+    # shell will actually search.
+    try {
+        return [Environment]::ExpandEnvironmentVariables($Candidate).TrimEnd('\') -eq $Needle
+    } catch {}
+    return $false
+}
+
+function Test-PathContainsDir {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$PathValue,
+          [Parameter(Mandatory = $true)][string]$Dir)
+
+    if ([string]::IsNullOrEmpty($PathValue)) { return $false }
+    $Needle = $Dir.TrimEnd('\')
+    foreach ($Segment in $PathValue.Split(';')) {
+        if (Test-PathSegment -Segment $Segment -Needle $Needle) { return $true }
+    }
+    return $false
+}
+
+# Drop a directory from a PATH value, leaving every other segment byte-for-byte
+# alone. Returns $null when nothing matched, so the caller can skip the write.
+#
+# Uninstalling used to leave the PATH entry behind, pointing at a directory it
+# had just deleted.
+function Remove-PathSegment {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$PathValue,
+          [Parameter(Mandatory = $true)][string]$Dir)
+
+    if ([string]::IsNullOrEmpty($PathValue)) { return $null }
+    $Needle = $Dir.TrimEnd('\')
+    $Kept = @()
+    $Dropped = $false
+    foreach ($Segment in $PathValue.Split(';')) {
+        if (Test-PathSegment -Segment $Segment -Needle $Needle) { $Dropped = $true }
+        else { $Kept += $Segment }
+    }
+    if (-not $Dropped) { return $null }
+    return ($Kept -join ';')
+}
 
 # --- Parse flags ---
+# Two passes: collect every flag first, then act. Acting inline meant
+# `--uninstall --dir=C:\tools` uninstalled from the default directory, because
+# --uninstall was reached before --dir had been read.
+$DoUninstall = $false
+$Purge = $false
+
 foreach ($arg in $args) {
-    if ($arg -eq "--uninstall") {
-        $Target = Join-Path $InstallDir $BinaryName
-        if (Test-Path $Target) {
-            Remove-Item $Target -Force
-            Write-Host "Uninstalled agav from $InstallDir" -ForegroundColor Green
-        } else {
-            Write-Host "agav not found in $InstallDir" -ForegroundColor Red
-        }
-        exit 0
-    }
+    if ($arg -eq "--uninstall") { $DoUninstall = $true }
+    # --purge is useless on its own, so it implies --uninstall.
+    if ($arg -eq "--purge") { $DoUninstall = $true; $Purge = $true }
     if ($arg -match "^--version=(.+)$") { $Version = $Matches[1] }
     if ($arg -match "^--dir=(.+)$") { $InstallDir = $Matches[1] }
+    if ($arg -eq "--skip-checksum") { $SkipChecksum = $true }
     if ($arg -eq "--help" -or $arg -eq "-h") {
         Write-Host "Usage: install.ps1 [OPTIONS]"
         Write-Host ""
         Write-Host "Options:"
         Write-Host "  --version=<tag>    Install a specific version (default: latest)"
         Write-Host "  --dir=<path>       Install directory (default: %LOCALAPPDATA%\agav)"
-        Write-Host "  --uninstall        Remove agav"
+        Write-Host "  --skip-checksum    Install without verifying the SHA-256 checksum"
+        Write-Host "  --uninstall        Remove agav, keeping your settings and history"
+        Write-Host "  --purge            Remove agav and delete %USERPROFILE%\.agav as well"
         Write-Host "  -h, --help         Show this help"
+        Write-Host ""
+        Write-Host "Environment:"
+        Write-Host "  AGAV_VERSION         Version to install; overridden by --version."
+        Write-Host "  AGAV_INSTALL_DIR     Install directory; overridden by --dir."
+        Write-Host "  AGAV_SKIP_CHECKSUM   Set to 1/true/yes to skip verification."
         exit 0
     }
+}
+
+if ($DoUninstall) {
+    $Target = Join-Path $InstallDir $BinaryName
+    $Removed = $false
+    $PathChanged = $false
+    Remove-StaleArtifacts -Dir $InstallDir -Name $BinaryName
+
+    if (Test-Path -LiteralPath $Target) {
+        try {
+            Remove-Item -LiteralPath $Target -Force
+            $Removed = $true
+        } catch {
+            # Almost always a running agav holding its own image open.
+            Write-Host "Could not remove $Target." -ForegroundColor Red
+            Write-Host "Close any running agav sessions and try again." -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    # Same registry-direct read/write as the install path, and for the same
+    # reason: the [Environment] API hands back an already-expanded PATH, so
+    # writing it back would flatten every %VAR% in the segments we are keeping.
+    try {
+        $EnvKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+        if ($EnvKey) {
+            $RawPath = [string]$EnvKey.GetValue(
+                "PATH", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            $Trimmed = Remove-PathSegment -PathValue $RawPath -Dir $InstallDir
+            if ($null -ne $Trimmed) {
+                $EnvKey.SetValue("PATH", $Trimmed, $EnvKey.GetValueKind("PATH"))
+                $Removed = $true
+                $PathChanged = $true
+            }
+            $EnvKey.Close()
+        }
+    } catch {
+        Write-Host "Could not update your PATH: $($_.Exception.Message)" -ForegroundColor Yellow
+        Write-Host "Remove $InstallDir from it yourself." -ForegroundColor Yellow
+    }
+
+    # Only when we are the ones who left it empty. Never delete a directory the
+    # user has put their own files in.
+    if ((Test-Path -LiteralPath $InstallDir) -and
+        -not (Get-ChildItem -LiteralPath $InstallDir -Force -ErrorAction SilentlyContinue)) {
+        Remove-Item -LiteralPath $InstallDir -Force -ErrorAction SilentlyContinue
+    }
+
+    # Guarded: USERPROFILE is always set on Windows, but a null here would blow up
+    # Join-Path and abort the run with a stack trace after the binary is already
+    # gone - a confusing way to end a mostly-successful uninstall.
+    $DataDir = if ($env:USERPROFILE) { Join-Path $env:USERPROFILE ".agav" } else { $null }
+    $HasData = $DataDir -and (Test-Path -LiteralPath $DataDir)
+
+    # Purge runs before the not-found check on purpose: someone who deleted the
+    # exe by hand and then ran --purge to finish the job should get their data
+    # directory cleaned up, not "agav not found" with the data still sitting there.
+    $Purged = $false
+    if ($Purge -and $HasData) {
+        Remove-Item -LiteralPath $DataDir -Recurse -Force -ErrorAction SilentlyContinue
+        $Purged = $true
+        $Removed = $true
+    }
+
+    if (-not $Removed) {
+        Write-Host "agav not found in $InstallDir" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Uninstalled agav from $InstallDir" -ForegroundColor Green
+    if ($PathChanged) { Write-Host "Removed $InstallDir from your PATH." -ForegroundColor Green }
+    if ($Purged) {
+        Write-Host "Removed $DataDir" -ForegroundColor Green
+    } elseif ($HasData) {
+        Write-Host "Kept your settings and history in $DataDir - delete them with --purge." -ForegroundColor Cyan
+    }
+
+    if ($PathChanged) {
+        Write-Host "Restart your terminal to drop $InstallDir from PATH." -ForegroundColor Cyan
+    }
+    exit 0
 }
 
 # --- Detect architecture ---
@@ -148,11 +329,37 @@ function Save-FileWithProgress {
     }
 }
 
-if (-not (Test-Path $InstallDir)) {
+function Get-RemoteText {
+    param([Parameter(Mandatory = $true)][string]$Url)
+
+    Add-Type -AssemblyName System.Net.Http
+    $Handler = New-Object System.Net.Http.HttpClientHandler
+    try {
+        $Handler.DefaultProxyCredentials = [System.Net.CredentialCache]::DefaultCredentials
+    } catch {}
+    $Client = New-Object System.Net.Http.HttpClient($Handler)
+    $Client.DefaultRequestHeaders.UserAgent.ParseAdd("agav-installer")
+    $Response = $null
+    try {
+        $Response = $Client.GetAsync($Url).GetAwaiter().GetResult()
+        $Response.EnsureSuccessStatusCode() | Out-Null
+        return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    } finally {
+        if ($Response) { $Response.Dispose() }
+        $Client.Dispose()
+        $Handler.Dispose()
+    }
+}
+
+if (-not (Test-Path -LiteralPath $InstallDir)) {
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
 }
 
-$TmpFile = Join-Path $InstallDir "$BinaryName.tmp"
+Remove-StaleArtifacts -Dir $InstallDir -Name $BinaryName
+
+# Per-process so a leftover from a still-running agav cannot collide with this
+# one, and so two installers cannot overwrite each other's partial download.
+$TmpFile = Join-Path $InstallDir "$BinaryName.$PID.tmp"
 try {
     Save-FileWithProgress -Url $DownloadUrl -Destination $TmpFile -Activity "Downloading $AssetName"
 } catch {
@@ -160,12 +367,73 @@ try {
     # Write-Error here would abort the handler before the cleanup below runs.
     Write-Host "Download failed: $($_.Exception.Message)" -ForegroundColor Red
     Write-Host "Check available releases: https://github.com/$Repo/releases" -ForegroundColor Red
-    if (Test-Path $TmpFile) { Remove-Item $TmpFile -Force }
+    if (Test-Path -LiteralPath $TmpFile) { Remove-Item -LiteralPath $TmpFile -Force }
     exit 1
 }
 
+# --- Verify checksum ---
+# The other two installers refuse to install an unverified binary; this one used
+# to move whatever arrived straight into place. Fail closed here too, since the
+# next thing that happens is the user running it.
+if ($SkipChecksum) {
+    Write-Host "agav -> WARNING: skipping checksum verification." -ForegroundColor Yellow
+} else {
+    Write-Host "agav -> Verifying checksum..." -ForegroundColor Cyan
+    $Expected = $null
+    try {
+        # Published as "<hex>  <asset>" next to the binary, one file per asset.
+        $Expected = ((Get-RemoteText "$DownloadUrl.sha256").Trim() -split '\s+')[0]
+    } catch {
+        Write-Host "Could not download $DownloadUrl.sha256 - $($_.Exception.Message)" -ForegroundColor Red
+    }
+
+    if ($Expected -notmatch '^[0-9a-fA-F]{64}$') {
+        Write-Host "No usable SHA-256 checksum was published for $AssetName." -ForegroundColor Red
+        Write-Host "Re-run with --skip-checksum to install without verification." -ForegroundColor Red
+        Remove-Item -LiteralPath $TmpFile -Force -ErrorAction SilentlyContinue
+        exit 1
+    }
+
+    $Actual = (Get-FileHash -LiteralPath $TmpFile -Algorithm SHA256).Hash
+    if ($Actual -ne $Expected.ToUpperInvariant()) {
+        Write-Host "Checksum verification failed - refusing to install." -ForegroundColor Red
+        Write-Host "Expected: $($Expected.ToUpperInvariant())" -ForegroundColor Red
+        Write-Host "Actual:   $Actual" -ForegroundColor Red
+        Remove-Item -LiteralPath $TmpFile -Force -ErrorAction SilentlyContinue
+        exit 1
+    }
+    Write-Host "agav -> Checksum verified." -ForegroundColor Cyan
+}
+
 # --- Install ---
-Move-Item -Path $TmpFile -Destination $FinalPath -Force
+# Move-Item -Force onto a running agav.exe fails with a sharing violation:
+# Windows will not let the destination be deleted while the image is loaded. It
+# will happily *rename* it though, so shift the old binary aside first. That is
+# the same dance the in-app updater does.
+$BackupPath = "$FinalPath.$PID.bak"
+$MovedAside = $false
+try {
+    if (Test-Path -LiteralPath $FinalPath) {
+        Move-Item -LiteralPath $FinalPath -Destination $BackupPath -Force
+        $MovedAside = $true
+    }
+    Move-Item -LiteralPath $TmpFile -Destination $FinalPath -Force
+} catch {
+    Write-Host "Install failed: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host "Close any running agav sessions and try again." -ForegroundColor Red
+    # Put the working binary back rather than leaving the user with nothing.
+    if ($MovedAside -and -not (Test-Path -LiteralPath $FinalPath)) {
+        Move-Item -LiteralPath $BackupPath -Destination $FinalPath -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath $TmpFile -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+
+# Best-effort: the old image stays locked for as long as that process lives, so
+# a failure here is untidy, not a failed install. The next run sweeps it.
+if ($MovedAside) {
+    Remove-Item -LiteralPath $BackupPath -Force -ErrorAction SilentlyContinue
+}
 
 # --- Verify ---
 try {
@@ -176,13 +444,50 @@ try {
 }
 
 # --- PATH check ---
-$UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($UserPath -notlike "*$InstallDir*") {
-    [Environment]::SetEnvironmentVariable("PATH", "$InstallDir;$UserPath", "User")
-    Write-Host ""
-    Write-Host "agav -> Added $InstallDir to your PATH." -ForegroundColor Cyan
-    Write-Host "agav -> Restart your terminal, then run 'agav' to get started." -ForegroundColor Cyan
+#
+# Read and write the registry value directly instead of using
+# [Environment]::GetEnvironmentVariable/SetEnvironmentVariable. Get returns the
+# *expanded* value, so writing it back stored every %USERPROFILE%-style entry
+# as a baked-in absolute path and permanently flattened a REG_EXPAND_SZ PATH.
+$RawUserPath = ""
+$PathKind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+$EnvKey = $null
+try {
+    $EnvKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+    if ($EnvKey) {
+        $Existing = $EnvKey.GetValue(
+            "PATH", $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        if ($null -ne $Existing) {
+            $RawUserPath = [string]$Existing
+            $PathKind = $EnvKey.GetValueKind("PATH")
+        }
+    }
+} catch {
+    $EnvKey = $null
+}
+
+$AlreadyOnPath = Test-PathContainsDir -PathValue $RawUserPath -Dir $InstallDir
+if (-not $AlreadyOnPath -and $EnvKey) {
+    $NewPath = if ([string]::IsNullOrEmpty($RawUserPath)) { $InstallDir } else { "$InstallDir;$RawUserPath" }
+    try {
+        $EnvKey.SetValue("PATH", $NewPath, $PathKind)
+        $AlreadyOnPath = $true
+        Write-Host ""
+        Write-Host "agav -> Added $InstallDir to your PATH." -ForegroundColor Cyan
+        Write-Host "agav -> Restart your terminal, then run 'agav' to get started." -ForegroundColor Cyan
+    } catch {
+        Write-Host ""
+        Write-Host "agav -> Could not update your PATH: $($_.Exception.Message)" -ForegroundColor Yellow
+        Write-Host "agav -> Add $InstallDir to it yourself, or run agav from $FinalPath." -ForegroundColor Yellow
+    }
 } else {
     Write-Host ""
     Write-Host "agav -> Run 'agav' to get started." -ForegroundColor Cyan
+}
+if ($EnvKey) { $EnvKey.Close() }
+
+# The registry write does not reach this already-running shell, and under
+# `irm | iex` that shell is the one the user is about to type into.
+if (-not (Test-PathContainsDir -PathValue $env:PATH -Dir $InstallDir)) {
+    $env:PATH = "$InstallDir;$env:PATH"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -38,11 +38,19 @@ function Remove-StaleArtifacts {
                 return
             }
             if ($Leftover -notmatch "^$([regex]::Escape($Name))\.(\d+)\.(bak|tmp)$") { return }
-            $OwnerPid = [int]$Matches[1]
+            $PidText = $Matches[1]
             $Kind = $Matches[2]
+            # TryParse, not [int]: \d+ happily matches a number too large for an
+            # Int32, and the cast would throw under $ErrorActionPreference =
+            # "Stop", aborting the whole install from inside a cleanup routine
+            # whose entire job is to tolerate junk. Nothing we wrote looks like
+            # that, so treat it as ownerless and sweep it.
+            $OwnerPid = 0
+            $HasOwner = [int]::TryParse($PidText, [ref]$OwnerPid)
             # A .tmp belonging to a live process is a download in flight for a
             # second installer. Locked .bak files just fail to delete, harmlessly.
-            if ($Kind -eq "tmp" -and (Get-Process -Id $OwnerPid -ErrorAction SilentlyContinue)) { return }
+            if ($Kind -eq "tmp" -and $HasOwner -and
+                (Get-Process -Id $OwnerPid -ErrorAction SilentlyContinue)) { return }
             Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
         }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,7 +22,9 @@ lock_dir_held=0
 path_action="already"
 path_profile=""
 conflict_manager=""
-conflict_path=""
+# Newline-separated, not space-separated: a home directory with a space in it
+# would otherwise split one path into several when this is read back.
+path_removed_from=""
 
 # --- Output helpers ---
 
@@ -248,7 +250,6 @@ detect_conflicting_install() {
       *".bun"*) conflict_manager="bun" ;;
       *)        conflict_manager="npm" ;;
     esac
-    conflict_path="$existing_path"
     step "Detected existing $conflict_manager-managed Agav at $existing_path"
     warn "Multiple installs can be ambiguous — PATH order decides which one runs."
   fi
@@ -364,7 +365,8 @@ add_to_path() {
     # A block is already here but points somewhere else — a previous run with a
     # different --dir. Rewrite that block instead of appending a second one,
     # which used to stack up a new stanza on every re-run.
-    rewritten="${TMPDIR:-/tmp}/agav-profile.$$"
+    # Alongside the profile rather than in /tmp — see remove_path_block.
+    rewritten="$profile.agav-install.$$"
     if awk -v begin="$begin_marker" -v end="$end_marker" -v line="$path_line" '
       $0 == begin { print; print line; skipping = 1; next }
       $0 == end   { print; skipping = 0; next }
@@ -412,7 +414,11 @@ remove_path_block() {
     [ -f "$profile" ] || continue
     grep -qF "# >>> Agav installer >>>" "$profile" 2>/dev/null || continue
 
-    stripped="${TMPDIR:-/tmp}/agav-uninstall.$$"
+    # Alongside the profile rather than in /tmp: $HOME is not world-writable, so
+    # nobody else on the machine can pre-plant a symlink on this name and have
+    # the redirect below clobber whatever it points at. It is also guaranteed to
+    # be on the same filesystem.
+    stripped="$profile.agav-uninstall.$$"
     # Blank lines are buffered and only emitted once something follows them, so
     # the blank line add_to_path printed before the block goes with it instead
     # of piling up one more empty line per install/uninstall cycle.
@@ -428,7 +434,8 @@ remove_path_block() {
       # profile keeps its inode, mode, and ownership. No -s guard here: a
       # profile that contained nothing but our block correctly ends up empty.
       if cat "$stripped" >"$profile"; then
-        path_removed_from="$path_removed_from $profile"
+        path_removed_from="$path_removed_from$profile
+"
       fi
     fi
     rm -f "$stripped"
@@ -558,8 +565,10 @@ if [ "$do_uninstall" -eq 1 ]; then
     exit 1
   fi
 
-  for profile in $path_removed_from; do
-    step "Removed the Agav PATH entry from $profile"
+  # read -r, not `for x in $list`: word splitting would break any path with a
+  # space in it into several bogus entries.
+  printf '%s' "$path_removed_from" | while IFS= read -r cleaned_profile; do
+    step "Removed the Agav PATH entry from $cleaned_profile"
   done
 
   if [ "$purged" -eq 1 ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,7 @@ REPO="prapaa-ai/agav"
 BINARY_NAME="agav"
 VERSION="${AGAV_VERSION:-latest}"
 NON_INTERACTIVE="${AGAV_NON_INTERACTIVE:-false}"
+SKIP_CHECKSUM="${AGAV_SKIP_CHECKSUM:-0}"
 
 BIN_DIR="${AGAV_INSTALL_DIR:-$HOME/.local/bin}"
 BIN_PATH="$BIN_DIR/$BINARY_NAME"
@@ -14,8 +15,10 @@ STANDALONE_ROOT="$AGAV_HOME/packages/standalone"
 RELEASES_DIR="$STANDALONE_ROOT/releases"
 CURRENT_LINK="$STANDALONE_ROOT/current"
 LOCK_FILE="$STANDALONE_ROOT/install.lock"
+LOCK_DIR="$STANDALONE_ROOT/install.lock.d"
 
 tmp_dir=""
+lock_dir_held=0
 path_action="already"
 path_profile=""
 conflict_manager=""
@@ -87,44 +90,69 @@ download_text() {
 }
 
 # --- Checksum verification ---
+#
+# This is the only thing standing between a hijacked download and a binary the
+# user is about to run, so every path through it fails closed. Set
+# AGAV_SKIP_CHECKSUM=1 to opt out deliberately; nothing else may skip silently.
 
+checksum_bypassed() {
+  case "$SKIP_CHECKSUM" in
+    1 | [Tt][Rr][Uu][Ee] | [Yy][Ee][Ss]) return 0 ;;
+  esac
+  return 1
+}
+
+# Prints the hex digest on success; prints nothing and returns 1 when the
+# machine has no SHA-256 tool at all.
 file_sha256() {
   path="$1"
 
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$path" | awk '{print $1}'
-    return
+    return 0
   fi
 
   if command -v shasum >/dev/null 2>&1; then
     shasum -a 256 "$path" | awk '{print $1}'
-    return
+    return 0
   fi
 
   if command -v openssl >/dev/null 2>&1; then
     openssl dgst -sha256 "$path" | sed 's/^.*= //'
-    return
+    return 0
   fi
 
-  warn "sha256sum, shasum, or openssl not found — skipping checksum verification."
-  printf 'skip\n'
+  return 1
+}
+
+checksum_abort() {
+  err "$1"
+  err "Re-run with AGAV_SKIP_CHECKSUM=1 to install without verification."
+  rm -f "$2"
+  exit 1
 }
 
 verify_checksum() {
   archive_path="$1"
   expected="$2"
 
-  if [ "$expected" = "skip" ] || [ -z "$expected" ]; then
-    return
+  if [ -z "$expected" ]; then
+    checksum_abort "No published checksum to verify against." "$archive_path"
   fi
 
-  actual="$(file_sha256 "$archive_path")"
-  if [ "$actual" = "skip" ]; then
-    return
+  if ! actual="$(file_sha256 "$archive_path")" || [ -z "$actual" ]; then
+    checksum_abort \
+      "Cannot verify the download: none of sha256sum, shasum, or openssl is installed." \
+      "$archive_path"
   fi
+
+  # Case-fold both sides: openssl and sha256sum agree on lowercase, but a
+  # hand-edited SHA256SUMS need not.
+  actual="$(printf '%s' "$actual" | tr 'A-F' 'a-f')"
+  expected="$(printf '%s' "$expected" | tr 'A-F' 'a-f')"
 
   if [ "$actual" != "$expected" ]; then
-    err "Checksum verification failed."
+    err "Checksum verification failed — refusing to install."
     err "Expected: $expected"
     err "Actual:   $actual"
     rm -f "$archive_path"
@@ -263,10 +291,42 @@ acquire_lock() {
     lockf 9
     return
   fi
+
+  # Stock macOS ships neither flock nor lockf, so without this the lock was a
+  # silent no-op and two concurrent installers could race on `rm -rf` of the
+  # same release directory. mkdir is atomic on every POSIX filesystem.
+  waited=0
+  while [ "$waited" -lt 120 ]; do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      lock_dir_held=1
+      printf '%s\n' "$$" >"$LOCK_DIR/pid" 2>/dev/null || true
+      return
+    fi
+
+    # Reclaim the lock from an installer that was killed before it could clean
+    # up, otherwise one Ctrl+C would wedge every future run on this machine.
+    holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [ -z "$holder" ] || ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$LOCK_DIR"
+      continue
+    fi
+
+    if [ "$waited" -eq 0 ]; then
+      step "Waiting for another Agav installer (pid $holder) to finish..."
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  warn "Timed out waiting for the install lock — continuing without it."
 }
 
 release_lock() {
   exec 9>&- 2>/dev/null || true
+  if [ "$lock_dir_held" -eq 1 ]; then
+    lock_dir_held=0
+    rm -rf "$LOCK_DIR"
+  fi
 }
 
 # --- PATH management ---
@@ -300,6 +360,30 @@ add_to_path() {
       path_action="configured"
       return
     fi
+
+    # A block is already here but points somewhere else — a previous run with a
+    # different --dir. Rewrite that block instead of appending a second one,
+    # which used to stack up a new stanza on every re-run.
+    rewritten="${TMPDIR:-/tmp}/agav-profile.$$"
+    if awk -v begin="$begin_marker" -v end="$end_marker" -v line="$path_line" '
+      $0 == begin { print; print line; skipping = 1; next }
+      $0 == end   { print; skipping = 0; next }
+      skipping    { next }
+                  { print }
+    ' "$profile" >"$rewritten" 2>/dev/null && [ -s "$rewritten" ]; then
+      # Write through the existing file rather than mv'ing over it, so the
+      # profile keeps its inode, mode, and ownership.
+      if cat "$rewritten" >"$profile"; then
+        rm -f "$rewritten"
+        path_action="added"
+        return
+      fi
+    fi
+    rm -f "$rewritten"
+    warn "Could not update the Agav block in $profile — add this line yourself:"
+    warn "$path_line"
+    path_action="already"
+    return
   fi
 
   {
@@ -308,6 +392,47 @@ add_to_path() {
     printf '%s\n' "$end_marker"
   } >>"$profile"
   path_action="added"
+}
+
+# Take the installer's block back out of every profile that has one.
+#
+# add_to_path writes this block but nothing ever removed it, so uninstalling
+# left a dead PATH entry pointing at a deleted directory — permanently, and in
+# a file most people never read.
+#
+# Every candidate profile is scanned rather than just pick_profile's answer:
+# the block may have been written by an earlier run under a different shell,
+# and pick_profile depends on $os, which is not detected until after uninstall
+# has already run.
+remove_path_block() {
+  path_removed_from=""
+
+  for profile in \
+    "$HOME/.zprofile" "$HOME/.bash_profile" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+    [ -f "$profile" ] || continue
+    grep -qF "# >>> Agav installer >>>" "$profile" 2>/dev/null || continue
+
+    stripped="${TMPDIR:-/tmp}/agav-uninstall.$$"
+    # Blank lines are buffered and only emitted once something follows them, so
+    # the blank line add_to_path printed before the block goes with it instead
+    # of piling up one more empty line per install/uninstall cycle.
+    if awk '
+      $0 == "# >>> Agav installer >>>" { skipping = 1; blanks = 0; next }
+      $0 == "# <<< Agav installer <<<" { skipping = 0; next }
+      skipping { next }
+      /^[[:space:]]*$/ { blanks++; next }
+      { while (blanks > 0) { print ""; blanks-- } print }
+      END { while (blanks > 0) { print ""; blanks-- } }
+    ' "$profile" >"$stripped" 2>/dev/null; then
+      # Write through the existing file rather than mv'ing over it, so the
+      # profile keeps its inode, mode, and ownership. No -s guard here: a
+      # profile that contained nothing but our block correctly ends up empty.
+      if cat "$stripped" >"$profile"; then
+        path_removed_from="$path_removed_from $profile"
+      fi
+    fi
+    rm -f "$stripped"
+  done
 }
 
 # --- Prompts ---
@@ -356,18 +481,18 @@ replace_symlink() {
 
 # --- Parse args ---
 
+# Two passes: collect every flag first, then act. Acting inline meant
+# `--uninstall --dir=/opt/bin` uninstalled from the default directory, because
+# --uninstall was reached before --dir had been read.
+do_uninstall=0
+do_purge=0
+
 for arg in "$@"; do
   case "$arg" in
-    --uninstall)
-      if [ -f "$BIN_PATH" ]; then
-        rm -f "$BIN_PATH"
-        rm -rf "$STANDALONE_ROOT"
-        step "Uninstalled Agav from $BIN_DIR"
-      else
-        err "Agav not found at $BIN_PATH"
-      fi
-      exit 0
-      ;;
+    --uninstall) do_uninstall=1 ;;
+    # --purge is useless on its own, so it implies --uninstall rather than
+    # making people pass both.
+    --purge)     do_uninstall=1; do_purge=1 ;;
     --version=*) VERSION="${arg#*=}" ;;
     --dir=*)     BIN_DIR="${arg#*=}"; BIN_PATH="$BIN_DIR/$BINARY_NAME" ;;
     --help|-h)
@@ -379,18 +504,75 @@ Usage: install.sh [OPTIONS]
 Options:
   --version=<tag>    Install a specific version (default: latest)
   --dir=<path>       Install directory (default: ~/.local/bin)
-  --uninstall        Remove Agav
+  --uninstall        Remove Agav, keeping your settings and history
+  --purge            Remove Agav and delete ~/.agav as well
   -h, --help         Show this help
 
 Environment:
   AGAV_VERSION          Version to install; overridden by --version.
   AGAV_INSTALL_DIR      Install directory; overridden by --dir.
   AGAV_NON_INTERACTIVE  Set to 1/true/yes to skip prompts.
+  AGAV_SKIP_CHECKSUM    Set to 1/true/yes to install without verifying SHA-256.
 EOF
       exit 0
       ;;
   esac
 done
+
+if [ "$do_uninstall" -eq 1 ]; then
+  removed=0
+  # -e follows the symlink and is false when the target is already gone, so a
+  # dangling ~/.local/bin/agav used to report "not found" and leave both the
+  # broken link and the ~100 MB release tree behind. -L catches it.
+  if [ -e "$BIN_PATH" ] || [ -L "$BIN_PATH" ]; then
+    rm -f "$BIN_PATH"
+    removed=1
+  fi
+  if [ -d "$STANDALONE_ROOT" ]; then
+    rm -rf "$STANDALONE_ROOT"
+    removed=1
+  fi
+  # rmdir, not rm -rf: if anything else put files under packages/ we have no
+  # business deleting them. Fails harmlessly when the directory is not empty.
+  rmdir "$AGAV_HOME/packages" 2>/dev/null || true
+
+  remove_path_block
+  if [ -n "$path_removed_from" ]; then
+    removed=1
+  fi
+
+  # Purge runs before the not-found check on purpose: someone who deleted the
+  # binary by hand and then ran --purge to finish the job should get their data
+  # directory cleaned up, not "Agav not found" with the data still sitting there.
+  purged=0
+  if [ "$do_purge" -eq 1 ] && [ -d "$AGAV_HOME" ]; then
+    rm -rf "$AGAV_HOME"
+    purged=1
+    removed=1
+  fi
+
+  if [ "$removed" -eq 1 ]; then
+    step "Uninstalled Agav from $BIN_DIR"
+  else
+    err "Agav not found at $BIN_PATH"
+    exit 1
+  fi
+
+  for profile in $path_removed_from; do
+    step "Removed the Agav PATH entry from $profile"
+  done
+
+  if [ "$purged" -eq 1 ]; then
+    step "Removed $AGAV_HOME"
+  elif [ -d "$AGAV_HOME" ]; then
+    step "Kept your settings and history in $AGAV_HOME — delete them with --purge."
+  fi
+
+  if [ -n "$path_removed_from" ]; then
+    step "Restart your shell to drop $BIN_DIR from PATH."
+  fi
+  exit 0
+fi
 
 # --- Main ---
 
@@ -456,26 +638,38 @@ download_file "$download_url" "$archive_path" || {
   exit 1
 }
 
-# Verify it's a real binary
-file_type="$(file "$archive_path" 2>/dev/null || echo "unknown")"
-case "$file_type" in
-  *executable* | *ELF* | *Mach-O*) ;;
-  *)
-    err "Downloaded file is not a valid binary: $file_type"
-    exit 1
-    ;;
-esac
-
-# Download and verify checksum if available
-checksum_url="https://github.com/${REPO}/releases/download/v${resolved_version}/SHA256SUMS"
-expected_checksum=""
-if checksum_text="$(download_text "$checksum_url" 2>/dev/null)"; then
-  expected_checksum="$(printf '%s\n' "$checksum_text" | awk -v asset="$asset_name" '$2 == asset { print $1 }')"
-  if [ -n "$expected_checksum" ]; then
-    step "Verifying checksum..."
-    verify_checksum "$archive_path" "$expected_checksum"
-    step "Checksum verified."
+# Verify the checksum before anything else looks at the file. This is the
+# authoritative integrity gate, so it runs first and every failure is fatal.
+if checksum_bypassed; then
+  warn "AGAV_SKIP_CHECKSUM is set — installing without verifying the download."
+else
+  checksum_url="https://github.com/${REPO}/releases/download/v${resolved_version}/SHA256SUMS"
+  step "Verifying checksum..."
+  if ! checksum_text="$(download_text "$checksum_url" 2>/dev/null)"; then
+    checksum_abort "Could not download $checksum_url." "$archive_path"
   fi
+  # sha256sum writes "<hex>  <name>", so the asset is field 2.
+  expected_checksum="$(printf '%s\n' "$checksum_text" | awk -v asset="$asset_name" '$2 == asset { print $1 }')"
+  if [ -z "$expected_checksum" ]; then
+    checksum_abort "SHA256SUMS has no entry for $asset_name." "$archive_path"
+  fi
+  verify_checksum "$archive_path" "$expected_checksum"
+  step "Checksum verified."
+fi
+
+# A friendly diagnostic, not a security control — the checksum above already
+# proved the bytes are the published ones. Skip it when `file` is missing
+# rather than failing: slim containers routinely omit it, and treating an
+# absent tool as a corrupt download blocked the install outright.
+if command -v file >/dev/null 2>&1; then
+  file_type="$(file -b "$archive_path" 2>/dev/null || true)"
+  case "$file_type" in
+    *executable* | *ELF* | *Mach-O*) ;;
+    *)
+      err "Downloaded file is not a valid binary: ${file_type:-unknown}"
+      exit 1
+      ;;
+  esac
 fi
 
 # Install to versioned release directory
@@ -520,13 +714,17 @@ case "$path_action" in
     ;;
 esac
 
-# Clean up old releases (keep current + previous)
+# Clean up superseded releases. Compare by directory name, not by path:
+# replace_symlink may have written a relative target, and comparing a relative
+# readlink against an absolute path never matched, so the live release was only
+# spared by the separate $resolved_version test.
 if [ -d "$RELEASES_DIR" ]; then
-  current_target="$(readlink "$CURRENT_LINK" 2>/dev/null || true)"
+  current_name="$(basename "$(readlink "$CURRENT_LINK" 2>/dev/null || true)" 2>/dev/null || true)"
   for dir in "$RELEASES_DIR"/*/; do
     [ -d "$dir" ] || continue
     dir="${dir%/}"
-    if [ "$dir" != "$current_target" ] && [ "$(basename "$dir")" != "$resolved_version" ]; then
+    name="$(basename "$dir")"
+    if [ "$name" != "$resolved_version" ] && [ "$name" != "$current_name" ]; then
       rm -rf "$dir"
     fi
   done

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -1,0 +1,69 @@
+# Installer tests
+
+Tests for `scripts/install.sh` and `scripts/install.ps1`. These two files are
+delivered outside the release pipeline — they are copied by hand to
+`agav.dev` — so nothing else in the repo covers them.
+
+Run everything your machine can run:
+
+```bash
+npm run test:installer          # or: sh scripts/tests/run-installer-tests.sh
+```
+
+It reports what it skipped instead of skipping silently.
+
+No suite downloads a release binary or contacts GitHub. The shell suites only
+ever reach `--uninstall`, `--purge` and `--help`, all of which return long
+before the first `download_file` call site; the PowerShell suite replaces
+`Save-FileWithProgress` and `Get-RemoteText` with local fakes that copy a
+20-byte file. All four run green under `docker run --network none`.
+
+The one exception is `install-ps1-lint.test.ps1`, which fetches PSScriptAnalyzer
+from PSGallery when the module is not already installed. Offline it says so and
+falls back to the parse and encoding checks rather than failing.
+
+## The suites
+
+| File | What it covers |
+| --- | --- |
+| `install-sh.test.sh` | `install.sh --uninstall` / `--purge` end to end, against a throwaway `HOME` |
+| `install-sh-path.test.sh` | `add_to_path` in isolation, lifted out of the source with `awk` |
+| `install-ps1.test.ps1` | `install.ps1` end to end — install, upgrade, checksums, uninstall, purge |
+| `install-ps1-path.test.ps1` | The three PATH helpers, lifted out of the source via the PowerShell AST |
+| `install-ps1-lint.test.ps1` | It parses, it is pure ASCII, and PSScriptAnalyzer is happy with it under 5.1 |
+
+Each takes the installer path as its one optional argument, defaulting to the
+sibling in `scripts/`.
+
+The helpers are lifted out of the shipped file rather than copied, and the
+PowerShell stub is regenerated from source on every run, so a test can never
+pass against a stale duplicate of the code it is meant to be checking.
+
+## Running one at a time
+
+```bash
+sh scripts/tests/install-sh.test.sh
+dash scripts/tests/install-sh.test.sh          # install.sh is #!/bin/sh; dash is what Debian gives it
+pwsh -NoProfile -File scripts/tests/install-ps1.test.ps1
+```
+
+Without a local `pwsh`, the runner falls back to Docker:
+
+```bash
+docker run --rm -v "$PWD/scripts:/s:ro" \
+  mcr.microsoft.com/powershell:lts-7.4-ubuntu-22.04 \
+  pwsh -NoProfile -File /s/tests/install-ps1.test.ps1 /s/install.ps1
+```
+
+CI runs the PowerShell suites natively on `windows-latest`, which is the only
+place the registry half of the PATH handling is exercised for real. Linux and
+macOS runs skip it: `Microsoft.Win32.Registry` throws there, and the installer
+catches it, exactly as it would on a machine with a locked-down `HKCU`.
+
+## What the PowerShell suite writes
+
+`install-ps1.test.ps1` really does write `HKCU\Environment\PATH` on Windows,
+because that is what an install does. It captures the original value before the
+first test and restores it in a `finally` block. Everything else lives under a
+directory in `%TEMP%`, and the purge tests refuse to run at all unless the data
+directory they are about to delete resolves inside it.

--- a/scripts/tests/install-ps1-lint.test.ps1
+++ b/scripts/tests/install-ps1-lint.test.ps1
@@ -1,0 +1,109 @@
+# Static checks on install.ps1: it parses, it is pure ASCII, and PSScriptAnalyzer
+# has nothing to say about it - including under Windows PowerShell 5.1, which is
+# the host `install.cmd` actually launches it with.
+#
+#   pwsh -NoProfile -File scripts/tests/install-ps1-lint.test.ps1
+param(
+    [string]$Installer = (Join-Path (Join-Path $PSScriptRoot "..") "install.ps1")
+)
+
+$ErrorActionPreference = "Continue"
+
+if (-not (Test-Path -LiteralPath $Installer)) {
+    Write-Host "no installer at $Installer" -ForegroundColor Red
+    exit 1
+}
+$Installer = (Resolve-Path -LiteralPath $Installer).Path
+
+$Pass = 0
+$Fail = 0
+function Check([string]$Name, [bool]$Cond, [string]$Detail = "") {
+    if ($Cond) { Write-Host "  PASS  $Name" -ForegroundColor Green; $script:Pass++ }
+    else { Write-Host "  FAIL  $Name  $Detail" -ForegroundColor Red; $script:Fail++ }
+}
+
+Write-Host "== it parses =="
+$Errors = $null
+$Tokens = $null
+[System.Management.Automation.Language.Parser]::ParseFile($Installer, [ref]$Tokens, [ref]$Errors) | Out-Null
+Check "no parse errors" (-not $Errors -or $Errors.Count -eq 0) ($Errors | Out-String)
+
+Write-Host "== it is pure ASCII =="
+# install.cmd fetches this with Invoke-WebRequest, which writes raw bytes, and
+# Windows PowerShell 5.1 decodes a BOM-less -File script as Windows-1252. A
+# UTF-8 character whose trailing byte is 0x93/0x94 becomes a smart quote, which
+# the parser accepts as a string delimiter, and the whole script fails to parse.
+$Bytes = [System.IO.File]::ReadAllBytes($Installer)
+$HighByte = -1
+for ($i = 0; $i -lt $Bytes.Length; $i++) {
+    if ($Bytes[$i] -ge 0x80) { $HighByte = $i; break }
+}
+Check "no bytes above 0x7F" ($HighByte -lt 0) "first at offset $HighByte"
+Check "no UTF-8 BOM" (-not ($Bytes.Length -ge 3 -and $Bytes[0] -eq 0xEF -and $Bytes[1] -eq 0xBB -and $Bytes[2] -eq 0xBF))
+
+Write-Host "== PSScriptAnalyzer =="
+$Analyzer = Get-Module -ListAvailable -Name PSScriptAnalyzer | Select-Object -First 1
+if (-not $Analyzer) {
+    Write-Host "  installing PSScriptAnalyzer from PSGallery..." -ForegroundColor Cyan
+    try {
+        # PowerShellGet under Windows PowerShell 5.1 still negotiates TLS 1.0 by
+        # default, which PSGallery refuses outright.
+        try {
+            [Net.ServicePointManager]::SecurityProtocol =
+                [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        } catch {}
+        Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue
+        Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -AllowClobber -ErrorAction Stop
+        $Analyzer = Get-Module -ListAvailable -Name PSScriptAnalyzer | Select-Object -First 1
+    } catch {
+        Write-Host "  SKIP  PSScriptAnalyzer unavailable: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+if ($Analyzer) {
+    Import-Module PSScriptAnalyzer
+
+    # Four rules are written for modules and are wrong for a one-shot installer:
+    #
+    #   PSAvoidUsingWriteHost   - Write-Host is the point. This script's output is
+    #                             for a person watching a terminal, and it must
+    #                             survive `irm | iex`, where the pipeline belongs
+    #                             to the caller.
+    #   PSAvoidUsingEmptyCatchBlock - every one is a deliberate best-effort probe
+    #                             (TLS 1.2, proxy credentials, --version).
+    #   PSUseShouldProcessForStateChangingFunctions and PSUseSingularNouns - both
+    #                             about the contract an exported cmdlet owes its
+    #                             callers. These are script-local helpers.
+    $Ignored = @(
+        "PSAvoidUsingWriteHost",
+        "PSAvoidUsingEmptyCatchBlock",
+        "PSUseShouldProcessForStateChangingFunctions",
+        "PSUseSingularNouns"
+    )
+    $General = @(Invoke-ScriptAnalyzer -Path $Installer -Severity Error, Warning -ExcludeRule $Ignored)
+    if ($General.Count -gt 0) {
+        $General | Format-Table -AutoSize Severity, RuleName, Line, Message | Out-String -Width 200 | Write-Host
+    }
+    Check "no errors or warnings" ($General.Count -eq 0) "$($General.Count) finding(s)"
+
+    # 5.1 is what install.cmd launches, and the 14393 cmdlet set is the oldest
+    # still-supported Windows 10 servicing baseline. IncludeRules keeps this to
+    # the compatibility question alone - without it the default rule set runs too
+    # and this second pass just repeats the first.
+    $Settings = @{
+        IncludeRules = @("PSUseCompatibleSyntax", "PSUseCompatibleCmdlets")
+        Rules = @{
+            PSUseCompatibleSyntax  = @{ Enable = $true; TargetVersions = @("5.1", "7.0") }
+            PSUseCompatibleCmdlets = @{ Enable = $true; compatibility = @("desktop-5.1.14393.206-windows") }
+        }
+    }
+    $Compat = @(Invoke-ScriptAnalyzer -Path $Installer -Settings $Settings)
+    if ($Compat.Count -gt 0) {
+        $Compat | Format-Table -AutoSize Severity, RuleName, Line, Message | Out-String -Width 200 | Write-Host
+    }
+    Check "compatible with Windows PowerShell 5.1 and pwsh 7" ($Compat.Count -eq 0) "$($Compat.Count) finding(s)"
+}
+
+Write-Host ""
+Write-Host "$Pass passed, $Fail failed" -ForegroundColor $(if ($Fail -eq 0) { "Green" } else { "Red" })
+exit $(if ($Fail -eq 0) { 0 } else { 1 })

--- a/scripts/tests/install-ps1-path.test.ps1
+++ b/scripts/tests/install-ps1-path.test.ps1
@@ -1,0 +1,135 @@
+# Unit tests for install.ps1's three PATH helpers.
+#
+# Whatever Remove-PathSegment returns is written straight back to the user's
+# PATH, so most of what follows is about collateral damage to segments we do
+# not own. Nothing here touches the registry or the filesystem.
+#
+#   pwsh -NoProfile -File scripts/tests/install-ps1-path.test.ps1
+param(
+    [string]$Installer = (Join-Path (Join-Path $PSScriptRoot "..") "install.ps1")
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $Installer)) {
+    Write-Host "no installer at $Installer" -ForegroundColor Red
+    exit 1
+}
+$Installer = (Resolve-Path -LiteralPath $Installer).Path
+
+$Pass = 0
+$Fail = 0
+function Check([string]$Name, [bool]$Cond, [string]$Detail = "") {
+    if ($Cond) { Write-Host "  PASS  $Name" -ForegroundColor Green; $script:Pass++ }
+    else { Write-Host "  FAIL  $Name  $Detail" -ForegroundColor Red; $script:Fail++ }
+}
+
+# Lift the helpers out of the installer verbatim via the AST, so this tests the
+# shipped source rather than a copy that can drift.
+$Errors = $null
+$Tokens = $null
+$Ast = [System.Management.Automation.Language.Parser]::ParseFile($Installer, [ref]$Tokens, [ref]$Errors)
+if ($Errors -and $Errors.Count -gt 0) {
+    Write-Host "$Installer does not parse:" -ForegroundColor Red
+    $Errors | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+    exit 1
+}
+foreach ($Name in @("Test-PathSegment", "Test-PathContainsDir", "Remove-PathSegment")) {
+    $Fn = $Ast.Find({ param($n)
+        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $Name }, $true)
+    if (-not $Fn) { Write-Host "could not find $Name in the source" -ForegroundColor Red; exit 1 }
+    Invoke-Expression $Fn.Extent.Text
+}
+
+$Dir = "C:\Users\me\AppData\Local\agav"
+
+Write-Host "== positive matches =="
+Check "exact segment"        (Test-PathContainsDir -PathValue "C:\Windows;$Dir;C:\Other" -Dir $Dir)
+Check "only segment"         (Test-PathContainsDir -PathValue $Dir -Dir $Dir)
+Check "trailing backslash"   (Test-PathContainsDir -PathValue "C:\Windows;$Dir\" -Dir $Dir)
+Check "quoted segment"       (Test-PathContainsDir -PathValue "C:\Windows;`"$Dir`"" -Dir $Dir)
+Check "surrounding spaces"   (Test-PathContainsDir -PathValue "C:\Windows;  $Dir  " -Dir $Dir)
+Check "dir given with slash" (Test-PathContainsDir -PathValue "C:\Windows;$Dir" -Dir "$Dir\")
+
+Write-Host "== the actual bug: -notlike wildcard/substring matching =="
+# "C:\agav-old" contains "C:\agav" as a substring, so `-notlike "*$InstallDir*"`
+# reported the directory as already present and silently skipped the PATH edit.
+Check "sibling with a longer name is not a match" `
+    (-not (Test-PathContainsDir -PathValue "C:\Windows;C:\agav-old" -Dir "C:\agav"))
+Check "parent directory is not a match" `
+    (-not (Test-PathContainsDir -PathValue "C:\Windows;C:\Users\me\AppData\Local" -Dir $Dir))
+Check "child directory is not a match" `
+    (-not (Test-PathContainsDir -PathValue "C:\Windows;$Dir\bin" -Dir $Dir))
+# The old code also fed the directory to -like as a *pattern*. A PATH entry with
+# a bracket in it made the pattern match nothing, or throw.
+Check "a bracket in the dir does not blow up the comparison" `
+    (Test-PathContainsDir -PathValue "C:\Windows;C:\tools[x]\agav" -Dir "C:\tools[x]\agav")
+
+Write-Host "== unexpanded REG_EXPAND_SZ entries =="
+$env:AGAVTESTHOME = "C:\Users\me"
+Check "matches through %VAR% expansion" `
+    (Test-PathContainsDir -PathValue "C:\Windows;%AGAVTESTHOME%\bin" -Dir "C:\Users\me\bin")
+Check "unrelated %VAR% still does not match" `
+    (-not (Test-PathContainsDir -PathValue "C:\Windows;%AGAVTESTHOME%\bin" -Dir "C:\Users\you\bin"))
+
+Write-Host "== degenerate input =="
+Check "empty PATH"           (-not (Test-PathContainsDir -PathValue "" -Dir $Dir))
+Check "null PATH"            (-not (Test-PathContainsDir -PathValue $null -Dir $Dir))
+Check "empty segments only"  (-not (Test-PathContainsDir -PathValue ";;;" -Dir $Dir))
+Check "trailing semicolon"   (Test-PathContainsDir -PathValue "$Dir;" -Dir $Dir)
+
+# ---------------------------------------------------------------------------
+# Remove-PathSegment: uninstall's half of the same problem. It has to drop our
+# segment and leave every other one byte-for-byte alone, because whatever it
+# returns is written straight back to the user's PATH.
+# ---------------------------------------------------------------------------
+Write-Host "== Remove-PathSegment: removal =="
+Check "removes from the middle" `
+    ((Remove-PathSegment -PathValue "C:\Windows;$Dir;C:\Other" -Dir $Dir) -eq "C:\Windows;C:\Other")
+Check "removes from the front" `
+    ((Remove-PathSegment -PathValue "$Dir;C:\Windows" -Dir $Dir) -eq "C:\Windows")
+Check "removes from the end" `
+    ((Remove-PathSegment -PathValue "C:\Windows;$Dir" -Dir $Dir) -eq "C:\Windows")
+Check "sole segment leaves an empty PATH" `
+    ((Remove-PathSegment -PathValue $Dir -Dir $Dir) -eq "")
+Check "removes every duplicate, not just the first" `
+    ((Remove-PathSegment -PathValue "$Dir;C:\Windows;$Dir\" -Dir $Dir) -eq "C:\Windows")
+Check "removes a quoted segment" `
+    ((Remove-PathSegment -PathValue "C:\Windows;`"$Dir`"" -Dir $Dir) -eq "C:\Windows")
+Check "removes a %VAR% segment that expands to the dir" `
+    ((Remove-PathSegment -PathValue "C:\Windows;%AGAVTESTHOME%\bin" -Dir "C:\Users\me\bin") -eq "C:\Windows")
+
+Write-Host "== Remove-PathSegment: null means 'nothing to write' =="
+# Returning $null rather than the unchanged string is what lets the caller skip
+# the registry write entirely - and skip claiming it changed the PATH.
+Check "no match returns null"       ($null -eq (Remove-PathSegment -PathValue "C:\Windows;C:\Other" -Dir $Dir))
+Check "substring near-miss is null" ($null -eq (Remove-PathSegment -PathValue "C:\Windows;C:\agav-old" -Dir "C:\agav"))
+Check "child dir is null"           ($null -eq (Remove-PathSegment -PathValue "C:\Windows;$Dir\bin" -Dir $Dir))
+Check "empty PATH is null"          ($null -eq (Remove-PathSegment -PathValue "" -Dir $Dir))
+Check "null PATH is null"           ($null -eq (Remove-PathSegment -PathValue $null -Dir $Dir))
+
+Write-Host "== Remove-PathSegment: everything else survives untouched =="
+# The whole risk of this function is collateral damage to segments we do not own.
+$Keep = "%USERPROFILE%\bin;C:\Program Files\Git\cmd;`"C:\Quoted Dir`";C:\tools[x]\bin"
+Check "unrelated segments are byte-identical" `
+    ((Remove-PathSegment -PathValue "$Keep;$Dir" -Dir $Dir) -eq $Keep) `
+    "got: $(Remove-PathSegment -PathValue "$Keep;$Dir" -Dir $Dir)"
+Check "%VARS% in kept segments are not expanded" `
+    ((Remove-PathSegment -PathValue "%AGAVTESTHOME%\bin;$Dir" -Dir $Dir) -eq "%AGAVTESTHOME%\bin")
+Check "empty segments are preserved, not silently compacted" `
+    ((Remove-PathSegment -PathValue "C:\Windows;;$Dir" -Dir $Dir) -eq "C:\Windows;")
+
+Write-Host "== install and uninstall agree =="
+# If these two ever disagree, install adds a segment uninstall cannot find.
+foreach ($Case in @("C:\Windows;$Dir", "$Dir", "C:\Windows;$Dir\", "C:\Windows;  $Dir  ",
+                    "C:\Windows;C:\agav-old", "C:\Windows;$Dir\bin", "")) {
+    $Contains = Test-PathContainsDir -PathValue $Case -Dir $Dir
+    $Removed = $null -ne (Remove-PathSegment -PathValue $Case -Dir $Dir)
+    Check "agree on '$Case'" ($Contains -eq $Removed) "contains=$Contains removed=$Removed"
+}
+
+$env:AGAVTESTHOME = ""
+
+Write-Host ""
+Write-Host "$Pass passed, $Fail failed" -ForegroundColor $(if ($Fail -eq 0) { "Green" } else { "Red" })
+exit $(if ($Fail -eq 0) { 0 } else { 1 })

--- a/scripts/tests/install-ps1.test.ps1
+++ b/scripts/tests/install-ps1.test.ps1
@@ -80,10 +80,25 @@ $env:FAKE_ASSET = $Asset
 $PSExe = (Get-Process -Id $PID).Path
 if (-not $PSExe) { $PSExe = "pwsh" }
 
+# Quote one argument for the -Command line below.
+function ConvertTo-Quoted([string]$Value) { "'" + ($Value -replace "'", "''") + "'" }
+
+# -Command, not -File. pwsh's -File parser reads `--dir=C:\tools` as a
+# `-name:value` pair and splits it at the colon, so the script sees `--dir=C`
+# and a stray `\tools`; Windows PowerShell 5.1 does not. Neither is how anyone
+# invokes this - install.cmd uses `powershell.exe -File`, and the documented
+# one-liner is `& ([scriptblock]::Create((irm ...))) --dir=...`, which binds
+# arguments the way -Command does here.
+function Invoke-Script([string[]]$Arguments = @()) {
+    $Line = "& $(ConvertTo-Quoted $Script)"
+    foreach ($Arg in $Arguments) { $Line += " $(ConvertTo-Quoted $Arg)" }
+    $out = & $PSExe -NoProfile -Command $Line 2>&1 | Out-String
+    return [pscustomobject]@{ Code = $LASTEXITCODE; Out = $out }
+}
+
 function Invoke-Install([string]$Dir, [string[]]$Arguments = @()) {
     $env:AGAV_INSTALL_DIR = $Dir
-    $out = & $PSExe -NoProfile -File $Script @Arguments 2>&1 | Out-String
-    return [pscustomobject]@{ Code = $LASTEXITCODE; Out = $out }
+    return Invoke-Script $Arguments
 }
 
 # --- State this suite is allowed to change, and must put back ---------------
@@ -334,14 +349,14 @@ New-Item -ItemType Directory -Path "$Root/default" -Force | Out-Null
 Set-Content "$Root/default/agav.exe" "default install" -NoNewline
 New-Item -ItemType Directory -Path "$Root/explicit" -Force | Out-Null
 Set-Content "$Root/explicit/agav.exe" "explicit install" -NoNewline
-$out = & $PSExe -NoProfile -File $Script "--uninstall" "--dir=$Root/explicit" 2>&1 | Out-String
-Check "removed the --dir target" (-not (Test-Path "$Root/explicit/agav.exe")) $out
+$r = Invoke-Script @("--uninstall", "--dir=$Root/explicit")
+Check "removed the --dir target" (-not (Test-Path "$Root/explicit/agav.exe")) $r.Out
 Check "left the default target alone" (Test-Path "$Root/default/agav.exe")
 
 Write-Host "== --dir= wins over AGAV_INSTALL_DIR on install =="
 $env:AGAV_INSTALL_DIR = "$Root/envdir"
-$out = & $PSExe -NoProfile -File $Script "--dir=$Root/flagdir" 2>&1 | Out-String
-Check "installed to --dir" (Test-Path "$Root/flagdir/agav.exe") $out
+$r = Invoke-Script @("--dir=$Root/flagdir")
+Check "installed to --dir" (Test-Path "$Root/flagdir/agav.exe") $r.Out
 Check "did not install to env dir" (-not (Test-Path "$Root/envdir/agav.exe"))
 
 }

--- a/scripts/tests/install-ps1.test.ps1
+++ b/scripts/tests/install-ps1.test.ps1
@@ -1,0 +1,358 @@
+# Exercises install.ps1 end to end against a throwaway directory.
+#
+# The two functions that touch the network are redefined just before the main
+# install flow starts; everything above that point is the shipped file verbatim,
+# generated on every run so the stub cannot drift from the source.
+#
+#   pwsh -NoProfile -File scripts/tests/install-ps1.test.ps1
+#   powershell -NoProfile -File scripts\tests\install-ps1.test.ps1
+#
+# On Windows this really does write HKCU\Environment\PATH, exactly as a user's
+# install would. The original value is captured up front and put back in the
+# finally block below, whatever happens in between.
+param(
+    [string]$Installer = (Join-Path (Join-Path $PSScriptRoot "..") "install.ps1")
+)
+
+# Continue, not Stop: a failing assertion should print and move on rather than
+# take the rest of the suite with it.
+$ErrorActionPreference = "Continue"
+
+if (-not (Test-Path -LiteralPath $Installer)) {
+    Write-Host "no installer at $Installer" -ForegroundColor Red
+    exit 1
+}
+$Installer = (Resolve-Path -LiteralPath $Installer).Path
+
+$Pass = 0
+$Fail = 0
+function Check([string]$Name, [bool]$Cond, [string]$Detail = "") {
+    if ($Cond) { Write-Host "  PASS  $Name" -ForegroundColor Green; $script:Pass++ }
+    else { Write-Host "  FAIL  $Name  $Detail" -ForegroundColor Red; $script:Fail++ }
+}
+
+$Root = Join-Path ([System.IO.Path]::GetTempPath()) "agav-ps1-test"
+Remove-Item -Recurse -Force $Root -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $Root -Force | Out-Null
+
+# --- Build the stub ---------------------------------------------------------
+# Insert the fakes immediately before the first line of the install flow, so
+# every parse, flag, uninstall and PATH decision above it is the real thing.
+$StubBody = @'
+# ---- TEST STUBS ----
+function Save-FileWithProgress {
+    param([string]$Url, [string]$Destination, [string]$Activity)
+    if ($env:FAKE_DL_FAIL -eq "1") { throw "simulated 404 for $Url" }
+    Copy-Item -LiteralPath $env:FAKE_ASSET -Destination $Destination -Force
+}
+function Get-RemoteText {
+    param([string]$Url)
+    if ($env:FAKE_SHA_FAIL -eq "1") { throw "simulated 404 for $Url" }
+    return $env:FAKE_SHA_TEXT
+}
+# ---- END TEST STUBS ----
+'@
+
+$Anchor = 'if (-not (Test-Path -LiteralPath $InstallDir)) {'
+$Lines = @(Get-Content -LiteralPath $Installer)
+$Index = -1
+for ($i = 0; $i -lt $Lines.Count; $i++) {
+    if ($Lines[$i] -eq $Anchor) { $Index = $i; break }
+}
+if ($Index -lt 0) {
+    Write-Host "could not find the install-flow anchor in $Installer" -ForegroundColor Red
+    Write-Host "looked for: $Anchor" -ForegroundColor Red
+    exit 1
+}
+$Script = Join-Path $Root "install-stub.ps1"
+Set-Content -LiteralPath $Script -Encoding ASCII -Value (
+    @($Lines[0..($Index - 1)]) + ($StubBody -split "\r?\n") + @("") + @($Lines[$Index..($Lines.Count - 1)])
+)
+
+# --- Fake release asset, and its real digest --------------------------------
+$Asset = Join-Path $Root "asset.bin"
+Set-Content -LiteralPath $Asset -Value "I am the agav binary" -NoNewline
+$Digest = (Get-FileHash -LiteralPath $Asset -Algorithm SHA256).Hash
+$env:FAKE_ASSET = $Asset
+
+# Re-invoke whichever host is running this suite, so the same file is exercised
+# under Windows PowerShell 5.1 and pwsh without a second copy of the harness.
+$PSExe = (Get-Process -Id $PID).Path
+if (-not $PSExe) { $PSExe = "pwsh" }
+
+function Invoke-Install([string]$Dir, [string[]]$Arguments = @()) {
+    $env:AGAV_INSTALL_DIR = $Dir
+    $out = & $PSExe -NoProfile -File $Script @Arguments 2>&1 | Out-String
+    return [pscustomobject]@{ Code = $LASTEXITCODE; Out = $out }
+}
+
+# --- State this suite is allowed to change, and must put back ---------------
+$SavedUserProfile = $env:USERPROFILE
+$SavedInstallDir = $env:AGAV_INSTALL_DIR
+$SavedSkip = $env:AGAV_SKIP_CHECKSUM
+$SavedRegPath = $null
+$SavedRegKind = $null
+$HaveRegistry = $false
+try {
+    $Key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
+    if ($Key) {
+        $SavedRegPath = $Key.GetValue(
+            "PATH", $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        if ($null -ne $SavedRegPath) { $SavedRegKind = $Key.GetValueKind("PATH") }
+        $Key.Close()
+        $HaveRegistry = $true
+    }
+} catch {
+    # Not Windows, or no access. The installer tolerates both, and so does this.
+}
+
+function Restore-State {
+    $env:USERPROFILE = $script:SavedUserProfile
+    $env:AGAV_INSTALL_DIR = $script:SavedInstallDir
+    $env:AGAV_SKIP_CHECKSUM = $script:SavedSkip
+    $env:FAKE_ASSET = ""
+    $env:FAKE_SHA_TEXT = ""
+    $env:FAKE_SHA_FAIL = ""
+    $env:FAKE_DL_FAIL = ""
+    if (-not $script:HaveRegistry) { return }
+    try {
+        $Key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+        if (-not $Key) { return }
+        if ($null -eq $script:SavedRegPath) { $Key.DeleteValue("PATH", $false) }
+        else { $Key.SetValue("PATH", $script:SavedRegPath, $script:SavedRegKind) }
+        $Key.Close()
+    } catch {
+        Write-Host "WARNING: could not restore your user PATH: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+function Invoke-Suite {
+
+Write-Host "== `$Matches populated by -notmatch when the pattern DOES match =="
+$n = "agav.exe.1234.bak"
+if ($n -notmatch "^agav\.exe\.(\d+)\.(bak|tmp)$") { Check "unreachable" $false }
+else { Check "-notmatch still fills `$Matches" ($Matches[1] -eq "1234" -and $Matches[2] -eq "bak") "got $($Matches | Out-String)" }
+
+Write-Host "== --help =="
+$r = Invoke-Install "$Root/help" @("--help")
+Check "--help exits 0" ($r.Code -eq 0) "code=$($r.Code)"
+Check "--help documents --skip-checksum" ($r.Out -match "--skip-checksum")
+Check "--help does not install" (-not (Test-Path "$Root/help"))
+
+Write-Host "== happy path =="
+$env:FAKE_SHA_TEXT = "$Digest  agav-windows-x64.exe"
+$env:FAKE_SHA_FAIL = "0"; $env:FAKE_DL_FAIL = "0"
+$d = "$Root/ok"
+$r = Invoke-Install $d
+Check "install exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "binary landed" (Test-Path "$d/agav.exe")
+Check "content matches asset" ((Get-Content -Raw "$d/agav.exe") -eq (Get-Content -Raw $Asset))
+Check "reports checksum verified" ($r.Out -match "Checksum verified")
+Check "no .tmp left" (@(Get-ChildItem $d -Filter "*.tmp" -EA SilentlyContinue).Count -eq 0)
+Check "no .bak left" (@(Get-ChildItem $d -Filter "*.bak" -EA SilentlyContinue).Count -eq 0)
+
+Write-Host "== upgrade over an existing install (rename-aside) =="
+Set-Content -LiteralPath "$d/agav.exe" -Value "OLD" -NoNewline
+$r = Invoke-Install $d
+Check "upgrade exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "old binary replaced" ((Get-Content -Raw "$d/agav.exe") -eq (Get-Content -Raw $Asset))
+Check "backup cleaned up" (@(Get-ChildItem $d -Filter "*.bak" -EA SilentlyContinue).Count -eq 0)
+
+Write-Host "== checksum mismatch =="
+$env:FAKE_SHA_TEXT = ("a" * 64) + "  agav-windows-x64.exe"
+$d = "$Root/mismatch"
+$r = Invoke-Install $d
+Check "mismatch exits 1" ($r.Code -eq 1) "code=$($r.Code)"
+Check "mismatch installs nothing" (-not (Test-Path "$d/agav.exe"))
+Check "mismatch leaves no .tmp" (@(Get-ChildItem $d -Filter "*.tmp" -EA SilentlyContinue).Count -eq 0)
+Check "mismatch does NOT advertise the bypass" ($r.Out -notmatch "skip-checksum")
+
+Write-Host "== checksum fetch 404 =="
+$env:FAKE_SHA_FAIL = "1"
+$d = "$Root/sha404"
+$r = Invoke-Install $d
+Check "sha 404 exits 1" ($r.Code -eq 1) "code=$($r.Code)"
+Check "sha 404 installs nothing" (-not (Test-Path "$d/agav.exe"))
+Check "sha 404 leaves no .tmp" (@(Get-ChildItem $d -Filter "*.tmp" -EA SilentlyContinue).Count -eq 0)
+Check "sha 404 suggests the bypass" ($r.Out -match "skip-checksum")
+
+Write-Host "== garbage checksum body =="
+$env:FAKE_SHA_FAIL = "0"; $env:FAKE_SHA_TEXT = "<html>404 not found</html>"
+$d = "$Root/garbage"
+$r = Invoke-Install $d
+Check "garbage checksum exits 1" ($r.Code -eq 1) "code=$($r.Code)"
+Check "garbage checksum installs nothing" (-not (Test-Path "$d/agav.exe"))
+
+Write-Host "== --skip-checksum =="
+$env:FAKE_SHA_FAIL = "1"
+$d = "$Root/skip"
+$r = Invoke-Install $d @("--skip-checksum")
+Check "--skip-checksum exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "--skip-checksum installs" (Test-Path "$d/agav.exe")
+Check "--skip-checksum warns" ($r.Out -match "skipping checksum")
+
+Write-Host "== AGAV_SKIP_CHECKSUM env =="
+$env:AGAV_SKIP_CHECKSUM = "true"
+$d = "$Root/skipenv"
+$r = Invoke-Install $d
+Check "AGAV_SKIP_CHECKSUM=true installs" (Test-Path "$d/agav.exe") "code=$($r.Code) out=$($r.Out)"
+$env:AGAV_SKIP_CHECKSUM = ""
+
+Write-Host "== download failure =="
+$env:FAKE_DL_FAIL = "1"; $env:FAKE_SHA_FAIL = "0"; $env:FAKE_SHA_TEXT = "$Digest  agav-windows-x64.exe"
+$d = "$Root/dlfail"
+$r = Invoke-Install $d
+Check "download failure exits 1" ($r.Code -eq 1) "code=$($r.Code)"
+Check "download failure installs nothing" (-not (Test-Path "$d/agav.exe"))
+$env:FAKE_DL_FAIL = "0"
+
+Write-Host "== stale artifact sweep =="
+$d = "$Root/stale"
+New-Item -ItemType Directory -Path $d -Force | Out-Null
+Set-Content "$d/agav.exe.9999999.bak" "dead pid backup" -NoNewline
+Set-Content "$d/agav.exe.9999998.tmp" "dead pid download" -NoNewline
+Set-Content "$d/agav.exe.tmp" "legacy download" -NoNewline
+Set-Content "$d/agav.exe.$PID.tmp" "LIVE download" -NoNewline
+Set-Content "$d/notes.txt" "keep me" -NoNewline
+$r = Invoke-Install $d
+Check "sweep exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "dead-pid .bak swept" (-not (Test-Path "$d/agav.exe.9999999.bak"))
+Check "dead-pid .tmp swept" (-not (Test-Path "$d/agav.exe.9999998.tmp"))
+Check "legacy .tmp swept" (-not (Test-Path "$d/agav.exe.tmp"))
+Check "LIVE .tmp spared" (Test-Path "$d/agav.exe.$PID.tmp")
+Check "unrelated file spared" (Test-Path "$d/notes.txt")
+
+Write-Host "== a leftover with an absurd pid does not abort the install =="
+# \d+ matches a number too big for an Int32, and the cast threw under
+# $ErrorActionPreference = "Stop" - taking the whole installer down from inside
+# the routine that exists to tolerate junk.
+$d = "$Root/bigpid"
+New-Item -ItemType Directory -Path $d -Force | Out-Null
+Set-Content "$d/agav.exe.99999999999.bak" "absurd pid" -NoNewline
+Set-Content "$d/agav.exe.99999999999.tmp" "absurd pid" -NoNewline
+Set-Content "$d/agav.exe.0000$PID.tmp" "live pid, zero padded" -NoNewline
+$r = Invoke-Install $d
+Check "install still exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "binary installed" (Test-Path "$d/agav.exe")
+Check "unparseable-pid .bak swept" (-not (Test-Path "$d/agav.exe.99999999999.bak"))
+Check "unparseable-pid .tmp swept" (-not (Test-Path "$d/agav.exe.99999999999.tmp"))
+Check "zero-padded live pid still spared" (Test-Path "$d/agav.exe.0000$PID.tmp")
+
+Write-Host "== uninstall =="
+$d = "$Root/ok"
+$r = Invoke-Install $d @("--uninstall")
+Check "uninstall exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "uninstall removes the binary" (-not (Test-Path "$d/agav.exe"))
+$r = Invoke-Install $d @("--uninstall")
+Check "uninstall of nothing exits 1" ($r.Code -eq 1) "code=$($r.Code)"
+
+Write-Host "== uninstall sweeps stale artifacts and the empty dir =="
+$d = "$Root/unstale"
+New-Item -ItemType Directory -Path $d -Force | Out-Null
+Set-Content "$d/agav.exe" "binary" -NoNewline
+Set-Content "$d/agav.exe.9999999.bak" "dead pid backup" -NoNewline
+$r = Invoke-Install $d @("--uninstall")
+Check "uninstall exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "uninstall swept the stale .bak" (-not (Test-Path "$d/agav.exe.9999999.bak"))
+Check "uninstall removed the now-empty dir" (-not (Test-Path $d))
+
+Write-Host "== uninstall never deletes a dir holding the user's own files =="
+$d = "$Root/unkeep"
+New-Item -ItemType Directory -Path $d -Force | Out-Null
+Set-Content "$d/agav.exe" "binary" -NoNewline
+Set-Content "$d/notes.txt" "keep me" -NoNewline
+$r = Invoke-Install $d @("--uninstall")
+Check "binary removed" (-not (Test-Path "$d/agav.exe")) "out=$($r.Out)"
+Check "non-empty dir spared" (Test-Path $d)
+Check "unrelated file spared" (Test-Path "$d/notes.txt")
+
+# From here on the data directory is real and gets deleted, so point the child
+# processes at a fake home first.
+$env:USERPROFILE = "$Root/home"
+$DataDir = Join-Path $env:USERPROFILE ".agav"
+# The one thing in this suite that destroys data. If $Root were ever
+# misconfigured this would be the user's real ~/.agav, so refuse outright
+# rather than trust the assignment above.
+if ($DataDir -notlike "$Root*") {
+    throw "refusing to run the purge tests: $DataDir is outside $Root"
+}
+
+function New-DataDir {
+    Remove-Item -Recurse -Force $DataDir -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $DataDir -Force | Out-Null
+    Set-Content "$DataDir/settings.json" '{"keep":true}' -NoNewline
+}
+
+Write-Host "== plain --uninstall keeps the data directory =="
+$d = "$Root/keepdata"
+New-Item -ItemType Directory -Path $d -Force | Out-Null
+Set-Content "$d/agav.exe" "binary" -NoNewline
+New-DataDir
+$r = Invoke-Install $d @("--uninstall")
+Check "exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "settings survive" (Test-Path "$DataDir/settings.json")
+Check "says what it kept, and how to remove it" `
+    ($r.Out -match "Kept your settings" -and $r.Out -match "--purge") "out=$($r.Out)"
+
+Write-Host "== --purge removes the data directory =="
+$d = "$Root/purge"
+New-Item -ItemType Directory -Path $d -Force | Out-Null
+Set-Content "$d/agav.exe" "binary" -NoNewline
+New-DataDir
+$r = Invoke-Install $d @("--purge")
+Check "exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "--purge implies --uninstall: binary gone" (-not (Test-Path "$d/agav.exe"))
+Check "data directory gone" (-not (Test-Path $DataDir))
+Check "reports the removal" ($r.Out -match "Removed .*\.agav") "out=$($r.Out)"
+Check "does not also claim it kept anything" ($r.Out -notmatch "Kept your settings")
+
+Write-Host "== --purge after the binary was already removed by hand =="
+# The point of --purge is the data directory. Bailing out with "not found"
+# because the exe is already gone would leave the data behind for good.
+$d = "$Root/purgeonly"
+New-Item -ItemType Directory -Path $d -Force | Out-Null
+New-DataDir
+$r = Invoke-Install $d @("--purge")
+Check "exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "data directory gone" (-not (Test-Path $DataDir))
+
+Write-Host "== nothing to do at all still fails =="
+$d = "$Root/nothing"
+Remove-Item -Recurse -Force $DataDir -ErrorAction SilentlyContinue
+$r = Invoke-Install $d @("--purge")
+Check "exits 1" ($r.Code -eq 1) "code=$($r.Code) out=$($r.Out)"
+Check "says not found" ($r.Out -match "not found")
+
+Write-Host "== --help documents --purge =="
+$r = Invoke-Install "$Root/help2" @("--help")
+Check "--help lists --purge" ($r.Out -match "--purge")
+Check "--help says plain uninstall keeps your data" ($r.Out -match "keeping your settings")
+
+Write-Host "== --uninstall --dir=X honours --dir (two-pass parsing) =="
+$env:AGAV_INSTALL_DIR = "$Root/default"
+New-Item -ItemType Directory -Path "$Root/default" -Force | Out-Null
+Set-Content "$Root/default/agav.exe" "default install" -NoNewline
+New-Item -ItemType Directory -Path "$Root/explicit" -Force | Out-Null
+Set-Content "$Root/explicit/agav.exe" "explicit install" -NoNewline
+$out = & $PSExe -NoProfile -File $Script "--uninstall" "--dir=$Root/explicit" 2>&1 | Out-String
+Check "removed the --dir target" (-not (Test-Path "$Root/explicit/agav.exe")) $out
+Check "left the default target alone" (Test-Path "$Root/default/agav.exe")
+
+Write-Host "== --dir= wins over AGAV_INSTALL_DIR on install =="
+$env:AGAV_INSTALL_DIR = "$Root/envdir"
+$out = & $PSExe -NoProfile -File $Script "--dir=$Root/flagdir" 2>&1 | Out-String
+Check "installed to --dir" (Test-Path "$Root/flagdir/agav.exe") $out
+Check "did not install to env dir" (-not (Test-Path "$Root/envdir/agav.exe"))
+
+}
+
+try {
+    Invoke-Suite
+} finally {
+    Restore-State
+    Remove-Item -Recurse -Force $Root -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "$Pass passed, $Fail failed" -ForegroundColor $(if ($Fail -eq 0) { "Green" } else { "Red" })
+exit $(if ($Fail -eq 0) { 0 } else { 1 })

--- a/scripts/tests/install-sh-path.test.sh
+++ b/scripts/tests/install-sh-path.test.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Lift add_to_path out of the shipped installer and exercise it directly; the
+# install flow around it needs the network, this function does not.
+#
+#   sh scripts/tests/install-sh-path.test.sh [path/to/install.sh]
+#
+# See install-sh.test.sh for why SC2319/SC2181 are off. SC2034 fires on the
+# globals the lifted functions read ($os, $BIN_DIR) - they look unused here
+# because their only reader arrives via eval.
+# shellcheck disable=SC2319,SC2181,SC2016,SC2012,SC2034,SC2154
+SRC="${1:-"$(dirname "$0")/../install.sh"}"
+[ -f "$SRC" ] || { echo "no installer at $SRC" >&2; exit 1; }
+PASS=0; FAIL=0
+check() { if [ "$2" -eq 0 ]; then printf '  PASS  %s\n' "$1"; PASS=$((PASS+1)); else printf '  FAIL  %s  %s\n' "$1" "${3:-}"; FAIL=$((FAIL+1)); fi; }
+
+eval "$(awk '/^pick_profile\(\) \{/,/^\}/' "$SRC")"
+eval "$(awk '/^add_to_path\(\) \{/,/^\}/' "$SRC")"
+
+R="${TMPDIR:-/tmp}/agav-addpath.$$"; rm -rf "$R"
+
+# add_to_path reads $PATH to decide whether there is anything to do, so the
+# cases below leave it alone rather than overriding it: a stripped-down PATH
+# also strips the ls/cat/rm the function itself calls. The directories used
+# here are fictional, so the ambient PATH never contains them.
+case ":$PATH:" in *":/opt/agav/bin:"*|*":/opt/new/bin:"*)
+  echo "refusing to run: PATH already contains a directory this suite pretends is absent" >&2
+  exit 1 ;;
+esac
+
+fresh() { HOME="$R/$1"; mkdir -p "$HOME"; os="linux"; SHELL="/bin/bash"; BIN_DIR="$2"; }
+BEGIN="# >>> Agav installer >>>"
+
+echo "== appends a block to a profile that has none =="
+fresh plain /opt/agav/bin
+printf 'export EDITOR=vi\n' >"$HOME/.bashrc"
+add_to_path
+grep -qF "$BEGIN" "$HOME/.bashrc"; check "block written" $?
+grep -qF 'export PATH="/opt/agav/bin:$PATH"' "$HOME/.bashrc"; check "correct PATH line" $?
+[ "$path_action" = "added" ]; check "reports added" $? "$path_action"
+
+echo "== rewrites a block that points somewhere else (the temp-file branch) =="
+fresh rewrite /opt/new/bin
+printf '# top\n\n%s\nexport PATH="/opt/old/bin:$PATH"\n# <<< Agav installer <<<\n# bottom\n' "$BEGIN" >"$HOME/.bashrc"
+ino_before="$(ls -i "$HOME/.bashrc" | awk '{print $1}')"
+add_to_path
+grep -qF 'export PATH="/opt/new/bin:$PATH"' "$HOME/.bashrc"; check "new dir written" $?
+grep -qF '/opt/old/bin' "$HOME/.bashrc"; [ $? -ne 0 ]; check "old dir gone" $?
+[ "$(grep -cF "$BEGIN" "$HOME/.bashrc")" -eq 1 ]; check "exactly one block, not two" $?
+grep -qF '# top' "$HOME/.bashrc" && grep -qF '# bottom' "$HOME/.bashrc"; check "surrounding lines kept" $?
+[ "$ino_before" = "$(ls -i "$HOME/.bashrc" | awk '{print $1}')" ]; check "same inode" $?
+[ -z "$(find "$HOME" -name '*.agav-install.*')" ]; check "no scratch file left in HOME" $? "$(find "$HOME" -name '*agav*')"
+[ -z "$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'agav-profile.*' 2>/dev/null)" ]; check "nothing written to /tmp" $?
+
+echo "== a home directory with a space, on the rewrite branch =="
+fresh "Jane Doe" "/opt/new/bin"
+printf '%s\nexport PATH="/opt/old/bin:$PATH"\n# <<< Agav installer <<<\n' "$BEGIN" >"$HOME/.bashrc"
+add_to_path
+grep -qF 'export PATH="/opt/new/bin:$PATH"' "$HOME/.bashrc"; check "rewrite still works" $?
+[ -z "$(find "$R" -name '*.agav-install.*')" ]; check "no scratch file left" $?
+
+echo "== already on PATH: profile untouched =="
+fresh onpath /opt/agav/bin
+printf 'export EDITOR=vi\n' >"$HOME/.bashrc"
+PATH="$PATH:/opt/agav/bin" add_to_path
+grep -qF "$BEGIN" "$HOME/.bashrc"; [ $? -ne 0 ]; check "nothing written" $?
+
+rm -rf "$R"
+echo; echo "$PASS passed, $FAIL failed"; [ "$FAIL" -eq 0 ]

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -1,0 +1,236 @@
+#!/bin/sh
+# Exercises install.sh's uninstall path against a throwaway HOME. Uninstall
+# returns before detect_platform, so none of this touches the network and the
+# suite is safe to run anywhere.
+#
+#   sh scripts/tests/install-sh.test.sh [path/to/install.sh]
+#
+# `<condition>; check "name" $?` is the assertion idiom throughout. SC2319 and
+# SC2181 both want an `if` instead, but reading $? straight off the condition is
+# the whole point here, and an `if` per assertion would triple the file.
+# shellcheck disable=SC2319,SC2181,SC2016,SC2012
+SRC="${1:-"$(dirname "$0")/../install.sh"}"
+[ -f "$SRC" ] || { echo "no installer at $SRC" >&2; exit 1; }
+PASS=0
+FAIL=0
+
+check() { # check <name> <condition-exit-code> [detail]
+  if [ "$2" -eq 0 ]; then
+    printf '  PASS  %s\n' "$1"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL  %s  %s\n' "$1" "${3:-}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+ROOT="${TMPDIR:-/tmp}/agav-sh-test.$$"
+rm -rf "$ROOT"
+mkdir -p "$ROOT"
+
+# Each case gets a pristine HOME so profiles and ~/.agav cannot leak between
+# tests. Returns with $H, $BIN, $DATA set.
+fresh() {
+  H="$ROOT/$1"
+  BIN="$H/.local/bin"
+  DATA="$H/.agav"
+  rm -rf "$H"
+  mkdir -p "$BIN" "$DATA"
+}
+
+# Run the installer with everything pointed at the throwaway HOME. Output lands
+# in $OUT, exit status in $CODE.
+run() {
+  OUT="$(HOME="$H" AGAV_INSTALL_DIR="$BIN" AGAV_HOME="$DATA" sh "$SRC" "$@" 2>&1)"
+  CODE=$?
+}
+
+BEGIN="# >>> Agav installer >>>"
+END="# <<< Agav installer <<<"
+
+write_block() { # write_block <profile> [dir]
+  printf '\n%s\nexport PATH="%s:$PATH"\n%s\n' "$BEGIN" "${2:-$BIN}" "$END" >>"$1"
+}
+
+echo "== a normal uninstall =="
+fresh normal
+: >"$BIN/agav"
+mkdir -p "$DATA/packages/standalone/agav-v1"
+run --uninstall
+check "exits 0" "$CODE" "code=$CODE out=$OUT"
+[ ! -e "$BIN/agav" ]; check "binary removed" $?
+[ ! -d "$DATA/packages/standalone" ]; check "standalone release tree removed" $?
+[ ! -d "$DATA/packages" ]; check "empty packages/ dir removed" $?
+echo "$OUT" | grep -q "Uninstalled Agav"; check "reports success" $?
+
+echo "== no profile block: must not abort early =="
+# `[ -n \"\$x\" ] && removed=1` under set -e exits the script the moment the
+# test is false, silently, before anything is reported.
+fresh noblock
+: >"$BIN/agav"
+run --uninstall
+check "exits 0" "$CODE" "code=$CODE out=$OUT"
+echo "$OUT" | grep -q "Uninstalled Agav"; check "still reached the success message" $? "out=$OUT"
+echo "$OUT" | grep -qv "Restart your shell"; check "no spurious restart hint" $?
+
+echo "== a dangling symlink still counts as installed =="
+fresh dangling
+ln -s "$ROOT/gone-forever" "$BIN/agav"
+run --uninstall
+check "exits 0" "$CODE" "code=$CODE out=$OUT"
+[ ! -L "$BIN/agav" ]; check "broken symlink removed" $?
+
+echo "== packages/ is spared when something else lives there =="
+fresh otherpkg
+: >"$BIN/agav"
+mkdir -p "$DATA/packages/somebody-elses"
+run --uninstall
+[ -d "$DATA/packages/somebody-elses" ]; check "unrelated package dir spared" $?
+
+echo "== the PATH block comes back out =="
+fresh oneprofile
+: >"$BIN/agav"
+printf 'export EDITOR=vi\n' >"$H/.zshrc"
+write_block "$H/.zshrc"
+printf 'alias ll="ls -l"\n' >>"$H/.zshrc"
+run --uninstall
+check "exits 0" "$CODE" "code=$CODE out=$OUT"
+grep -qF "$BEGIN" "$H/.zshrc"; [ $? -ne 0 ]; check "begin marker gone" $?
+grep -qF "$END" "$H/.zshrc"; [ $? -ne 0 ]; check "end marker gone" $?
+grep -qF 'export PATH' "$H/.zshrc"; [ $? -ne 0 ]; check "the exported PATH line gone" $?
+grep -qF 'export EDITOR=vi' "$H/.zshrc"; check "line before the block kept" $?
+grep -qF 'alias ll="ls -l"' "$H/.zshrc"; check "line after the block kept" $?
+echo "$OUT" | grep -q "Removed the Agav PATH entry from $H/.zshrc"; check "names the profile it edited" $? "out=$OUT"
+echo "$OUT" | grep -q "Restart your shell"; check "tells you to restart the shell" $?
+
+echo "== every profile that has one, not just the shell we guessed =="
+fresh manyprofiles
+: >"$BIN/agav"
+for p in .zprofile .bash_profile .zshrc .bashrc .profile; do
+  printf '# mine\n' >"$H/$p"
+  write_block "$H/$p"
+done
+run --uninstall
+n=0
+for p in .zprofile .bash_profile .zshrc .bashrc .profile; do
+  if ! grep -qF "$BEGIN" "$H/$p" && grep -qF '# mine' "$H/$p"; then n=$((n + 1)); fi
+done
+[ "$n" -eq 5 ]; check "all 5 profiles cleaned, contents kept" $? "cleaned=$n"
+
+echo "== a profile containing nothing but our block ends up empty =="
+fresh onlyblock
+: >"$BIN/agav"
+: >"$H/.profile"
+write_block "$H/.profile"
+run --uninstall
+[ -f "$H/.profile" ]; check "profile still exists" $?
+[ ! -s "$H/.profile" ]; check "profile is empty, not left with stray blank lines" $? "content=$(od -c "$H/.profile" | head -2)"
+
+echo "== install/uninstall cycles do not pile up blank lines =="
+fresh cycles
+: >"$BIN/agav"
+printf 'export EDITOR=vi\n' >"$H/.profile"
+before="$(wc -l <"$H/.profile")"
+i=0
+while [ "$i" -lt 3 ]; do
+  write_block "$H/.profile"
+  run --uninstall
+  : >"$BIN/agav"
+  i=$((i + 1))
+done
+after="$(wc -l <"$H/.profile")"
+[ "$before" -eq "$after" ]; check "line count unchanged after 3 cycles" $? "before=$before after=$after"
+
+echo "== the profile keeps its identity =="
+fresh inode
+: >"$BIN/agav"
+printf 'export EDITOR=vi\n' >"$H/.profile"
+write_block "$H/.profile"
+chmod 600 "$H/.profile"
+ino_before="$(ls -i "$H/.profile" | awk '{print $1}')"
+mode_before="$(ls -l "$H/.profile" | cut -c1-10)"
+run --uninstall
+ino_after="$(ls -i "$H/.profile" | awk '{print $1}')"
+mode_after="$(ls -l "$H/.profile" | cut -c1-10)"
+[ "$ino_before" = "$ino_after" ]; check "same inode (not replaced by a mv)" $? "$ino_before vs $ino_after"
+[ "$mode_before" = "$mode_after" ]; check "same permissions" $? "$mode_before vs $mode_after"
+
+echo "== a stale block pointing at some other dir is still ours to remove =="
+fresh otherdir
+: >"$BIN/agav"
+printf '# mine\n' >"$H/.zshrc"
+write_block "$H/.zshrc" "/some/older/agav/dir"
+run --uninstall
+grep -qF "$BEGIN" "$H/.zshrc"; [ $? -ne 0 ]; check "block removed regardless of the dir inside it" $?
+
+echo "== plain --uninstall keeps your data =="
+fresh keepdata
+: >"$BIN/agav"
+printf '{}' >"$DATA/settings.json"
+run --uninstall
+check "exits 0" "$CODE" "code=$CODE"
+[ -f "$DATA/settings.json" ]; check "settings survive" $?
+echo "$OUT" | grep -q "Kept your settings"; check "says what it kept" $? "out=$OUT"
+echo "$OUT" | grep -q -- "--purge"; check "says how to remove it" $?
+
+echo "== --purge removes your data =="
+fresh purge
+: >"$BIN/agav"
+printf '{}' >"$DATA/settings.json"
+run --purge
+check "exits 0" "$CODE" "code=$CODE out=$OUT"
+[ ! -e "$BIN/agav" ]; check "--purge implies --uninstall: binary gone" $?
+[ ! -d "$DATA" ]; check "data directory gone" $?
+echo "$OUT" | grep -q "Removed $DATA"; check "reports the removal" $? "out=$OUT"
+echo "$OUT" | grep -qv "Kept your settings"; check "does not also claim it kept anything" $?
+
+echo "== --purge after the binary was removed by hand =="
+# The point of --purge is the data. Refusing because the binary is already gone
+# would strand it there for good.
+fresh purgeonly
+printf '{}' >"$DATA/settings.json"
+run --purge
+check "exits 0" "$CODE" "code=$CODE out=$OUT"
+[ ! -d "$DATA" ]; check "data directory gone" $?
+
+echo "== nothing to do at all still fails =="
+fresh nothing
+rm -rf "$DATA"
+run --purge
+[ "$CODE" -eq 1 ]; check "exits 1" $? "code=$CODE"
+echo "$OUT" | grep -q "not found"; check "says not found" $? "out=$OUT"
+
+echo "== a home directory with a space in it =="
+# `for p in $path_removed_from` split one path into several, so the summary
+# claimed to have edited four profiles that do not exist.
+fresh "John Smith"
+: >"$BIN/agav"
+for p in .zshrc .profile; do
+  printf '# mine\n' >"$H/$p"
+  write_block "$H/$p"
+done
+run --uninstall
+[ "$(echo "$OUT" | grep -c 'Removed the Agav PATH entry')" -eq 2 ]
+check "one message per profile, not one per word" $? "out=$OUT"
+echo "$OUT" | grep -qF "Removed the Agav PATH entry from $H/.zshrc"; check "the path is intact" $?
+grep -qF "$BEGIN" "$H/.zshrc"; [ $? -ne 0 ]; check "profile still actually cleaned" $?
+
+echo "== no scratch files left behind =="
+[ -z "$(find "$H" -name '*.agav-uninstall.*' -o -name '*.agav-profile.*' -o -name '*.agav-install.*')" ]
+check "no temp files in HOME" $? "$(find "$H" -name '*agav-*')"
+[ -z "$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'agav-uninstall.*' -o -maxdepth 1 -name 'agav-profile.*' 2>/dev/null)" ]
+check "no temp files in TMPDIR" $?
+
+echo "== --help =="
+fresh help
+run --help
+check "exits 0" "$CODE" "code=$CODE"
+echo "$OUT" | grep -q -- "--purge"; check "documents --purge" $? "out=$OUT"
+echo "$OUT" | grep -q "keeping your settings"; check "says plain uninstall keeps your data" $?
+[ -e "$BIN/agav" ] || true
+echo "$OUT" | grep -qv "Uninstalled"; check "--help does not uninstall" $?
+
+rm -rf "$ROOT"
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/run-installer-tests.sh
+++ b/scripts/tests/run-installer-tests.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Run every installer test suite that this machine can run, and skip the rest
+# out loud rather than silently.
+#
+#   sh scripts/tests/run-installer-tests.sh
+#
+# The POSIX suites run under every shell that is installed, because install.sh
+# is `#!/bin/sh` and that is dash on Debian, bash on Fedora, and ash in a
+# BusyBox container. The PowerShell suites prefer a native pwsh and fall back to
+# Docker; with neither, they are reported as skipped.
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS="$(dirname "$HERE")"
+PS_IMAGE="mcr.microsoft.com/powershell:lts-7.4-ubuntu-22.04"
+
+failed=0
+skipped=""
+
+heading() { printf '\n\033[1m===== %s =====\033[0m\n' "$1"; }
+note() { printf '\033[36m%s\033[0m\n' "$1"; }
+skip() { printf '\033[33mSKIP  %s\033[0m\n' "$1"; skipped="$skipped  - $1
+"; }
+track() { if [ "$1" -ne 0 ]; then failed=$((failed + 1)); fi; }
+
+# --- shellcheck -------------------------------------------------------------
+heading "shellcheck"
+if command -v shellcheck >/dev/null 2>&1; then
+  if shellcheck -s sh "$SCRIPTS/install.sh" "$HERE/install-sh.test.sh" \
+    "$HERE/install-sh-path.test.sh" "$HERE/run-installer-tests.sh"; then
+    note "clean"
+  else
+    track 1
+  fi
+elif command -v docker >/dev/null 2>&1; then
+  note "no local shellcheck; using docker"
+  if docker run --rm -v "$SCRIPTS:/mnt:ro" koalaman/shellcheck:stable \
+    -s sh /mnt/install.sh /mnt/tests/install-sh.test.sh \
+    /mnt/tests/install-sh-path.test.sh /mnt/tests/run-installer-tests.sh; then
+    note "clean"
+  else
+    track 1
+  fi
+else
+  skip "shellcheck (install it, or start Docker)"
+fi
+
+# --- POSIX suites, once per available shell ---------------------------------
+# BusyBox ships ash as an applet rather than a binary named `ash`, so ask for it
+# by the name people actually have.
+for shell in sh dash bash busybox; do
+  command -v "$shell" >/dev/null 2>&1 || { skip "install.sh suites under $shell (not installed)"; continue; }
+  if [ "$shell" = "busybox" ]; then runner="busybox sh"; else runner="$shell"; fi
+  heading "install.sh suites under $shell"
+  # shellcheck disable=SC2086
+  $runner "$HERE/install-sh.test.sh" "$SCRIPTS/install.sh" || track 1
+  # shellcheck disable=SC2086
+  $runner "$HERE/install-sh-path.test.sh" "$SCRIPTS/install.sh" || track 1
+done
+
+# --- PowerShell suites ------------------------------------------------------
+ps_suites="install-ps1.test.ps1 install-ps1-path.test.ps1 install-ps1-lint.test.ps1"
+
+if command -v pwsh >/dev/null 2>&1; then
+  for suite in $ps_suites; do
+    heading "$suite (native pwsh)"
+    pwsh -NoProfile -File "$HERE/$suite" "$SCRIPTS/install.ps1" || track 1
+  done
+elif command -v docker >/dev/null 2>&1; then
+  note "no local pwsh; using docker"
+  for suite in $ps_suites; do
+    heading "$suite (docker)"
+    # Read-only: nothing under scripts/ should be written, and a failure to
+    # mount that way is a bug worth hearing about.
+    docker run --rm -v "$SCRIPTS:/s:ro" "$PS_IMAGE" \
+      pwsh -NoProfile -File "/s/tests/$suite" /s/install.ps1 || track 1
+  done
+else
+  skip "install.ps1 suites (install pwsh, or start Docker)"
+fi
+
+printf '\n'
+if [ -n "$skipped" ]; then
+  printf '\033[33mSkipped:\033[0m\n%s' "$skipped"
+fi
+if [ "$failed" -eq 0 ]; then
+  printf '\033[32mAll suites that ran passed.\033[0m\n'
+else
+  printf '\033[31m%s suite(s) failed.\033[0m\n' "$failed"
+  exit 1
+fi

--- a/source/__tests__/utils.auto-update-downloads.test.ts
+++ b/source/__tests__/utils.auto-update-downloads.test.ts
@@ -1,0 +1,93 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// auto-update.ts resolves ~/.agav once at import time, so the fake home has to
+// exist and be installed before the module is first evaluated.
+const home = await mkdtemp(join(tmpdir(), "agav-home-"));
+const agavDir = join(home, ".agav");
+await mkdir(agavDir, { recursive: true });
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return { ...actual, default: actual, homedir: () => home };
+});
+
+const { cleanupStaleDownloads } = await import("../utils/auto-update.js");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+/** Write a file into the fake ~/.agav and backdate it by `ageMs`. */
+async function seed(name: string, ageMs: number): Promise<void> {
+  const path = join(agavDir, name);
+  await writeFile(path, "x");
+  const when = new Date(NOW - ageMs);
+  const { utimes } = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  await utimes(path, when, when);
+}
+
+beforeEach(async () => {
+  for (const entry of await readdir(agavDir)) {
+    await rm(join(agavDir, entry), { recursive: true, force: true });
+  }
+});
+
+afterAll(async () => {
+  await rm(home, { recursive: true, force: true });
+});
+
+describe("cleanupStaleDownloads", () => {
+  // A process killed mid-transfer leaves a partial ~100 MB file in ~/.agav and
+  // nothing ever collected it.
+  it("removes abandoned downloads", async () => {
+    await seed("agav-update-v0.1.7.4242", 2 * DAY_MS);
+    await seed("agav-update-v0.1.6.99", 8 * DAY_MS);
+
+    await cleanupStaleDownloads(NOW);
+
+    expect(await readdir(agavDir)).toEqual([]);
+  });
+
+  // Age, not pid: a concurrently running agav may be mid-download, and yanking
+  // its temp file would fail its update for no reason.
+  it("leaves a download that could still be in flight", async () => {
+    await seed("agav-update-v0.1.8.1234", 30 * 1000);
+
+    await cleanupStaleDownloads(NOW);
+
+    expect(await readdir(agavDir)).toEqual(["agav-update-v0.1.8.1234"]);
+  });
+
+  it("never touches anything that is not a download", async () => {
+    await seed("config.json", 30 * DAY_MS);
+    await seed("update-state.json", 30 * DAY_MS);
+    await seed("prompt-history.json", 30 * DAY_MS);
+
+    await cleanupStaleDownloads(NOW);
+
+    expect((await readdir(agavDir)).sort()).toEqual([
+      "config.json",
+      "prompt-history.json",
+      "update-state.json",
+    ]);
+  });
+
+  it("skips directories that happen to match the prefix", async () => {
+    await mkdir(join(agavDir, "agav-update-cache"), { recursive: true });
+
+    await cleanupStaleDownloads(NOW);
+
+    expect(await readdir(agavDir)).toEqual(["agav-update-cache"]);
+  });
+
+  it("never throws when ~/.agav does not exist yet", async () => {
+    await rm(agavDir, { recursive: true, force: true });
+
+    await expect(cleanupStaleDownloads(NOW)).resolves.toBeUndefined();
+
+    await mkdir(agavDir, { recursive: true });
+  });
+});

--- a/source/__tests__/utils.auto-update-install.test.ts
+++ b/source/__tests__/utils.auto-update-install.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile, readdir } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -13,7 +13,9 @@ vi.mock("node:fs/promises", async () => {
 });
 
 const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-const { installUpdate, cleanupStaleBackups } = await import("../utils/auto-update.js");
+const { installUpdate, cleanupStaleBackups, pruneOldReleases, isNewer } = await import(
+  "../utils/auto-update.js"
+);
 
 let dir: string;
 
@@ -76,6 +78,116 @@ describe("installUpdate on a plain binary install", () => {
     const backups = (await readdir(dir)).filter((f) => f.endsWith(".bak")).sort();
     expect(backups).toContain("agav.exe.99999.bak");
     expect(backups).toContain(`agav.exe.${process.pid}.bak`);
+  });
+});
+
+/** Build the installer's `<root>/standalone/releases/<version>/agav` layout. */
+async function seedManagedInstall(versions: string[], running: string) {
+  const releases = join(dir, "packages", "standalone", "releases");
+  for (const version of versions) {
+    await mkdir(join(releases, version), { recursive: true });
+    await writeFile(join(releases, version, "agav"), `binary ${version}`);
+  }
+  const downloadPath = join(dir, "agav-update-v9.9.9");
+  await writeFile(downloadPath, "new binary");
+  return { releases, binaryPath: join(releases, running, "agav"), downloadPath };
+}
+
+describe("installUpdate on a managed install", () => {
+  // Every auto-update left its predecessor behind: a ~100 MB release directory
+  // per version, forever. install.sh has always pruned; this side never did.
+  it("keeps only the release it just installed", async () => {
+    const { releases, binaryPath, downloadPath } = await seedManagedInstall(
+      ["0.1.5", "0.1.6", "0.1.7"],
+      "0.1.7",
+    );
+
+    await installUpdate(downloadPath, "v0.1.8", binaryPath);
+
+    expect((await readdir(releases)).sort()).toEqual(["0.1.8"]);
+    expect(await readFile(join(releases, "0.1.8", "agav"), "utf8")).toBe("new binary");
+  });
+
+  it("points `current` at the new release before pruning the old ones", async () => {
+    const { binaryPath, downloadPath } = await seedManagedInstall(["0.1.7"], "0.1.7");
+
+    await installUpdate(downloadPath, "v0.1.8", binaryPath);
+
+    const currentLink = join(dir, "packages", "standalone", "current");
+    // Resolving through the symlink proves it was swapped, not left dangling
+    // at the directory the prune removed.
+    expect(await readFile(join(currentLink, "agav"), "utf8")).toBe("new binary");
+  });
+
+  it("still installs when a leftover release directory cannot be removed", async () => {
+    const { releases, binaryPath, downloadPath } = await seedManagedInstall(
+      ["0.1.6", "0.1.7"],
+      "0.1.7",
+    );
+    rmMock.mockImplementation(async (target: any, opts: any) => {
+      if (String(target).endsWith("0.1.6")) throw new Error("EBUSY");
+      return (actualFs.rm as any)(target, opts);
+    });
+
+    await expect(installUpdate(downloadPath, "v0.1.8", binaryPath)).resolves.toBeUndefined();
+    expect(await readFile(join(releases, "0.1.8", "agav"), "utf8")).toBe("new binary");
+  });
+});
+
+describe("pruneOldReleases", () => {
+  it("leaves files and the kept directory alone", async () => {
+    const releases = join(dir, "releases");
+    await mkdir(join(releases, "0.1.6"), { recursive: true });
+    await mkdir(join(releases, "0.1.7"), { recursive: true });
+    await writeFile(join(releases, "notes.txt"), "keep me");
+
+    await pruneOldReleases(releases, join(releases, "0.1.7"));
+
+    expect((await readdir(releases)).sort()).toEqual(["0.1.7", "notes.txt"]);
+  });
+
+  it("never throws when the releases directory is missing", async () => {
+    await expect(pruneOldReleases(join(dir, "nope"), join(dir, "nope", "x"))).resolves.toBeUndefined();
+  });
+});
+
+describe("isNewer", () => {
+  it.each([
+    ["v0.1.8", "0.1.7"],
+    ["v0.2.0", "0.1.9"],
+    ["v1.0.0", "0.9.9"],
+    ["v0.1.10", "0.1.9"],
+  ])("treats %s as newer than %s", (remote, local) => {
+    expect(isNewer(remote, local)).toBe(true);
+  });
+
+  it.each([
+    ["v0.1.7", "0.1.7"],
+    ["v0.1.6", "0.1.7"],
+    ["v0.0.9", "0.1.0"],
+  ])("treats %s as not newer than %s", (remote, local) => {
+    expect(isNewer(remote, local)).toBe(false);
+  });
+
+  // Regression: `split(".").map(Number)` turned the suffixed part into NaN, and
+  // NaN loses every comparison, so the loop fell through to "not newer". A
+  // patch-level pre-release marked latest froze every client on its current
+  // version, silently and forever.
+  it("compares the core version of a pre-release tag", () => {
+    expect(isNewer("v0.1.8-rc1", "0.1.7")).toBe(true);
+    expect(isNewer("v0.1.8-beta.3", "0.1.7")).toBe(true);
+    expect(isNewer("v0.2.0-rc1", "0.1.7")).toBe(true);
+    expect(isNewer("v1.0.0+build.42", "0.9.9")).toBe(true);
+  });
+
+  it("does not sidegrade into a pre-release of the version already installed", () => {
+    expect(isNewer("v0.1.7-rc1", "0.1.7")).toBe(false);
+  });
+
+  it("refuses to act on a tag it cannot parse", () => {
+    expect(isNewer("nightly", "0.1.7")).toBe(false);
+    expect(isNewer("", "0.1.7")).toBe(false);
+    expect(isNewer("v0.1.8", "not-a-version")).toBe(false);
   });
 });
 

--- a/source/__tests__/utils.auto-update.test.ts
+++ b/source/__tests__/utils.auto-update.test.ts
@@ -84,8 +84,57 @@ describe("installer docs and scripts", () => {
   it("does not suppress PowerShell web request progress in install.cmd", () => {
     const installCmd = readFileSync(new URL("../../scripts/install.cmd", import.meta.url), "utf8");
 
-    expect(installCmd).toContain("Invoke-WebRequest -Uri '%INSTALLER_URL%' -OutFile '%TMP_PS1%'");
+    expect(installCmd).toContain("Invoke-WebRequest -UseBasicParsing -Uri '%INSTALLER_URL%' -OutFile '%TMP_PS1%'");
     expect(installCmd).not.toContain("$ProgressPreference='SilentlyContinue'");
+  });
+
+  // Fetching from a branch meant cmd users always ran whatever happened to be
+  // on main rather than a released installer.
+  it("fetches install.ps1 from the release host, not a git branch", () => {
+    const installCmd = readFileSync(new URL("../../scripts/install.cmd", import.meta.url), "utf8");
+
+    expect(installCmd).not.toContain("raw.githubusercontent.com");
+    // www, not the apex: PowerShell 5.1 cannot follow the apex's 308.
+    expect(installCmd).toContain("https://www.agav.dev/install.ps1");
+  });
+
+  it("verifies the download in every installer, and fails closed", () => {
+    const installSh = readFileSync(new URL("../../scripts/install.sh", import.meta.url), "utf8");
+    const installPs1 = readFileSync(new URL("../../scripts/install.ps1", import.meta.url), "utf8");
+
+    // Nothing may skip verification except the documented opt-out.
+    expect(installSh).toContain("checksum_abort");
+    expect(installSh).toContain("AGAV_SKIP_CHECKSUM");
+    expect(installPs1).toContain("Get-FileHash");
+    expect(installPs1).toContain("$DownloadUrl.sha256");
+    expect(installPs1).toContain("Checksum verification failed");
+  });
+
+  // Windows cannot delete the image of a running process, so the installer has
+  // to rename the old binary aside exactly like the in-app updater does.
+  it("install.ps1 moves a running binary aside instead of overwriting it", () => {
+    const installPs1 = readFileSync(new URL("../../scripts/install.ps1", import.meta.url), "utf8");
+
+    expect(installPs1).toContain('$BackupPath = "$FinalPath.$PID.bak"');
+    expect(installPs1).toMatch(/Move-Item -LiteralPath \$FinalPath -Destination \$BackupPath/);
+  });
+
+  // The expanded value written back as a literal destroys %USERPROFILE%-style
+  // entries in the user's PATH.
+  it("install.ps1 edits PATH without flattening REG_EXPAND_SZ", () => {
+    const installPs1 = readFileSync(new URL("../../scripts/install.ps1", import.meta.url), "utf8");
+
+    expect(installPs1).toContain("DoNotExpandEnvironmentNames");
+    expect(installPs1).toContain("GetValueKind");
+    expect(installPs1).not.toContain('[Environment]::SetEnvironmentVariable("PATH"');
+  });
+
+  // `file` is absent from slim containers; an absent tool is not a bad download.
+  it("install.sh treats a missing `file` command as skippable, not fatal", () => {
+    const installSh = readFileSync(new URL("../../scripts/install.sh", import.meta.url), "utf8");
+
+    expect(installSh).toContain("if command -v file >/dev/null 2>&1; then");
+    expect(installSh).not.toContain('file "$archive_path" 2>/dev/null || echo "unknown"');
   });
 });
 

--- a/source/utils/auto-update.ts
+++ b/source/utils/auto-update.ts
@@ -1,6 +1,6 @@
 import { join, sep } from "node:path";
 import { homedir, platform, arch } from "node:os";
-import { readFile, writeFile, rename, chmod, copyFile, unlink, mkdir, readdir, symlink, rm } from "node:fs/promises";
+import { readFile, writeFile, rename, chmod, copyFile, unlink, mkdir, readdir, stat, symlink, rm } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { createWriteStream, createReadStream } from "node:fs";
 import { createHash } from "node:crypto";
@@ -14,6 +14,10 @@ const AGAV_DIR = join(homedir(), ".agav");
 const UPDATE_STATE_FILE = join(AGAV_DIR, "update-state.json");
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const REPO = "prapaa-ai/agav";
+/** Prefix for in-flight downloads sitting in ~/.agav, swept on a later launch. */
+const DOWNLOAD_PREFIX = "agav-update-";
+/** A download older than this cannot belong to a live process worth waiting on. */
+const STALE_DOWNLOAD_MS = 24 * 60 * 60 * 1000;
 
 interface UpdateState {
   lastCheck: number;
@@ -27,13 +31,30 @@ function currentVersion(): string {
   return VERSION;
 }
 
-function isNewer(remote: string, local: string): boolean {
-  const r = remote.replace(/^v/, "").split(".").map(Number);
-  const l = local.split(".").map(Number);
+/**
+ * Pull `major.minor.patch` out of a tag, ignoring any `v` prefix and any
+ * pre-release or build suffix. Returns null for anything that isn't a version.
+ */
+function parseVersion(value: string): [number, number, number] | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(value.trim());
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isNewer(remote: string, local: string): boolean {
+  // Parse rather than `split(".").map(Number)`. A tag like v0.2.0-rc1 turned
+  // the last part into NaN, and NaN loses every comparison, so the loop fell
+  // through to `return false` — one pre-release marked "latest" would have
+  // silently frozen every client on its current version.
+  const r = parseVersion(remote);
+  const l = parseVersion(local);
+  if (!r || !l) return false;
   for (let i = 0; i < 3; i++) {
-    if ((r[i] ?? 0) > (l[i] ?? 0)) return true;
-    if ((r[i] ?? 0) < (l[i] ?? 0)) return false;
+    if (r[i]! > l[i]!) return true;
+    if (r[i]! < l[i]!) return false;
   }
+  // Equal core versions: a pre-release of the version we already run is not an
+  // upgrade, so don't sidegrade v0.1.7 → v0.1.7-rc1.
   return false;
 }
 
@@ -66,7 +87,10 @@ function getBinaryName(): string {
 async function downloadBinary(version: string, label?: string): Promise<string | null> {
   const binaryName = getBinaryName();
   const url = `https://github.com/${REPO}/releases/download/${version}/${binaryName}`;
-  const tmpPath = join(AGAV_DIR, `agav-update-${version}`);
+  // Keyed by pid as well as version: two agav processes updating to the same
+  // version at once would otherwise interleave their writes into one file, and
+  // both would fail the checksum.
+  const tmpPath = join(AGAV_DIR, `${DOWNLOAD_PREFIX}${version}.${process.pid}`);
   const activity = label ?? `Downloading ${version}`;
 
   // A fixed deadline on the whole transfer would kill a healthy download on a
@@ -249,6 +273,10 @@ export async function installUpdate(
     await safeMove(downloadedPath, dest);
     await chmod(dest, 0o755);
     await replaceSymlink(layout.currentLink, releaseDir);
+    // Only after the symlink points at the new release — a prune that ran first
+    // would delete the release we are still running from while `current` still
+    // named it, leaving a window where the install is unusable.
+    await pruneOldReleases(layout.releasesDir, releaseDir);
     return;
   }
 
@@ -264,6 +292,60 @@ export async function installUpdate(
   // failing to delete the old one is untidy, not a failed update — reporting it
   // as one sent Windows users chasing an update that had actually succeeded.
   await rm(backupPath, { force: true }).catch(() => {});
+}
+
+/**
+ * Delete every release directory except the one just installed.
+ *
+ * install.sh prunes like this at the end of every run; the updater did not, so
+ * a managed install grew by one ~100 MB release directory on every single
+ * auto-update and never gave the space back.
+ *
+ * Removing the directory we are currently executing from is safe on POSIX —
+ * this branch never runs on Windows — because the kernel keeps the inode alive
+ * for the lifetime of the running process.
+ */
+export async function pruneOldReleases(releasesDir: string, keepDir: string): Promise<void> {
+  try {
+    const entries = await readdir(releasesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const dir = join(releasesDir, entry.name);
+      if (dir === keepDir) continue;
+      // Best-effort per directory: one undeletable leftover must not stop the
+      // rest from being reclaimed, and none of it can fail the update.
+      await rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  } catch {
+    // Housekeeping. The update itself already succeeded.
+  }
+}
+
+/**
+ * Delete abandoned downloads from ~/.agav. A process killed mid-transfer leaves
+ * a partial ~100 MB file behind, and nothing else ever collects it.
+ *
+ * Age-gated rather than pid-gated: a live download belonging to a concurrently
+ * running agav must not be pulled out from under it, and no legitimate transfer
+ * is still in flight a day later.
+ */
+export async function cleanupStaleDownloads(now = Date.now()): Promise<void> {
+  try {
+    const entries = await readdir(AGAV_DIR);
+    for (const entry of entries) {
+      if (!entry.startsWith(DOWNLOAD_PREFIX)) continue;
+      const path = join(AGAV_DIR, entry);
+      try {
+        const info = await stat(path);
+        if (!info.isFile() || now - info.mtimeMs < STALE_DOWNLOAD_MS) continue;
+        await rm(path, { force: true });
+      } catch {
+        // Vanished or locked — either way, not this launch's problem.
+      }
+    }
+  } catch {
+    // Cleanup is never worth failing a launch over.
+  }
 }
 
 /**
@@ -409,6 +491,7 @@ export async function forceUpdate(targetVersion?: string): Promise<boolean> {
   }
 
   await cleanupStaleBackups(binaryPath);
+  await cleanupStaleDownloads();
 
   process.stderr.write(`  Downloading ${latestTag}...`);
   const downloaded = await downloadBinary(latestTag);
@@ -442,6 +525,9 @@ export async function forceUpdate(targetVersion?: string): Promise<boolean> {
     // Name the reason. "replace error" alone gave a Windows user reporting a
     // locked-file failure nothing to act on.
     process.stderr.write(` failed (${error instanceof Error ? error.message : String(error)}).\n`);
+    // Nothing moved the download into place, so it would otherwise sit in
+    // ~/.agav forever — a ~100 MB leak on every failed update.
+    await rm(downloaded, { force: true }).catch(() => {});
     return false;
   }
 }
@@ -458,6 +544,7 @@ export async function checkAndUpdate(): Promise<void> {
   // still running. This launch is the first moment that lock is gone.
   const currentBinary = getCurrentBinaryPath();
   if (currentBinary) await cleanupStaleBackups(currentBinary);
+  await cleanupStaleDownloads();
 
   // Check rate limit
   const state = await loadState();
@@ -546,5 +633,6 @@ export async function checkAndUpdate(): Promise<void> {
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     process.stderr.write(` failed (${reason}). Continuing with current version.\n`);
+    await rm(downloaded, { force: true }).catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary

- Fixes the Windows install failures reported from the field: the `308` redirect on `irm https://agav.dev/install.ps1 | iex`, and `agav update` failing with a replace error.
- Makes uninstall actually complete on both platforms — it left a dead `PATH` entry, an orphaned release tree, and no way to remove `~/.agav` at all.
- Adds test suites for both installers and wires them into PR checks. These two files ship outside the release pipeline, so nothing covered them before.

## Changes

- `install.ps1`: whole-segment PATH matching (`-like "*$Dir*"` matched `C:\agav-old`), registry read/write via `DoNotExpandEnvironmentNames` so a `REG_EXPAND_SZ` PATH is not flattened, rename-aside upgrade, fail-closed checksum verification, stale-artifact sweep, two-pass flag parsing.
- `install.sh`: `remove_path_block` takes the installer's block back out of every candidate profile, dangling symlinks count as installed, temp files no longer land on predictable `/tmp` names.
- Both: new `--purge` flag (implies `--uninstall`) to delete settings and history; plain `--uninstall` keeps them and says so.
- `auto-update.ts`: the replace error path, with tests.
- `install.cmd` / `release.yml`: redirect handling and release-asset fixes.
- `README.md`: rewritten uninstall section, including what each flag removes.
- `scripts/tests/`: five suites plus a runner (`npm run test:installer`).
- `pr-checks.yml`: `installer-sh` on ubuntu (shellcheck + dash/bash/busybox-ash) and `installer-ps1` on windows-latest (Windows PowerShell 5.1 and pwsh 7), both gated on `scripts/` changing.

## Related Issues

Relates to the Windows install and update reports.

## Type

- [x] Bug fix

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

`npm test` 254/254. Installer suites: 48 + 13 under macOS `sh`, and under `dash`, `bash` and BusyBox `ash` on Debian; 67 + 38 + 5 under pwsh. shellcheck clean.

The suites never download a release binary or contact GitHub — the shell ones only reach `--uninstall`/`--purge`/`--help`, and the PowerShell one stubs the two download functions. Verified by running them under `docker run --network none`.

## Screenshots / Terminal Output

```
===== install.sh suites under dash =====
48 passed, 0 failed
13 passed, 0 failed

===== install-ps1.test.ps1 =====
67 passed, 0 failed

===== install-ps1-path.test.ps1 =====
38 passed, 0 failed

===== install-ps1-lint.test.ps1 =====
5 passed, 0 failed

All suites that ran passed.
```

---

Note on merging: `package.json` is already bumped to `0.1.8`, so merging this to `main` will trigger `release.yml`. The installer scripts themselves still need copying to `cli-ui/public/` and deploying separately — `agav.dev` does not serve them from this repo.
