### PR TITLE
docs: restructure README around usage and document the CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,116 @@
 <div align="center">
 
-<pre align="center" style="color: #0891B2;">
-   █████╗  ██████╗  █████╗ ██╗   ██╗
-  ██╔══██╗██╔════╝ ██╔══██╗██║   ██║
-  ███████║██║  ███╗███████║██║   ██║
-  ██╔══██║██║   ██║██╔══██║╚██╗ ██╔╝
-  ██║  ██║╚██████╔╝██║  ██║ ╚████╔╝
-  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝  ╚═══╝
-</pre>
+# Agav
 
 **A terminal-native AI coding assistant for real repositories**
 
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-0.1.2-111?style=for-the-badge">
-  <img alt="Node.js" src="https://img.shields.io/badge/node-22%2B-111?style=for-the-badge&logo=node.js&logoColor=83CD29">
-  <img alt="TypeScript" src="https://img.shields.io/badge/typescript-5.x-111?style=for-the-badge&logo=typescript&logoColor=3178C6">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.1.8-111?style=for-the-badge">
   <img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-111?style=for-the-badge">
 </p>
 
 </div>
 
 <div align="center">
-  <img src="./assets/image.png" alt="Agav preview" width="100%" style="border-radius: 16px;" />
+  <img src="https://agav.dev/preview.gif" alt="Agav preview" width="100%" style="border-radius: 16px;" />
 </div>
+
+## What it does
+
+Agav reads, searches and edits the repository you run it in, and runs the commands you'd otherwise run yourself.
+
+- **Five providers** — Anthropic, OpenAI, Gemini, Vertex AI and Ollama, switchable mid-session with `/model`.
+- **Sandboxed commands** — shell tools run under Seatbelt on macOS and Bubblewrap on Linux where either is available.
+- **Non-interactive mode** — `agav run` and `agav --print` make the same agent scriptable from CI, with per-tool permissions and optional JSON Schema output.
+- **Sessions that survive** — resume, branch, name, search and export past conversations; `/compact` reclaims context without starting over.
+- **Extensible** — MCP servers, plugins, skills and subagents.
+- **Repository-aware editing** — LSP-backed queries, notebook support, test running, and `/undo` for the last file change.
+
+## Quickstart
+
+Run it inside a repository:
+
+```bash
+agav
+```
+
+Pick a provider and model, or take the defaults:
+
+```bash
+agav --provider openai --model gpt-4o
+agav --provider vertex-ai --model vertex/gemini-3.5-flash
+agav -r                                  # resume a session (lists them if no id)
+```
+
+Non-interactive, for scripts and CI:
+
+```bash
+agav run "review the code in src/"
+agav run --permission '{"bash":"deny"}' "check for security issues"
+agav -P "what does this project do?"
+agav -P --stream "explain this repository"
+cat error.log | agav -P "explain this error"
+```
+
+Keep it current:
+
+```bash
+agav update
+```
+
+### Options
+
+| Flag | Meaning |
+| --- | --- |
+| `--provider`, `-p` | `anthropic`, `openai`, `gemini`, `vertex-ai` or `ollama` (default: `anthropic`) |
+| `--model`, `-m` | Model name |
+| `--effort` | Reasoning effort: `low`, `medium`, `high` or `max` (default: `high`) |
+| `--print`, `-P` | Run the prompt, print the result, exit |
+| `--stream` | Stream text to stdout in real time, with `--print` |
+| `--output-schema` | Require pipe-mode output to match an inline JSON Schema, or `@file` |
+| `--permission` | JSON tool permissions for run mode |
+| `--resume`, `-r [id]` | Resume a session; prefix match if an id is given |
+| `--auto-accept`, `-y` | Skip tool confirmations |
+| `--deny-writes` | Block all write operations |
+| `--openai-api` | OpenAI API mode: `responses` or `chat` (default: `responses`) |
+| `--ollama-host` / `--ollama-port` / `--ollama-endpoint` / `--ollama-api-key` | Ollama connection |
+| `--help`, `-h` / `--version`, `-v` | Help, version |
+
+## Slash commands
+
+<details>
+<summary>26 commands, available in any session</summary>
+
+| Command | What it does |
+| --- | --- |
+| `/help` | Show available commands |
+| `/model` | Show or change the current model |
+| `/fast` | Switch to a fast, lightweight model |
+| `/deep` | Switch to a powerful model for complex tasks |
+| `/effort` | Show or change reasoning effort |
+| `/context` | Show context window usage |
+| `/compact` | Compact conversation history to free up context |
+| `/plan` | Show or manage the active plan |
+| `/steer` | Add context or direction to guide the agent |
+| `/undo` | Revert the last file change |
+| `/memory` | Manage persistent memories |
+| `/remember` | Save a memory |
+| `/forget` | Delete a memory by name |
+| `/history` | List saved sessions or load one by index |
+| `/search` | Search past sessions by keyword |
+| `/branch` | Fork a new session or list branches |
+| `/name` | Name the current session |
+| `/export` | Export conversation as a markdown file |
+| `/new` | Start a new chat without deleting saved sessions |
+| `/clear` | Start a new chat (alias: `/new`) |
+| `/watch` | Watch files and run a command on change |
+| `/loop` | Repeat a prompt on an interval |
+| `/schedule` | Manage persistent scheduled tasks |
+| `/changelog` | Show release notes for the current version |
+| `/debug` | Show internal state for debugging |
+| `/exit` | Exit Agav |
+
+</details>
 
 ## Installation
 
