### PR TITLE
fix(release): derive the README version badge instead of pushing it

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -384,6 +384,29 @@ jobs:
           if [ "$FAIL" -eq 1 ]; then exit 1; fi
           echo "No sensitive files tracked."
 
+  readme-badges:
+    name: README Badge Freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+      - name: Check the version badge is derived, not hardcoded
+        run: |
+          # A literal shields.io/badge/version-x.y.z badge has to be rewritten
+          # on every release. The release workflow used to do that by pushing
+          # to main, the ruleset rejected it, and the badge sat at 0.1.2 for
+          # six releases. Keep the badge derived from package.json instead.
+          if grep -nE 'img\.shields\.io/badge/version-' README.md; then
+            echo "::error file=README.md::Hardcoded version badge. Use https://img.shields.io/github/package-json/v/${{ github.repository }} so the badge tracks package.json."
+            exit 1
+          fi
+          if ! grep -q 'img\.shields\.io/github/package-json/v/' README.md; then
+            echo "::error file=README.md::The derived version badge is missing from README.md."
+            exit 1
+          fi
+          echo "Version badge is derived from package.json."
+
   # --- Terminal gate ---
   required:
     name: All Checks
@@ -402,6 +425,7 @@ jobs:
       - lockfile-integrity
       - semgrep
       - sensitive-files
+      - readme-badges
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate results
@@ -421,7 +445,8 @@ jobs:
             "${{ needs.dependency-audit.result }}" \
             "${{ needs.lockfile-integrity.result }}" \
             "${{ needs.semgrep.result }}" \
-            "${{ needs.sensitive-files.result }}"; do
+            "${{ needs.sensitive-files.result }}" \
+            "${{ needs.readme-badges.result }}"; do
             case "$result" in
               success|skipped) ;;
               *) echo "::error::Check failed: $result"; FAIL=1 ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,56 +119,12 @@ jobs:
         with:
           token: ${{ secrets.TOKEN }}
           fetch-depth: 0
-      - name: Update README version badge
-        id: readme_update
-        env:
-          NEW_VERSION: ${{ needs.check-version.outputs.version }}
-        run: |
-          # 1. Update version badge in README.md
-          node -e "
-            const fs = require('fs');
-            const file = 'README.md';
-            let content = fs.readFileSync(file, 'utf8');
-            const target = 'version-' + process.env.NEW_VERSION + '-111';
-            content = content.replace(/version-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?-111/, target);
-            fs.writeFileSync(file, content, 'utf8');
-          "
-          
-          # 2. Check if there are changes
-          if git diff --quiet README.md; then
-            echo "README.md version badge is already up to date."
-            echo "commit_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # 3. Determine target branch
-          if [ "${{ github.ref_type }}" = "branch" ]; then
-            BRANCH="${{ github.ref_name }}"
-          else
-            # If triggered by a tag push, find branch containing the commit
-            BRANCH=$(git branch -r --contains HEAD | grep -v 'HEAD' | head -n 1 | sed 's|origin/||' | tr -d '[:space:]')
-            if [ -z "$BRANCH" ]; then
-              BRANCH="${{ github.event.repository.default_branch }}"
-            fi
-          fi
-          
-          echo "Target branch to push README update: $BRANCH"
-          
-          # 4. Commit and push
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "chore: update README version badge to v${NEW_VERSION} [skip ci]"
-          
-          # Push to the branch, allowing failure if branch protection blocks it
-          if git push origin HEAD:"$BRANCH"; then
-            echo "Successfully updated README version badge on branch $BRANCH."
-            echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::Failed to push README update to branch $BRANCH. Reverting local commit."
-            git reset --hard HEAD~1
-            echo "commit_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          fi
+      # No README badge commit here. The version badge reads package.json from
+      # the default branch through shields.io, so it tracks the release without
+      # a commit. The previous step pushed a rewritten badge straight to main,
+      # which the branch ruleset rejects with GH013, and it swallowed that
+      # failure as a warning — so the badge silently stopped tracking after
+      # 0.1.2 while every release still reported success.
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -210,7 +166,7 @@ jobs:
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
-          target_commitish: ${{ steps.readme_update.outputs.commit_sha || github.sha }}
+          target_commitish: ${{ github.sha }}
           body: |
             ## Changes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **A terminal-native AI coding assistant for real repositories**
 
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-0.1.8-111?style=for-the-badge">
+  <img alt="Version" src="https://img.shields.io/github/package-json/v/prapaa-ai/agav?style=for-the-badge&amp;label=version&amp;color=111">
   <img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-111?style=for-the-badge">
 </p>
 


### PR DESCRIPTION
## Summary

- The README version badge was hardcoded and rewritten by `release.yml`, which pushed the change straight to `main`. The branch ruleset rejects that with `GH013`, and the step swallowed the failure as a `::warning::` before `git reset --hard HEAD~1` — so every release stayed green while the badge sat at `0.1.2` for six versions.
- Make the badge derive its value from `package.json` on the default branch via shields.io, so there is nothing to commit and no automation left to rot.
- Add a PR check so a hardcoded badge cannot be reintroduced.

## Changes

- `README.md` — version badge now points at `img.shields.io/github/package-json/v/prapaa-ai/agav`. Renders identically apart from a `v` prefix; `label` and `color=111` keep the existing style.
- `.github/workflows/release.yml` — removed the "Update README version badge" step (the `node` rewrite, the branch resolution, the commit, and the push-or-swallow block) and took `target_commitish` from `github.sha` directly, since the step no longer produces a commit.
- `.github/workflows/pr-checks.yml` — new `README Badge Freshness` job that fails on a reintroduced `shields.io/badge/version-` literal or a missing derived badge. Wired into the `All Checks` terminal gate.

## Related Issues

Closes #39

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

- [ ] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

No source code changed, so the provider and pipe-mode boxes do not apply. Verified instead:

- Both badge endpoints resolve and return `V0.1.8`, matching `package.json`, with `cache-control: max-age=300` — the badge picks up a release within minutes of the merge.
- Both workflow files parse as YAML; job graph and the `All Checks` `needs` list confirmed consistent.
- Ran the new guard's grep logic against the updated `README.md`: no hardcoded badge, derived badge present.
- Confirmed no remaining references to the deleted `readme_update` step id.

## Screenshots / Terminal Output

```
$ curl -sS "https://img.shields.io/github/package-json/v/prapaa-ai/agav?style=for-the-badge&label=version&color=111"
<svg ... aria-label="VERSION: V0.1.8">...</svg>

$ curl -sSI "...&color=111" | grep -i cache-control
cache-control: max-age=300, s-maxage=300
```