@@ -68,6 +156,16 @@ For Windows Command Prompt (`cmd.exe`):
 
 
 Or download a specific platform binary from [Releases](../../releases).
+
+### Staying up to date
+
+Agav checks for a newer release on startup and updates itself. Run it by hand at any time:
+
+```bash
+agav update
+```
+
+The automatic check is skipped when `CI` is set, when `AGAV_NO_UPDATE=1`, and when stdout is not a terminal — so scripted runs never block on it. Each release directory replaces the last, so `~/.agav/packages/standalone/releases/` holds one version rather than growing on every update.
 
 ### Uninstall
 
@@ -129,19 +227,15 @@ On Windows, remove the Agav entry from your user `PATH` under **Settings → Edi
 
 ### Run from source
 
-#### macOS
+Requires Node.js 22 or newer.
+
+**macOS and Linux:**
 
 ```bash
 git clone https://github.com/prapaa-ai/agav && cd agav && pnpm install --frozen-lockfile && pnpm build && pnpm start
 ```
 
-#### Linux
-
-```bash
-git clone https://github.com/prapaa-ai/agav && cd agav && pnpm install --frozen-lockfile && pnpm build && pnpm start
-```
-
-#### Windows
+**Windows:**
 
 ```powershell
 git clone https://github.com/prapaa-ai/agav; cd agav; pnpm install --frozen-lockfile; pnpm build; pnpm start
@@ -150,6 +244,24 @@ git clone https://github.com/prapaa-ai/agav; cd agav; pnpm install --frozen-lock
 ## Provider setup
 
 Anthropic, OpenAI, and Gemini need nothing more than their API key in the environment — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` — and Ollama just needs a local server running. Vertex AI takes a little more.
+
+### Ollama
+
+A local server on `localhost:11434` is picked up with no configuration. Point Agav elsewhere with flags or environment variables:
+
+```bash
+agav --provider ollama --model llama3.2
+agav --provider ollama --ollama-endpoint http://192.168.1.5:11434
+```
+
+| Setting | Environment variable |
+| --- | --- |
+| `--ollama-host` | `OLLAMA_HOST` |
+| `--ollama-port` | `OLLAMA_PORT` |
+| `--ollama-endpoint` | `OLLAMA_ENDPOINT` |
+| `--ollama-api-key` | `OLLAMA_API_KEY` (sent as `Authorization: Bearer`) |
+
+Agav sizes the context window per model. `AGAV_OLLAMA_NUM_CTX` overrides that cap when you know your hardware can take more.
 
 ### Vertex AI
 
@@ -180,6 +292,34 @@ The same settings can go in `.agav/config.json` (project) or `~/.agav/config.jso
 
 The service account's `project_id`, `client_email`, `private_key`, and optional `token_uri` are read from that file. Agav exchanges the signed credentials for a short-lived OAuth token and refreshes it automatically. Both model families are addressed with the same `vertex/` prefix — `vertex/gemini-3.5-flash`, `vertex/claude-sonnet-4-5@20250929` — and Claude needs the versioned ID that Vertex AI exposes, including its `@YYYYMMDD` suffix. Vertex AI's implicit Gemini caching and Claude's ephemeral prompt caching are used automatically when supported.
 
+## Configuration
+
+Settings live in `~/.agav/config.json` globally and `.agav/config.json` per project, with the project file winning. Keybindings go in `keybindings.json` beside either. MCP servers are declared under an `mcpServers` key in the same config.
+
+Drop an `AGAV.md` (or `.agavrc`) in a repository to add project-specific instructions to every session there.
+
+### Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | Provider credentials |
+| `VERTEX_AI_CREDENTIALS_PATH` / `VERTEX_AI_LOCATION` | Vertex AI service account and region |
+| `OLLAMA_HOST` / `OLLAMA_PORT` / `OLLAMA_ENDPOINT` / `OLLAMA_API_KEY` | Ollama connection |
+| `AGAV_OLLAMA_NUM_CTX` | Override the per-model Ollama context cap |
+| `AGAV_PERMISSION` | Default tool permissions for `agav run`, same JSON as `--permission` |
+| `AGAV_NO_UPDATE=1` | Disable the startup update check |
+| `AGAV_NO_SANDBOX=1` | Run shell commands unsandboxed |
+| `AGAV_KITTY_KEYBOARD` | Force the Kitty keyboard protocol on (`1`) or off (`0`) |
+| `AGAV_DEBUG_GEMINI` | Verbose Gemini request logging |
+| `LIBREOFFICE_PATH` | Path to LibreOffice, for document conversion |
+| `NO_COLOR` | Disable coloured output |
+
+`AGAV_SKIP_CHECKSUM=1` is read by the install scripts, not the CLI, and skips SHA-256 verification of the downloaded binary.
+
+### Sandboxing
+
+Shell commands run inside a sandbox when one is available: `sandbox-exec` (Seatbelt) on macOS, `bwrap` (Bubblewrap) on Linux. Agav detects the backend at runtime and falls back to running unsandboxed when neither is present. Set `AGAV_NO_SANDBOX=1` to opt out deliberately.
+
 ## Multi-line input
 
 Press **Shift+Enter** to insert a newline instead of sending the message.
@@ -192,7 +332,16 @@ This requires the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyb
 
 The prompt footer only advertises the bindings your terminal can actually send, so whatever it shows will work.
 
-### macOS Terminal.app
+To bind something else, set `newline` in `~/.agav/keybindings.json` (or `.agav/keybindings.json` in a project):
+
+```json
+{ "newline": ["shift+enter", "meta+enter", "ctrl+o"] }
+```
+
+If a terminal answers the protocol query but handles it badly, set `AGAV_KITTY_KEYBOARD=0` to force the legacy encoding, or `AGAV_KITTY_KEYBOARD=1` to force the protocol on.
+
+<details>
+<summary>macOS Terminal.app needs a little setup</summary>
 
 Terminal.app implements neither the Kitty protocol nor CSI-u, and ships with Option-as-Meta **off**, so out of the box `Ctrl+J` is the only newline key. You can verify the limitation yourself — Enter and Shift+Enter both emit a single `0d` byte:
 
@@ -210,17 +359,30 @@ Either of these recovers a dedicated key:
 
 For Shift+Enter with no setup at all, use a terminal that implements the protocol: Kitty, Ghostty, WezTerm, foot, Alacritty, or a recent iTerm2.
 
-To bind something else, set `newline` in `~/.agav/keybindings.json` (or `.agav/keybindings.json` in a project):
+</details>
 
-```json
-{ "newline": ["shift+enter", "meta+enter", "ctrl+o"] }
-```
+## Extending
 
-If a terminal answers the protocol query but handles it badly, set `AGAV_KITTY_KEYBOARD=0` to force the legacy encoding, or `AGAV_KITTY_KEYBOARD=1` to force the protocol on.
+- **MCP servers** — declare them under `mcpServers` in `config.json`; their tools and prompts join the session.
+- **Skills** — reusable instruction bundles, loadable from a marketplace or written yourself.
+- **Plugins** — loaded from `~/.agav/plugins/`.
+- **Subagents** — the agent can delegate a scoped task to a fresh context and keep the noise out of yours.
 
 ## Documentation
 
 Detailed CLI documentation can be found [here](https://docs.agav.dev).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md), and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for the ground rules.
+
+## Security
+
+To report a vulnerability, follow [SECURITY.md](SECURITY.md). Please don't open a public issue for one.
+
+## License
+
+[Apache 2.0](LICENSE).
 
 ## Contact
 


### PR DESCRIPTION
## Summary

- The README installed Agav and never said to run it — no usage, no flags, no commands. Adds a Quickstart and a What it does section above Installation.
- Documents the surface that already exists but was invisible: 26 slash commands, non-interactive mode, sandboxing, auto-update, Ollama configuration, environment variables.
- Version badge read `0.1.2` while `0.1.8` shipped.

## Changes

- Badge bumped to `0.1.8`. The rewrite in `release.yml` matches any version string, so it still targets correctly.
- **What it does** — providers, sandboxed commands, non-interactive mode, sessions, extensibility, repository-aware editing.
- **Quickstart** — interactive, provider/model selection, `--resume`, `agav run`, `--print`, pipe mode, plus an options table taken from `agav --help`.
- **Slash commands** — all 26 in a collapsible table, descriptions taken from `source/commands/*.ts`.
- **Staying up to date** — `agav update`, and the three conditions that skip the startup check (`CI`, `AGAV_NO_UPDATE=1`, non-TTY stdout) per `source/utils/auto-update.ts:539`.
- **Ollama** — promoted from one clause to its own section: flag/env table, endpoint example, `AGAV_OLLAMA_NUM_CTX`.
- **Configuration** — config precedence, `keybindings.json`, `mcpServers`, `AGAV.md`/`.agavrc`, an environment variable table, and a Sandboxing subsection covering Seatbelt, Bubblewrap and the fallback.
- **Extending** — MCP servers, skills, plugins, subagents.
- Contributing, Security and License sections linking `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` and `LICENSE`, none of which were referenced before.
- macOS and Linux "Run from source" merged — the commands were byte-identical — with the Node 22 requirement now stated in prose rather than implied by a badge.
- Node.js and TypeScript badges removed; ASCII logo replaced with a plain heading; preview switched to `https://agav.dev/preview.gif`.
- Terminal.app keyboard troubleshooting moved into `<details>` so the product leads.

Every documented flag, command, environment variable and default was read out of the source or `agav --help` rather than written from memory. Three items were dropped during that check: `AGAV_DIR` and `AGAV_HOME` are constants in `config.ts`, not environment variables, and `OLLAMA_EFFORT_PROMPTS` is a constant in `providers/effort.ts`. `AGAV_SKIP_CHECKSUM` is documented as installer-only, since the CLI never reads it.

## Related Issues

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] Chore

## Testing

- [ ] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

Documentation only — no code paths touched. Verified by rendering the Markdown and confirming both `<details>` blocks and all tables parse.

## Screenshots / Terminal Output

Structure after the change:

```
# Agav
## What it does
## Quickstart
### Options
## Slash commands
## Installation
### Quick install (recommended)
### Staying up to date
### Uninstall
### Run from source
## Provider setup
### Ollama
### Vertex AI
## Configuration
### Environment variables
### Sandboxing
## Multi-line input
## Extending
## Documentation
## Contributing
## Security
## License
## Contact
```