### PR TITLE
perf: cut binary size and publish gzipped release assets

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -128,11 +128,11 @@ jobs:
     if: needs.changed.outputs.source == 'true' || needs.changed.outputs.deps == 'true' || needs.changed.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.TOKEN }}
       - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
       - uses: pnpm/action-setup@v4
@@ -169,7 +169,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$RAW" -gt "$BUDGET" ]; then
-            echo "::warning::agav-linux-x64 is $RAW bytes, over the $BUDGET byte budget."
+            echo "::error::agav-linux-x64 is $RAW bytes, over the $BUDGET byte budget."
+            exit 1
           else
             echo "agav-linux-x64: $RAW bytes (budget $BUDGET), compressed $GZ bytes."
           fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -122,6 +122,62 @@ jobs:
       - run: pnpm build
       - run: npx vitest run --passWithNoTests
 
+  binary-size:
+    name: Binary Size
+    needs: changed
+    if: needs.changed.outputs.source == 'true' || needs.changed.outputs.deps == 'true' || needs.changed.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      # Only pnpm, deliberately: the release workflow no longer runs a separate
+      # `bun install react-devtools-core`, so this is the check that the ink
+      # devtools import still resolves through pnpm's peer layout. A compiled
+      # binary that cannot find it dies at startup, not at build time, which is
+      # exactly the class of break that used to reach a release.
+      - run: pnpm install --frozen-lockfile
+      - name: Compile and measure
+        run: |
+          # Same target and flags the release uses, so the number here is the
+          # number users download. linux-x64 stands in for the matrix: the
+          # difference between targets is the embedded Bun runtime, which no
+          # pull request can change.
+          mkdir -p dist
+          bun build source/cli.tsx --compile --target=bun-linux-x64 --outfile dist/agav-linux-x64
+          gzip -9 -k -n dist/agav-linux-x64
+
+          RAW=$(wc -c < dist/agav-linux-x64)
+          GZ=$(wc -c < dist/agav-linux-x64.gz)
+          # ~99 MiB of this is the embedded Bun runtime and is not ours to
+          # shrink. The budget leaves room for a few MB of growth and trips on
+          # the kind of regression that added 30 MB of native image codecs.
+          BUDGET=$((110 * 1024 * 1024))
+
+          {
+            echo "| Asset | Bytes | MiB |"
+            echo "| --- | ---: | ---: |"
+            echo "| agav-linux-x64 | $RAW | $((RAW / 1048576)) |"
+            echo "| agav-linux-x64.gz | $GZ | $((GZ / 1048576)) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$RAW" -gt "$BUDGET" ]; then
+            echo "::warning::agav-linux-x64 is $RAW bytes, over the $BUDGET byte budget."
+          else
+            echo "agav-linux-x64: $RAW bytes (budget $BUDGET), compressed $GZ bytes."
+          fi
+      - name: Smoke-test the compiled binary
+        # A binary that builds but cannot start is the failure this job exists
+        # to catch, and --version exercises the whole module graph's top level.
+        run: ./dist/agav-linux-x64 --version
+
   # --- Installer scripts ---
   # These ship outside the release pipeline (hand-copied to agav.dev), so
   # nothing else in this workflow would ever look at them.
@@ -415,6 +471,7 @@ jobs:
       - typecheck
       - build
       - test
+      - binary-size
       - installer-sh
       - installer-ps1
       - pr-title
@@ -436,6 +493,7 @@ jobs:
             "${{ needs.typecheck.result }}" \
             "${{ needs.build.result }}" \
             "${{ needs.test.result }}" \
+            "${{ needs.binary-size.result }}" \
             "${{ needs.installer-sh.result }}" \
             "${{ needs.installer-ps1.result }}" \
             "${{ needs.pr-title.result }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,16 +67,21 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
+      # react-devtools-core is a devDependency and a peer of ink, so
+      # `pnpm install` already puts it where Bun's resolver finds it. The
+      # separate `bun install` this used to run wrote an extra entry into
+      # package.json mid-release for no gain.
       - run: pnpm install --frozen-lockfile
-      - run: bun install react-devtools-core
       - name: Build binary
         run: |
           mkdir -p dist
-          if [ "${{ matrix.target }}" = "$(uname -s | tr A-Z a-z)-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')" ]; then
-            bun build source/cli.tsx --compile --outfile dist/agav-${{ matrix.target }}${{ matrix.ext }}
-          else
-            bun build source/cli.tsx --compile --target=bun-${{ matrix.target }} --outfile dist/agav-${{ matrix.target }}${{ matrix.ext }}
-          fi
+          # Always cross-compile, including for the runner's own platform. A
+          # host-target build embeds whichever native .node addons happen to
+          # resolve locally, while the cross toolchain silently drops the ones
+          # that do not resolve for the target — which is how the macOS
+          # binaries ended up ~27MB heavier than the others and how the two
+          # halves of the matrix stopped behaving alike.
+          bun build source/cli.tsx --compile --target=bun-${{ matrix.target }} --outfile dist/agav-${{ matrix.target }}${{ matrix.ext }}
       - name: Sign binary (macOS)
         if: startsWith(matrix.target, 'darwin')
         run: |
@@ -94,11 +99,25 @@ jobs:
             echo "cosign not available, skipping signing."
           fi
 
+      - name: Compress binary
+        run: |
+          # Published next to the raw binary, never in place of it: installers
+          # from earlier releases fetch the bare asset name and have to keep
+          # working. gzip rather than tar or zip because every client already
+          # decompresses it without an archive parser or any path handling —
+          # `gzip -d`, Node's zlib, and PowerShell's GZipStream. -n drops the
+          # name and mtime so the same input produces the same bytes.
+          cd dist
+          gzip -9 -k -n "agav-${{ matrix.target }}${{ matrix.ext }}"
+          ls -lh "agav-${{ matrix.target }}${{ matrix.ext }}" "agav-${{ matrix.target }}${{ matrix.ext }}.gz"
+
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum agav-${{ matrix.target }}${{ matrix.ext }} > agav-${{ matrix.target }}${{ matrix.ext }}.sha256
-          cat agav-${{ matrix.target }}${{ matrix.ext }}.sha256
+          for asset in "agav-${{ matrix.target }}${{ matrix.ext }}" "agav-${{ matrix.target }}${{ matrix.ext }}.gz"; do
+            sha256sum "$asset" > "$asset.sha256"
+            cat "$asset.sha256"
+          done
 
       - uses: actions/upload-artifact@v4
         with:
@@ -106,6 +125,8 @@ jobs:
           path: |
             dist/agav-${{ matrix.target }}${{ matrix.ext }}
             dist/agav-${{ matrix.target }}${{ matrix.ext }}.sha256
+            dist/agav-${{ matrix.target }}${{ matrix.ext }}.gz
+            dist/agav-${{ matrix.target }}${{ matrix.ext }}.gz.sha256
             dist/agav-${{ matrix.target }}.sig
 
   release:
@@ -140,17 +161,19 @@ jobs:
               # Copy binary
               cp "$dir/$asset" "release/$asset"
               chmod +x "release/$asset"
-              # Copy checksums and signatures
-              for ext in sha256 sig; do
+              # Copy the compressed binary, checksums, and signatures
+              for ext in sha256 sig gz gz.sha256; do
                 if [ -f "$dir/${asset}.${ext}" ]; then
                   cp "$dir/${asset}.${ext}" "release/${asset}.${ext}"
                 fi
               done
             done
           done
-          # Generate combined SHA256SUMS file
+          # Generate combined SHA256SUMS file. Both the raw and the compressed
+          # binary get a line; the detached .sha256 and .sig files do not.
           cd release
-          sha256sum agav-* 2>/dev/null | grep -v '\.sha256$\|\.sigstore' > SHA256SUMS || true
+          sha256sum agav-* 2>/dev/null | grep -v -e '\.sha256$' -e '\.sig$' -e '\.sigstore$' > SHA256SUMS || true
+          cat SHA256SUMS
           cd ..
           ls -lh release/
       - name: Generate release notes
@@ -194,6 +217,11 @@ jobs:
 
             <details>
             <summary>Manual install</summary>
+
+            Every binary is also published gzipped as `<asset>.gz`, about a
+            third of the size. The installers fetch that and fall back to the
+            raw asset; the digest below is the raw asset's either way, so
+            verify after decompressing.
 
             **macOS / Linux** — pick one of `agav-darwin-arm64`,
             `agav-darwin-x64`, `agav-linux-x64`, `agav-linux-arm64`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,8 +114,9 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
+          if command -v sha256sum >/dev/null 2>&1; then hash() { sha256sum "$1"; }; else hash() { shasum -a 256 "$1"; }; fi
           for asset in "agav-${{ matrix.target }}${{ matrix.ext }}" "agav-${{ matrix.target }}${{ matrix.ext }}.gz"; do
-            sha256sum "$asset" > "$asset.sha256"
+            hash "$asset" > "$asset.sha256"
             cat "$asset.sha256"
           done
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,18 @@ git clone https://github.com/prapaa-ai/agav && cd agav && pnpm install --frozen-
 git clone https://github.com/prapaa-ai/agav; cd agav; pnpm install --frozen-lockfile; pnpm build; pnpm start
 ```
 
+### Optional external tools
+
+Agav ships as a single binary with no bundled media libraries — those were 30 MB of download for features most sessions never touch. Attachments still work without any of these; the tools only widen what can be sent.
+
+| Tool | What it adds | Install |
+| --- | --- | --- |
+| Poppler (`pdftoppm`) | Page images for PDFs. Without it, a PDF is read as text only. | `brew install poppler` · `apt install poppler-utils` · `winget install oschwartz10612.Poppler` |
+| `sips` or ImageMagick | Downscales oversized images, and converts formats a model won't accept. Without either, PNG/JPEG/GIF/WebP under 3.5 MB are sent as-is and anything larger or in another format is refused. | `sips` ships with macOS · `brew install imagemagick` · `apt install imagemagick` · `winget install ImageMagick.ImageMagick` |
+| LibreOffice | Higher-fidelity `.docx` and `.pptx` conversion. Without it, Agav extracts the text, tabs, and speaker notes itself. | `brew install --cask libreoffice` · point `LIBREOFFICE_PATH` at a non-standard install |
+
+Agav says which tool is missing when it hits one of these limits, so there is nothing to configure up front.
+
 ## Provider setup
 
 Anthropic, OpenAI, and Gemini need nothing more than their API key in the environment — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` — and Ollama just needs a local server running. Vertex AI takes a little more.

--- a/package.json
+++ b/package.json
@@ -26,20 +26,18 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.106.0",
-    "@napi-rs/canvas": "^1.0.2",
     "ajv": "^8.20.0",
     "chalk": "^5.4.0",
+    "fflate": "^0.8.3",
     "ink": "^7.1.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "marked": "^15.0.0",
     "marked-terminal": "^7.3.0",
-    "officeparser": "^7.3.0",
     "ollama": "^0.6.3",
     "openai": "^6.46.0",
     "pdfjs-dist": "^6.1.200",
-    "react": "^19.2.0",
-    "sharp": "^0.35.3"
+    "react": "^19.2.0"
   },
   "devDependencies": {
     "@sindresorhus/tsconfig": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Terminal-native AI coding assistant for real repositories",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,15 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.106.0
         version: 0.106.0
-      '@napi-rs/canvas':
-        specifier: ^1.0.2
-        version: 1.0.2
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
       chalk:
         specifier: ^5.4.0
         version: 5.6.2
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       ink:
         specifier: ^7.1.0
         version: 7.1.0(@types/react@19.2.17)(react-devtools-core@7.0.1)(react@19.2.7)
@@ -35,9 +35,6 @@ importers:
       marked-terminal:
         specifier: ^7.3.0
         version: 7.3.0(marked@15.0.12)
-      officeparser:
-        specifier: ^7.3.0
-        version: 7.3.0
       ollama:
         specifier: ^0.6.3
         version: 0.6.3
@@ -50,9 +47,6 @@ importers:
       react:
         specifier: ^19.2.0
         version: 19.2.7
-      sharp:
-        specifier: ^0.35.3
-        version: 0.35.3(@types/node@22.20.1)
     devDependencies:
       '@sindresorhus/tsconfig':
         specifier: ^8.1.0
@@ -65,7 +59,7 @@ importers:
         version: 19.2.17
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.9(vitest@2.1.9(@types/node@22.20.1))
+        version: 2.1.9(supports-color@7.2.0)(vitest@2.1.9(@types/node@22.20.1)(supports-color@7.2.0))
       husky:
         specifier: ^9.0.0
         version: 9.1.7
@@ -80,7 +74,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.20.1)
+        version: 2.1.9(@types/node@22.20.1)(supports-color@7.2.0)
 
 packages:
 
@@ -125,15 +119,9 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@borewit/text-codec@0.2.2':
-    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
-
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -429,152 +417,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@img/colour@1.1.0':
-    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
-    engines: {node: '>=18'}
-
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
-    engines: {node: '>=20.9.0'}
-    os: [freebsd]
-
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
-    engines: {node: '>=20.9.0'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
-    engines: {node: '>=20.9.0'}
-
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
-    engines: {node: '>=20.9.0'}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
-    engines: {node: ^20.9.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [win32]
-
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -625,30 +467,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
     resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
     resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
@@ -704,66 +551,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -805,13 +665,6 @@ packages:
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
-
-  '@tokenizer/inflate@0.4.1':
-    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
-    engines: {node: '>=18'}
-
-  '@tokenizer/token@0.3.0':
-    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -860,10 +713,6 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
-
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
@@ -904,9 +753,6 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
-
-  bmp-js@0.1.0:
-    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
@@ -1002,10 +848,6 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1065,10 +907,6 @@ packages:
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
-  file-type@22.0.1:
-    resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
-    engines: {node: '>=22'}
-
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -1105,12 +943,6 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  idb-keyval@6.3.0:
-    resolution: {integrity: sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -1155,9 +987,6 @@ packages:
     resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
     engines: {node: '>=20'}
     hasBin: true
-
-  is-url@1.2.4:
-    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1246,28 +1075,9 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  officeparser@7.3.0:
-    resolution: {integrity: sha512-OfW388kpvh9Gh/2afUjJI+yipPNcJI1oYqQcZI2bw3LORf6pvu3BKpq5c2glDChtwZbK8dEL6S7YjoKIKL0SPg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    peerDependencies:
-      puppeteer: '*'
-    peerDependenciesMeta:
-      puppeteer:
-        optional: true
 
   ollama@0.6.3:
     resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
@@ -1295,10 +1105,6 @@ packages:
         optional: true
       zod:
         optional: true
-
-  opencollective-postinstall@2.0.3:
-    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
-    hasBin: true
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1355,9 +1161,6 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
-  regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1382,15 +1185,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
-    engines: {node: '>=20.9.0'}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1459,10 +1253,6 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  strtok3@10.3.5:
-    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
-    engines: {node: '>=18'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1478,12 +1268,6 @@ packages:
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
     engines: {node: '>=18'}
-
-  tesseract.js-core@7.0.0:
-    resolution: {integrity: sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==}
-
-  tesseract.js@7.0.0:
-    resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
 
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
@@ -1514,18 +1298,8 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
-  token-types@6.1.2:
-    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
-    engines: {node: '>=14.16'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.23.0:
     resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
@@ -1544,10 +1318,6 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -1617,17 +1387,8 @@ packages:
       jsdom:
         optional: true
 
-  wasm-feature-detect@1.8.0:
-    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1694,9 +1455,6 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
-  zlibjs@0.3.1:
-    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
-
 snapshots:
 
   '@alcalzone/ansi-tokenize@0.3.0':
@@ -1731,14 +1489,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@borewit/text-codec@0.2.2': {}
-
   '@colors/colors@1.5.0':
-    optional: true
-
-  '@emnapi/runtime@1.11.2':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -1888,112 +1639,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@img/colour@1.1.0': {}
-
-  '@img/sharp-darwin-arm64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-    optional: true
-
-  '@img/sharp-darwin-x64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-    optional: true
-
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-    optional: true
-
-  '@img/sharp-linux-arm@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-    optional: true
-
-  '@img/sharp-linux-s390x@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-    optional: true
-
-  '@img/sharp-linux-x64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-    optional: true
-
-  '@img/sharp-wasm32@0.35.3':
-    dependencies:
-      '@emnapi/runtime': 1.11.2
-    optional: true
-
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
-    optional: true
-
-  '@img/sharp-win32-arm64@0.35.3':
-    optional: true
-
-  '@img/sharp-win32-ia32@0.35.3':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.3':
-    optional: true
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2065,6 +1710,7 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 1.0.2
       '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
       '@napi-rs/canvas-win32-x64-msvc': 1.0.2
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2150,15 +1796,6 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
-  '@tokenizer/inflate@0.4.1':
-    dependencies:
-      debug: 4.4.3
-      token-types: 6.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tokenizer/token@0.3.0': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/node@22.20.1':
@@ -2169,21 +1806,21 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.20.1))':
+  '@vitest/coverage-v8@2.1.9(supports-color@7.2.0)(vitest@2.1.9(@types/node@22.20.1)(supports-color@7.2.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@7.2.0)
       istanbul-reports: 3.2.0
       magic-string: 0.30.21
       magicast: 0.3.5
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.20.1)
+      vitest: 2.1.9(@types/node@22.20.1)(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2227,8 +1864,6 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@xmldom/xmldom@0.9.10': {}
-
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2259,8 +1894,6 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
-
-  bmp-js@0.1.0: {}
 
   brace-expansion@2.1.2:
     dependencies:
@@ -2345,13 +1978,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   deep-eql@5.0.2: {}
-
-  detect-libc@2.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -2440,15 +2073,6 @@ snapshots:
 
   fflate@0.8.3: {}
 
-  file-type@22.0.1:
-    dependencies:
-      '@tokenizer/inflate': 0.4.1
-      strtok3: 10.3.5
-      token-types: 6.1.2
-      uint8array-extras: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
-
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -2477,10 +2101,6 @@ snapshots:
   html-escaper@2.0.2: {}
 
   husky@9.1.7: {}
-
-  idb-keyval@6.3.0: {}
-
-  ieee754@1.2.1: {}
 
   indent-string@5.0.0: {}
 
@@ -2540,8 +2160,6 @@ snapshots:
 
   is-in-ci@2.0.0: {}
 
-  is-url@1.2.4: {}
-
   isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -2552,10 +2170,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@7.2.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -2638,22 +2256,7 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   object-assign@4.1.1: {}
-
-  officeparser@7.3.0:
-    dependencies:
-      '@xmldom/xmldom': 0.9.10
-      fflate: 0.8.3
-      file-type: 22.0.1
-      pdfjs-dist: 6.1.200
-      tesseract.js: 7.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   ollama@0.6.3:
     dependencies:
@@ -2666,8 +2269,6 @@ snapshots:
   openai@6.46.0(ws@8.21.0):
     optionalDependencies:
       ws: 8.21.0
-
-  opencollective-postinstall@2.0.3: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -2719,8 +2320,6 @@ snapshots:
 
   react@19.2.7: {}
 
-  regenerator-runtime@0.13.11: {}
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -2764,39 +2363,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@7.8.5: {}
-
-  sharp@0.35.3(@types/node@22.20.1):
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 22.20.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -2861,10 +2427,6 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strtok3@10.3.5:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -2877,22 +2439,6 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   terminal-size@4.0.1: {}
-
-  tesseract.js-core@7.0.0: {}
-
-  tesseract.js@7.0.0:
-    dependencies:
-      bmp-js: 0.1.0
-      idb-keyval: 6.3.0
-      is-url: 1.2.4
-      node-fetch: 2.7.0
-      opencollective-postinstall: 2.0.3
-      regenerator-runtime: 0.13.11
-      tesseract.js-core: 7.0.0
-      wasm-feature-detect: 1.8.0
-      zlibjs: 0.3.1
-    transitivePeerDependencies:
-      - encoding
 
   test-exclude@7.0.2:
     dependencies:
@@ -2918,18 +2464,7 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
-  token-types@6.1.2:
-    dependencies:
-      '@borewit/text-codec': 0.2.2
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
-
-  tr46@0.0.3: {}
-
   ts-algebra@2.0.0: {}
-
-  tslib@2.8.1:
-    optional: true
 
   tsx@4.23.0:
     dependencies:
@@ -2945,16 +2480,14 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  uint8array-extras@1.5.0: {}
-
   undici-types@6.21.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
-  vite-node@2.1.9(@types/node@22.20.1):
+  vite-node@2.1.9(@types/node@22.20.1)(supports-color@7.2.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       es-module-lexer: 1.7.0
       pathe: 1.1.2
       vite: 5.4.21(@types/node@22.20.1)
@@ -2978,7 +2511,7 @@ snapshots:
       '@types/node': 22.20.1
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@22.20.1):
+  vitest@2.1.9(@types/node@22.20.1)(supports-color@7.2.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.20.1))
@@ -2988,7 +2521,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.3.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       expect-type: 1.4.0
       magic-string: 0.30.21
       pathe: 1.1.2
@@ -2998,7 +2531,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
       vite: 5.4.21(@types/node@22.20.1)
-      vite-node: 2.1.9(@types/node@22.20.1)
+      vite-node: 2.1.9(@types/node@22.20.1)(supports-color@7.2.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
@@ -3013,16 +2546,7 @@ snapshots:
       - supports-color
       - terser
 
-  wasm-feature-detect@1.8.0: {}
-
-  webidl-conversions@3.0.1: {}
-
   whatwg-fetch@3.6.20: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:
@@ -3074,5 +2598,3 @@ snapshots:
       yargs-parser: 20.2.9
 
   yoga-layout@3.2.1: {}
-
-  zlibjs@0.3.1: {}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -37,7 +37,7 @@ function Remove-StaleArtifacts {
                 Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
                 return
             }
-            if ($Leftover -notmatch "^$([regex]::Escape($Name))\.(\d+)\.(bak|tmp)$") { return }
+            if ($Leftover -notmatch "^$([regex]::Escape($Name))\.(\d+)\.(bak|tmp)(\.gz)?$") { return }
             $PidText = $Matches[1]
             $Kind = $Matches[2]
             # TryParse, not [int]: \d+ happily matches a number too large for an
@@ -337,6 +337,35 @@ function Save-FileWithProgress {
     }
 }
 
+# Every release publishes "<asset>.gz" beside the raw binary. It is roughly a
+# third of the size, and the raw asset stays published so an installer pinned to
+# an older release keeps resolving. gzip rather than a zip: GZipStream has been
+# in System.dll since .NET 2.0, so there is nothing to Add-Type and nothing that
+# can write outside the file it was handed.
+function Expand-GzipFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $Compressed = $null
+    $Gzip = $null
+    $Output = $null
+    try {
+        $Compressed = [System.IO.File]::OpenRead($Source)
+        $Gzip = New-Object System.IO.Compression.GZipStream($Compressed, [System.IO.Compression.CompressionMode]::Decompress)
+        $Output = [System.IO.File]::Open($Destination, [System.IO.FileMode]::Create)
+        $Buffer = New-Object byte[] (1MB)
+        while (($Read = $Gzip.Read($Buffer, 0, $Buffer.Length)) -gt 0) {
+            $Output.Write($Buffer, 0, $Read)
+        }
+    } finally {
+        if ($Output) { $Output.Dispose() }
+        if ($Gzip) { $Gzip.Dispose() }
+        if ($Compressed) { $Compressed.Dispose() }
+    }
+}
+
 function Get-RemoteText {
     param([Parameter(Mandatory = $true)][string]$Url)
 
@@ -368,15 +397,29 @@ Remove-StaleArtifacts -Dir $InstallDir -Name $BinaryName
 # Per-process so a leftover from a still-running agav cannot collide with this
 # one, and so two installers cannot overwrite each other's partial download.
 $TmpFile = Join-Path $InstallDir "$BinaryName.$PID.tmp"
+$TmpGzFile = "$TmpFile.gz"
+$GotCompressed = $false
 try {
-    Save-FileWithProgress -Url $DownloadUrl -Destination $TmpFile -Activity "Downloading $AssetName"
+    Save-FileWithProgress -Url "$DownloadUrl.gz" -Destination $TmpGzFile -Activity "Downloading $AssetName.gz"
+    Expand-GzipFile -Source $TmpGzFile -Destination $TmpFile
+    $GotCompressed = $true
 } catch {
-    # Write-Host, not Write-Error: $ErrorActionPreference is Stop, so a
-    # Write-Error here would abort the handler before the cleanup below runs.
-    Write-Host "Download failed: $($_.Exception.Message)" -ForegroundColor Red
-    Write-Host "Check available releases: https://github.com/$Repo/releases" -ForegroundColor Red
-    if (Test-Path -LiteralPath $TmpFile) { Remove-Item -LiteralPath $TmpFile -Force }
-    exit 1
+    Write-Host "agav -> Compressed download unavailable, falling back to the full binary." -ForegroundColor Yellow
+} finally {
+    if (Test-Path -LiteralPath $TmpGzFile) { Remove-Item -LiteralPath $TmpGzFile -Force -ErrorAction SilentlyContinue }
+}
+
+if (-not $GotCompressed) {
+    try {
+        Save-FileWithProgress -Url $DownloadUrl -Destination $TmpFile -Activity "Downloading $AssetName"
+    } catch {
+        # Write-Host, not Write-Error: $ErrorActionPreference is Stop, so a
+        # Write-Error here would abort the handler before the cleanup below runs.
+        Write-Host "Download failed: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host "Check available releases: https://github.com/$Repo/releases" -ForegroundColor Red
+        if (Test-Path -LiteralPath $TmpFile) { Remove-Item -LiteralPath $TmpFile -Force }
+        exit 1
+    }
 }
 
 # --- Verify checksum ---

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -252,10 +252,17 @@ if (Test-Path $FinalPath) {
 }
 
 # --- Resolve download URL ---
+# Normalize: strip a leading v/V so we can re-add it consistently, matching
+# install.sh's normalize_version.  Both `--version=0.3.0` and `--version=v0.3.0`
+# now produce the same URL.
+if ($Version -ne "latest") {
+    $Version = $Version -replace '^[vV]', ''
+}
+
 if ($Version -eq "latest") {
     $DownloadUrl = "https://github.com/$Repo/releases/latest/download/$AssetName"
 } else {
-    $DownloadUrl = "https://github.com/$Repo/releases/download/$Version/$AssetName"
+    $DownloadUrl = "https://github.com/$Repo/releases/download/v$Version/$AssetName"
 }
 
 Write-Host "agav -> Downloading agav for $Target..." -ForegroundColor Cyan

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -162,6 +162,36 @@ verify_checksum() {
   fi
 }
 
+# --- Compressed downloads ---
+#
+# Every release publishes `<asset>.gz` beside the raw binary. The archive is
+# roughly a third of the size, which is worth having on a download this large,
+# and the raw asset stays published so installers pinned to an older release
+# keep resolving. gzip, not tar or zip: no archive parser, no entry names, and
+# nothing that can write outside the directory it was told to.
+#
+# The digest is still taken from the raw asset's published entry and checked
+# against the decompressed file, so a substituted or truncated archive fails at
+# exactly the same gate an uncompressed download would.
+
+have_gunzip() {
+  command -v gzip >/dev/null 2>&1 || command -v gunzip >/dev/null 2>&1
+}
+
+gunzip_to() {
+  src="$1"
+  dest="$2"
+
+  if command -v gzip >/dev/null 2>&1; then
+    gzip -dc "$src" >"$dest" && return 0
+  elif command -v gunzip >/dev/null 2>&1; then
+    gunzip -c "$src" >"$dest" && return 0
+  fi
+
+  rm -f "$dest"
+  return 1
+}
+
 # --- Version helpers ---
 
 normalize_version() {
@@ -640,12 +670,26 @@ acquire_lock
 # Download binary
 download_url="https://github.com/${REPO}/releases/download/v${resolved_version}/${asset_name}"
 archive_path="$tmp_dir/$asset_name"
+compressed_path="$tmp_dir/${asset_name}.gz"
 
-step "Downloading $asset_name..."
-download_file "$download_url" "$archive_path" || {
-  err "Download failed. Check: https://github.com/${REPO}/releases"
-  exit 1
-}
+downloaded=""
+if have_gunzip; then
+  step "Downloading ${asset_name}.gz..."
+  if download_file "${download_url}.gz" "$compressed_path" && gunzip_to "$compressed_path" "$archive_path"; then
+    downloaded=1
+  else
+    rm -f "$compressed_path" "$archive_path"
+    warn "Compressed download unavailable — falling back to the full binary."
+  fi
+fi
+
+if [ -z "$downloaded" ]; then
+  step "Downloading $asset_name..."
+  download_file "$download_url" "$archive_path" || {
+    err "Download failed. Check: https://github.com/${REPO}/releases"
+    exit 1
+  }
+fi
 
 # Verify the checksum before anything else looks at the file. This is the
 # authoritative integrity gate, so it runs first and every failure is fatal.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -719,8 +719,7 @@ if command -v file >/dev/null 2>&1; then
   case "$file_type" in
     *executable* | *ELF* | *Mach-O*) ;;
     *)
-      err "Downloaded file is not a valid binary: ${file_type:-unknown}"
-      exit 1
+      warn "Downloaded file may not be a valid binary (file reports: ${file_type:-unknown}). The checksum matched, so proceeding anyway."
       ;;
   esac
 fi

--- a/scripts/tests/install-ps1.test.ps1
+++ b/scripts/tests/install-ps1.test.ps1
@@ -43,6 +43,21 @@ $StubBody = @'
 function Save-FileWithProgress {
     param([string]$Url, [string]$Destination, [string]$Activity)
     if ($env:FAKE_DL_FAIL -eq "1") { throw "simulated 404 for $Url" }
+    # The installer asks for "<asset>.gz" first and falls back to the raw asset.
+    # FAKE_GZ_FAIL is a release that predates the compressed asset; FAKE_GZ_JUNK
+    # is one where the bytes arrive but are not a gzip stream.
+    if ($Url.EndsWith(".gz")) {
+        if ($env:FAKE_GZ_FAIL -eq "1") { throw "simulated 404 for $Url" }
+        if ($env:FAKE_GZ_JUNK -eq "1") {
+            Copy-Item -LiteralPath $env:FAKE_ASSET -Destination $Destination -Force
+            return
+        }
+        $Raw = [System.IO.File]::ReadAllBytes($env:FAKE_ASSET)
+        $Out = [System.IO.File]::Open($Destination, [System.IO.FileMode]::Create)
+        $Gz = New-Object System.IO.Compression.GZipStream($Out, [System.IO.Compression.CompressionMode]::Compress)
+        try { $Gz.Write($Raw, 0, $Raw.Length) } finally { $Gz.Dispose(); $Out.Dispose() }
+        return
+    }
     Copy-Item -LiteralPath $env:FAKE_ASSET -Destination $Destination -Force
 }
 function Get-RemoteText {
@@ -129,6 +144,8 @@ function Restore-State {
     $env:FAKE_SHA_TEXT = ""
     $env:FAKE_SHA_FAIL = ""
     $env:FAKE_DL_FAIL = ""
+    $env:FAKE_GZ_FAIL = ""
+    $env:FAKE_GZ_JUNK = ""
     if (-not $script:HaveRegistry) { return }
     try {
         $Key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
@@ -157,6 +174,7 @@ Check "--help does not install" (-not (Test-Path "$Root/help"))
 Write-Host "== happy path =="
 $env:FAKE_SHA_TEXT = "$Digest  agav-windows-x64.exe"
 $env:FAKE_SHA_FAIL = "0"; $env:FAKE_DL_FAIL = "0"
+$env:FAKE_GZ_FAIL = "0"; $env:FAKE_GZ_JUNK = "0"
 $d = "$Root/ok"
 $r = Invoke-Install $d
 Check "install exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
@@ -165,6 +183,31 @@ Check "content matches asset" ((Get-Content -Raw "$d/agav.exe") -eq (Get-Content
 Check "reports checksum verified" ($r.Out -match "Checksum verified")
 Check "no .tmp left" (@(Get-ChildItem $d -Filter "*.tmp" -EA SilentlyContinue).Count -eq 0)
 Check "no .bak left" (@(Get-ChildItem $d -Filter "*.bak" -EA SilentlyContinue).Count -eq 0)
+Check "no .gz left" (@(Get-ChildItem $d -Filter "*.gz" -EA SilentlyContinue).Count -eq 0)
+# The compressed asset is roughly a third of the download, so preferring it is
+# the whole point; falling back silently would look identical from out here.
+Check "took the compressed asset" ($r.Out -notmatch "falling back to the full binary") "out=$($r.Out)"
+
+Write-Host "== a release with no compressed asset =="
+# Anything published before .gz existed, and any partial upload since.
+$env:FAKE_GZ_FAIL = "1"
+$d = "$Root/nogz"
+$r = Invoke-Install $d
+Check "no-gz install exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "no-gz binary landed" (Test-Path "$d/agav.exe")
+Check "no-gz content matches asset" ((Get-Content -Raw "$d/agav.exe") -eq (Get-Content -Raw $Asset))
+Check "no-gz says it fell back" ($r.Out -match "falling back to the full binary")
+Check "no-gz leaves no .gz" (@(Get-ChildItem $d -Filter "*.gz" -EA SilentlyContinue).Count -eq 0)
+$env:FAKE_GZ_FAIL = "0"
+
+Write-Host "== a .gz that is not actually gzip =="
+$env:FAKE_GZ_JUNK = "1"
+$d = "$Root/junkgz"
+$r = Invoke-Install $d
+Check "junk-gz install exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
+Check "junk-gz installs the raw asset instead" ((Get-Content -Raw "$d/agav.exe") -eq (Get-Content -Raw $Asset))
+Check "junk-gz leaves no .gz" (@(Get-ChildItem $d -Filter "*.gz" -EA SilentlyContinue).Count -eq 0)
+$env:FAKE_GZ_JUNK = "0"
 
 Write-Host "== upgrade over an existing install (rename-aside) =="
 Set-Content -LiteralPath "$d/agav.exe" -Value "OLD" -NoNewline
@@ -226,6 +269,7 @@ $d = "$Root/stale"
 New-Item -ItemType Directory -Path $d -Force | Out-Null
 Set-Content "$d/agav.exe.9999999.bak" "dead pid backup" -NoNewline
 Set-Content "$d/agav.exe.9999998.tmp" "dead pid download" -NoNewline
+Set-Content "$d/agav.exe.9999997.tmp.gz" "dead pid compressed download" -NoNewline
 Set-Content "$d/agav.exe.tmp" "legacy download" -NoNewline
 Set-Content "$d/agav.exe.$PID.tmp" "LIVE download" -NoNewline
 Set-Content "$d/notes.txt" "keep me" -NoNewline
@@ -233,6 +277,9 @@ $r = Invoke-Install $d
 Check "sweep exits 0" ($r.Code -eq 0) "code=$($r.Code) out=$($r.Out)"
 Check "dead-pid .bak swept" (-not (Test-Path "$d/agav.exe.9999999.bak"))
 Check "dead-pid .tmp swept" (-not (Test-Path "$d/agav.exe.9999998.tmp"))
+# An interrupted install leaves ~25MB of compressed download behind, which the
+# sweep missed entirely while it only knew about .tmp and .bak.
+Check "dead-pid .tmp.gz swept" (-not (Test-Path "$d/agav.exe.9999997.tmp.gz"))
 Check "legacy .tmp swept" (-not (Test-Path "$d/agav.exe.tmp"))
 Check "LIVE .tmp spared" (Test-Path "$d/agav.exe.$PID.tmp")
 Check "unrelated file spared" (Test-Path "$d/notes.txt")

--- a/source/__tests__/utils.office-text.test.ts
+++ b/source/__tests__/utils.office-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { zipSync, strToU8 } from "fflate";
+
+import { extractDocxText, extractPptxText } from "../utils/office-text.js";
+
+function docx(documentXml: string): Uint8Array {
+  return zipSync({
+    "[Content_Types].xml": strToU8("<Types/>"),
+    "word/document.xml": strToU8(documentXml),
+  });
+}
+
+const DOCUMENT = `<?xml version="1.0"?>
+<w:document xmlns:w="x"><w:body>
+  <w:p><w:r><w:t>Quarterly </w:t></w:r><w:r><w:t xml:space="preserve">report &amp; notes</w:t></w:r></w:p>
+  <w:p><w:r><w:t>Left</w:t></w:r><w:r><w:tab/></w:r><w:r><w:t>Right</w:t></w:r></w:p>
+  <w:p><w:r><w:t>One</w:t><w:br/><w:t>Two</w:t></w:r></w:p>
+  <w:p><w:r><w:delText>removed</w:delText></w:r></w:p>
+</w:body></w:document>`;
+
+describe("utils/office-text", () => {
+  it("reads docx runs, tabs, breaks, and entities in document order", () => {
+    const { sections } = extractDocxText(docx(DOCUMENT));
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0]).toBe("Quarterly report & notes\nLeft\tRight\nOne\nTwo");
+  });
+
+  it("skips numeric character references it cannot represent", () => {
+    const { sections } = extractDocxText(docx(`<w:p><w:r><w:t>&#8212; &#x2713; &#1114112;</w:t></w:r></w:p>`));
+
+    expect(sections[0]).toBe("— ✓ &#1114112;");
+  });
+
+  it("rejects a docx with no document part", () => {
+    expect(() => extractDocxText(zipSync({ "word/styles.xml": strToU8("<x/>") }))).toThrow(/no word\/document\.xml/);
+  });
+
+  it("orders slides numerically rather than lexically", () => {
+    const slide = (text: string) => strToU8(`<p:sld xmlns:a="x"><a:p><a:r><a:t>${text}</a:t></a:r></a:p></p:sld>`);
+    const { sections } = extractPptxText(zipSync({
+      "ppt/slides/slide10.xml": slide("Tenth"),
+      "ppt/slides/slide2.xml": slide("Second"),
+      "ppt/slides/slide1.xml": slide("First"),
+    }));
+
+    expect(sections).toEqual(["First", "Second", "Tenth"]);
+  });
+
+  it("attaches speaker notes through the slide relationship, not the file number", () => {
+    const { sections } = extractPptxText(zipSync({
+      "ppt/slides/slide1.xml": strToU8(`<p:sld xmlns:a="x"><a:p><a:r><a:t>Agenda</a:t></a:r></a:p></p:sld>`),
+      "ppt/slides/_rels/slide1.xml.rels": strToU8(`<Relationships><Relationship Id="rId2" Target="../notesSlides/notesSlide7.xml"/></Relationships>`),
+      "ppt/notesSlides/notesSlide7.xml": strToU8(`<p:notes xmlns:a="x"><a:p><a:r><a:t>Keep it short</a:t></a:r></a:p></p:notes>`),
+      "ppt/notesSlides/notesSlide1.xml": strToU8(`<p:notes xmlns:a="x"><a:p><a:r><a:t>Wrong notes</a:t></a:r></a:p></p:notes>`),
+    }));
+
+    expect(sections[0]).toBe("Agenda\n\n[Speaker notes]\nKeep it short");
+  });
+
+  it("refuses to inflate a part that declares an implausible size", () => {
+    // 64MB of zeroes compresses to a few KB, which is the shape of a zip bomb.
+    const archive = zipSync({ "word/document.xml": new Uint8Array(64 * 1024 * 1024) });
+
+    expect(() => extractDocxText(archive)).toThrow(/refusing to decompress/);
+  });
+});

--- a/source/__tests__/utils.office-text.test.ts
+++ b/source/__tests__/utils.office-text.test.ts
@@ -64,4 +64,20 @@ describe("utils/office-text", () => {
 
     expect(() => extractDocxText(archive)).toThrow(/refusing to decompress/);
   });
+
+  it("returns empty sections for a pptx with no slides", () => {
+    const { sections } = extractPptxText(zipSync({
+      "ppt/presentation.xml": strToU8("<x/>"),
+    }));
+    expect(sections).toEqual([]);
+  });
+
+  it("strips whitespace-only paragraphs", () => {
+    const { sections } = extractDocxText(docx(
+      `<w:p><w:r><w:t>Hello</w:t></w:r></w:p>` +
+      `<w:p><w:r><w:t>   </w:t></w:r></w:p>` +
+      `<w:p><w:r><w:t>World</w:t></w:r></w:p>`
+    ));
+    expect(sections[0]).toBe("Hello\nWorld");
+  });
 });

--- a/source/types.d.ts
+++ b/source/types.d.ts
@@ -1,3 +1,9 @@
 declare module "marked-terminal" {
   export function markedTerminal(options?: Record<string, unknown>): unknown;
 }
+
+// pdfjs-dist ships types for its main entry only. The worker is imported for
+// its side effect of being bundled, so the handler shape is all that matters.
+declare module "pdfjs-dist/legacy/build/pdf.worker.mjs" {
+  export const WorkerMessageHandler: unknown;
+}

--- a/source/utils/auto-update.ts
+++ b/source/utils/auto-update.ts
@@ -6,6 +6,7 @@ import { createWriteStream, createReadStream } from "node:fs";
 import { createHash } from "node:crypto";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
 import { ensureDir } from "./fs.js";
 import { VERSION } from "../version.js";
 import { reinstallHint } from "./shell-hints.js";
@@ -84,15 +85,20 @@ function getBinaryName(): string {
   return `agav-${osName}-${archName}`;
 }
 
-async function downloadBinary(version: string, label?: string): Promise<string | null> {
-  const binaryName = getBinaryName();
-  const url = `https://github.com/${REPO}/releases/download/${version}/${binaryName}`;
-  // Keyed by pid as well as version: two agav processes updating to the same
-  // version at once would otherwise interleave their writes into one file, and
-  // both would fail the checksum.
-  const tmpPath = join(AGAV_DIR, `${DOWNLOAD_PREFIX}${version}.${process.pid}`);
-  const activity = label ?? `Downloading ${version}`;
-
+/**
+ * Stream one URL to `destPath`, optionally gunzipping it on the way in.
+ *
+ * Returns false — rather than throwing — for anything that makes this attempt
+ * unusable, so the caller can fall back to another URL. The partial file is
+ * removed on failure; a truncated ~100 MB download must not be left behind for
+ * the stale sweep to find a day later.
+ */
+async function streamAssetToFile(
+  url: string,
+  destPath: string,
+  activity: string,
+  decompress: boolean,
+): Promise<boolean> {
   // A fixed deadline on the whole transfer would kill a healthy download on a
   // slow link, because the signal stays live while the body streams. Abort on
   // inactivity instead, re-arming the timer each time a chunk arrives.
@@ -106,13 +112,12 @@ async function downloadBinary(version: string, label?: string): Promise<string |
   };
 
   try {
-    await ensureDir(AGAV_DIR);
     armStallTimer();
     const res = await fetch(url, {
       redirect: "follow",
       signal: controller.signal,
     });
-    if (!res.ok || !res.body) return null;
+    if (!res.ok || !res.body) return false;
 
     const totalBytes = Number(res.headers.get("content-length")) || 0;
     let downloadedBytes = 0;
@@ -138,6 +143,8 @@ async function downloadBinary(version: string, label?: string): Promise<string |
       }
     };
 
+    // Counts bytes off the wire, ahead of any gunzip, so the numbers stay in
+    // step with the content-length the server advertised.
     const progressStream = new Transform({
       transform(chunk, _encoding, callback) {
         downloadedBytes += chunk.length;
@@ -146,10 +153,44 @@ async function downloadBinary(version: string, label?: string): Promise<string |
         callback(null, chunk);
       },
     });
-    const fileStream = createWriteStream(tmpPath);
-    await pipeline(res.body as any, progressStream, fileStream);
-    if (stallTimer) clearTimeout(stallTimer);
+    const fileStream = createWriteStream(destPath);
+    if (decompress) {
+      await pipeline(res.body as any, progressStream, createGunzip(), fileStream);
+    } else {
+      await pipeline(res.body as any, progressStream, fileStream);
+    }
     renderProgress(true);
+    return true;
+  } catch {
+    await rm(destPath, { force: true }).catch(() => {});
+    return false;
+  } finally {
+    if (stallTimer) clearTimeout(stallTimer);
+  }
+}
+
+async function downloadBinary(version: string, label?: string): Promise<string | null> {
+  const binaryName = getBinaryName();
+  const url = `https://github.com/${REPO}/releases/download/${version}/${binaryName}`;
+  // Keyed by pid as well as version: two agav processes updating to the same
+  // version at once would otherwise interleave their writes into one file, and
+  // both would fail the checksum.
+  const tmpPath = join(AGAV_DIR, `${DOWNLOAD_PREFIX}${version}.${process.pid}`);
+  const activity = label ?? `Downloading ${version}`;
+
+  try {
+    await ensureDir(AGAV_DIR);
+
+    // Releases publish a gzipped copy next to the raw binary; it is roughly a
+    // third of the size, which is most of an auto-update's cost on a slow link.
+    // Anything at all wrong with it — a release from before the compressed
+    // asset existed, a 404, bytes that are not a gzip stream — just falls back
+    // to the full binary. Either way the digest below is the one published for
+    // the *raw* asset, checked against the decompressed file, so the compressed
+    // path is not a second thing to trust.
+    let ok = await streamAssetToFile(`${url}.gz`, tmpPath, activity, true);
+    if (!ok) ok = await streamAssetToFile(url, tmpPath, activity, false);
+    if (!ok) return null;
 
     // Verify against the published checksum before this ever becomes
     // executable. We are about to replace our own binary and re-exec it, so an
@@ -165,8 +206,6 @@ async function downloadBinary(version: string, label?: string): Promise<string |
   } catch {
     await rm(tmpPath, { force: true }).catch(() => {});
     return null;
-  } finally {
-    if (stallTimer) clearTimeout(stallTimer);
   }
 }
 

--- a/source/utils/file-context.ts
+++ b/source/utils/file-context.ts
@@ -7,6 +7,8 @@ import { promisify } from "node:util";
 import { basename, extname, join, relative, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import type { ContentBlock } from "../providers/types.js";
+import { downscaleImage, imageToolHint, pdfRasterHint, rasterisePdfRange } from "./media-tools.js";
+import { extractDocxText, extractPptxText } from "./office-text.js";
 import { setEnvHint } from "./shell-hints.js";
 
 const execFileAsync = promisify(execFile);
@@ -17,6 +19,20 @@ export const MAX_DOCUMENT_PAGES = 10;
 const MAX_TEXT_TOOL_BYTES = 1024 * 1024;
 const IMAGE_LONG_EDGE = 1600;
 const IMAGE_QUALITY = 80;
+/**
+ * Ceiling for an image forwarded without downscaling. Base64 inflates by a
+ * third, and providers reject attachments past roughly 5MB encoded, so a
+ * larger original has to be resized or refused rather than sent and bounced.
+ */
+const MAX_RAW_IMAGE_BYTES = 3.5 * 1024 * 1024;
+/** Formats a provider accepts as-is when no downscaler is installed. */
+const RAW_IMAGE_MEDIA_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
 
 const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tif", ".tiff"]);
 const OFFICE_EXTENSIONS = new Set([".doc", ".docx", ".ppt", ".pptx"]);
@@ -261,38 +277,107 @@ async function readTextContext(path: string, info: Stats, options: FileContextOp
   };
 }
 
-async function imagePreview(path: string): Promise<{ block: ContentBlock; metadata: string }> {
-  try {
-    const { default: sharp } = await import("sharp");
-    const pipeline = sharp(path, { animated: false }).rotate().resize({
-      width: IMAGE_LONG_EDGE,
-      height: IMAGE_LONG_EDGE,
-      fit: "inside",
-      withoutEnlargement: true,
-    });
-    const { data, info } = await pipeline.flatten({ background: "#ffffff" }).jpeg({ quality: IMAGE_QUALITY }).toBuffer({ resolveWithObject: true });
+async function imagePreview(path: string, size: number): Promise<{ block: ContentBlock; metadata: string; warnings: string[] }> {
+  const preview = await downscaleImage(path, IMAGE_LONG_EDGE, IMAGE_QUALITY);
+  if (preview) {
+    const dimensions = preview.width && preview.height ? `${preview.width}x${preview.height}, ` : "";
     return {
-      block: { type: "image", imageData: data.toString("base64"), imageMediaType: "image/jpeg", imageWidth: info.width, imageHeight: info.height },
-      metadata: `${basename(path)} (${info.width}x${info.height}, JPEG preview)`,
-    };
-  } catch {
-    const raw = await readFile(path);
-    const ext = extname(path).toLowerCase();
-    const mime = ext === ".png" ? "image/png" : ext === ".gif" ? "image/gif" : ext === ".webp" ? "image/webp" : "image/jpeg";
-    return {
-      block: { type: "image", imageData: raw.toString("base64"), imageMediaType: mime },
-      metadata: `${basename(path)} (raw ${mime})`,
+      block: { type: "image", imageData: preview.data.toString("base64"), imageMediaType: preview.mediaType, imageWidth: preview.width, imageHeight: preview.height },
+      metadata: `${basename(path)} (${dimensions}JPEG preview)`,
+      warnings: [],
     };
   }
+
+  const extension = extname(path).toLowerCase();
+  const mediaType = RAW_IMAGE_MEDIA_TYPES[extension];
+  if (!mediaType) {
+    throw new Error(`${extension} images have to be converted before they can be sent, and no image tool was found. ${imageToolHint()}`);
+  }
+  if (size > MAX_RAW_IMAGE_BYTES) {
+    throw new Error(`${basename(path)} is ${(size / 1024 / 1024).toFixed(1)}MB and no image tool was found to downscale it. ${imageToolHint()}`);
+  }
+  const raw = await readFile(path);
+  return {
+    block: { type: "image", imageData: raw.toString("base64"), imageMediaType: mediaType },
+    metadata: `${basename(path)} (raw ${mediaType})`,
+    warnings: [`${basename(path)} was sent at full size. ${imageToolHint()}`],
+  };
 }
 
 async function readImageContext(path: string, size: number, options: FileContextOptions): Promise<FileContextResult> {
   if (options.startLine !== undefined || options.endLine !== undefined || options.startPage !== undefined || options.endPage !== undefined) {
     throw new Error("Line and page ranges cannot be used with image files");
   }
-  const preview = await imagePreview(path);
+  const preview = await imagePreview(path, size);
   const output = `Image preview: ${preview.metadata}\nPath: ${path}`;
-  return { path, kind: "image", output, contentBlocks: [{ type: "text", text: output }, preview.block], warnings: [], size };
+  return { path, kind: "image", output, contentBlocks: [{ type: "text", text: output }, preview.block], warnings: preview.warnings, size };
+}
+
+type Pdfjs = typeof import("pdfjs-dist/legacy/build/pdf.mjs");
+
+/**
+ * pdf.mjs constructs a `DOMMatrix` while its own module body runs, and neither
+ * Node nor Bun defines one. Its fallback is @napi-rs/canvas, whose prebuilt
+ * Skia binaries this build deliberately does not carry — and which Bun's
+ * cross-compiled targets dropped anyway, which is why PDFs already failed on
+ * the Linux and Windows releases. Without a matrix in scope the import itself
+ * throws and no PDF can be read at all.
+ *
+ * Construction is all that module initialisation needs. Everything past that
+ * belongs to canvas rendering, which also wants Path2D and a real 2D context;
+ * page images come from Poppler instead, so a method that is missing here
+ * would fail on a path that cannot run regardless.
+ */
+class AffineMatrix {
+  a = 1;
+  b = 0;
+  c = 0;
+  d = 1;
+  e = 0;
+  f = 0;
+
+  constructor(init?: number[]) {
+    if (Array.isArray(init) && init.length >= 6) {
+      [this.a, this.b, this.c, this.d, this.e, this.f] = init as [number, number, number, number, number, number];
+    }
+  }
+
+  get is2D(): boolean {
+    return true;
+  }
+
+  get isIdentity(): boolean {
+    return this.a === 1 && this.b === 0 && this.c === 0 && this.d === 1 && this.e === 0 && this.f === 0;
+  }
+}
+
+let pdfjsPromise: Promise<Pdfjs> | undefined;
+
+function loadPdfjs(): Promise<Pdfjs> {
+  pdfjsPromise ??= (async () => {
+    (globalThis as { DOMMatrix?: unknown }).DOMMatrix ??= AffineMatrix;
+    // pdf.mjs also warns on console during import about the canvas package it
+    // could not load. That write happens inside the module body, before
+    // `verbosity` can be turned down, and stray console output corrupts the
+    // Ink frame, so swallow this one import's warnings.
+    const warn = console.warn;
+    console.warn = () => {};
+    let pdfjs: Pdfjs;
+    try {
+      pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+    } finally {
+      console.warn = warn;
+    }
+    // Off the main thread pdf.mjs loads its worker by a bare `./pdf.worker.mjs`
+    // path relative to itself, which no bundler can follow and which does not
+    // exist inside a compiled binary. Importing the worker by name puts it in
+    // the bundle, and `globalThis.pdfjsWorker` is the hook pdf.mjs checks
+    // before it tries that path.
+    const worker = await import("pdfjs-dist/legacy/build/pdf.worker.mjs");
+    (globalThis as { pdfjsWorker?: unknown }).pdfjsWorker ??= worker;
+    return pdfjs;
+  })();
+  return pdfjsPromise;
 }
 
 async function readPdfContext(path: string, size: number, options: FileContextOptions): Promise<FileContextResult> {
@@ -300,22 +385,9 @@ async function readPdfContext(path: string, size: number, options: FileContextOp
     throw new Error("Line ranges cannot be used with PDF or Office documents");
   }
   validateRange(options.startPage, options.endPage, "Page range");
-  const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
-  let createCanvas: typeof import("@napi-rs/canvas").createCanvas;
-  let sharpModule: typeof import("sharp").default | null = null;
-  try {
-    const [canvasMod, sharpMod] = await Promise.all([
-      import("@napi-rs/canvas"),
-      import("sharp"),
-    ]);
-    createCanvas = canvasMod.createCanvas;
-    sharpModule = sharpMod.default;
-  } catch {
-    const canvasMod = await import("@napi-rs/canvas");
-    createCanvas = canvasMod.createCanvas;
-  }
+  const pdfjs = await loadPdfjs();
   const bytes = await readFile(path);
-  const loadingTask = pdfjs.getDocument({ data: new Uint8Array(bytes) });
+  const loadingTask = pdfjs.getDocument({ data: new Uint8Array(bytes), verbosity: pdfjs.VerbosityLevel.ERRORS });
   const pdf = await loadingTask.promise;
   const pageCount = pdf.numPages;
   const requestedStart = options.startPage ?? 1;
@@ -328,29 +400,41 @@ async function readPdfContext(path: string, size: number, options: FileContextOp
   const warnings: string[] = [];
   if (requestedEnd > actualEnd) warnings.push(`Document preview was limited to ${MAX_DOCUMENT_PAGES} pages.`);
 
-  const blocks: ContentBlock[] = [];
   const textSections: string[] = [];
+  const viewports = new Map<number, { width: number; height: number }>();
   try {
     for (let pageNumber = requestedStart; pageNumber <= actualEnd; pageNumber++) {
       const page = await pdf.getPage(pageNumber);
-      const baseViewport = page.getViewport({ scale: 1 });
-      const scale = Math.min(2, IMAGE_LONG_EDGE / Math.max(baseViewport.width, baseViewport.height));
-      const viewport = page.getViewport({ scale });
-      const canvas = createCanvas(Math.ceil(viewport.width), Math.ceil(viewport.height));
-      await page.render({ canvas: canvas as never, canvasContext: canvas.getContext("2d") as never, viewport }).promise;
-      const pngBuf = canvas.toBuffer("image/png");
-      const jpeg = sharpModule
-        ? await sharpModule(pngBuf).jpeg({ quality: IMAGE_QUALITY }).toBuffer()
-        : pngBuf;
+      const viewport = page.getViewport({ scale: 1 });
+      viewports.set(pageNumber, { width: viewport.width, height: viewport.height });
       const textContent = await page.getTextContent();
       const pageText = textContent.items.map((item) => "str" in item ? item.str : "").filter(Boolean).join(" ");
       textSections.push(`--- Page ${pageNumber} ---\n${pageText}`);
-      blocks.push({ type: "image", imageData: jpeg.toString("base64"), imageMediaType: sharpModule ? "image/jpeg" : "image/png", imageWidth: canvas.width, imageHeight: canvas.height });
       page.cleanup();
     }
   } finally {
     await loadingTask.destroy();
   }
+
+  // Page images are a bonus on top of the text. Rendering happens out of
+  // process, so a host without Poppler still gets everything a text PDF
+  // carries; only scans lose out, and the warning says so.
+  const longestPoints = Math.max(...[...viewports.values()].flatMap((v) => [v.width, v.height]));
+  const rasterised = await rasterisePdfRange(path, requestedStart, actualEnd, longestPoints, IMAGE_LONG_EDGE, IMAGE_QUALITY);
+  const blocks: ContentBlock[] = [];
+  for (const [pageNumber, viewport] of viewports) {
+    const data = rasterised?.pages.get(pageNumber);
+    if (!data) continue;
+    blocks.push({
+      type: "image",
+      imageData: data.toString("base64"),
+      imageMediaType: "image/jpeg",
+      imageWidth: Math.max(1, Math.round((viewport.width * rasterised!.dpi) / 72)),
+      imageHeight: Math.max(1, Math.round((viewport.height * rasterised!.dpi) / 72)),
+    });
+  }
+  if (blocks.length === 0) warnings.push(`Only the text of this document was read. ${pdfRasterHint()}`);
+
   const output = [`Document: ${path}`, `Pages ${requestedStart}-${actualEnd} of ${pageCount}`, ...textSections, ...warnings.map((warning) => `[Warning: ${warning}]`)].join("\n");
   return { path, kind: "pdf", output, contentBlocks: [{ type: "text", text: output }, ...blocks], warnings, pageCount, size };
 }
@@ -439,29 +523,22 @@ async function readOfficeContext(path: string, size: number, options: FileContex
   }
   validateRange(options.startPage, options.endPage, "Page range");
   const issues: string[] = [];
-  const { parseOffice } = await import("officeparser");
-  const ast = await parseOffice(path, {
-    extractAttachments: false,
-    includeRawContent: false,
-    ignoreComments: true,
-    ignoreNotes: false,
-    onWarning: (issue) => issues.push(String(issue.message ?? issue)),
-  });
+  const archive = new Uint8Array(await readFile(path));
   let text: string;
   let pageCount: number | undefined;
   const fallbackWarnings: string[] = [];
   if (extension === ".pptx") {
-    const slides = ast.content.filter((node) => node.type === "slide");
+    const slides = extractPptxText(archive).sections;
     pageCount = slides.length;
     const start = options.startPage ?? 1;
     if (start > pageCount) throw new Error(`Slide ${start} is outside the presentation (${pageCount} slides)`);
     const requestedEnd = Math.min(options.endPage ?? pageCount, pageCount);
     const end = Math.min(requestedEnd, start + MAX_DOCUMENT_PAGES - 1);
     if (requestedEnd > end) fallbackWarnings.push(`Document preview was limited to ${MAX_DOCUMENT_PAGES} slides.`);
-    text = slides.slice(start - 1, end).map((slide, index) => `--- Slide ${start + index} ---\n${slide.text ?? ""}`).join("\n");
+    text = slides.slice(start - 1, end).map((slide, index) => `--- Slide ${start + index} ---\n${slide}`).join("\n");
     fallbackWarnings.push(".pptx was read as extracted slide text because LibreOffice is unavailable; visual layout is not preserved.");
   } else {
-    text = ast.toText();
+    text = extractDocxText(archive).sections.join("\n");
     fallbackWarnings.push(".docx was read as extracted text because LibreOffice is unavailable; page ranges and visual layout are not preserved.");
   }
   if (Buffer.byteLength(text, "utf8") > MAX_MENTION_BYTES) {

--- a/source/utils/file-context.ts
+++ b/source/utils/file-context.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 import { basename, extname, join, relative, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import type { ContentBlock } from "../providers/types.js";
-import { downscaleImage, imageToolHint, pdfRasterHint, rasterisePdfRange } from "./media-tools.js";
+import { downscaleImage, hasImageTool, imageToolHint, pdfRasterHint, rasterisePdfRange } from "./media-tools.js";
 import { extractDocxText, extractPptxText } from "./office-text.js";
 import { setEnvHint } from "./shell-hints.js";
 
@@ -288,6 +288,8 @@ async function imagePreview(path: string, size: number): Promise<{ block: Conten
     };
   }
 
+  const toolAvailable = await hasImageTool();
+
   const extension = extname(path).toLowerCase();
   const mediaType = RAW_IMAGE_MEDIA_TYPES[extension];
   if (!mediaType) {
@@ -300,7 +302,9 @@ async function imagePreview(path: string, size: number): Promise<{ block: Conten
   return {
     block: { type: "image", imageData: raw.toString("base64"), imageMediaType: mediaType },
     metadata: `${basename(path)} (raw ${mediaType})`,
-    warnings: [`${basename(path)} was sent at full size. ${imageToolHint()}`],
+    warnings: [toolAvailable
+      ? `${basename(path)} could not be converted and was sent at full size; the installed image tool may not support this format.`
+      : `${basename(path)} was sent at full size. ${imageToolHint()}`],
   };
 }
 
@@ -387,7 +391,7 @@ async function readPdfContext(path: string, size: number, options: FileContextOp
   validateRange(options.startPage, options.endPage, "Page range");
   const pdfjs = await loadPdfjs();
   const bytes = await readFile(path);
-  const loadingTask = pdfjs.getDocument({ data: new Uint8Array(bytes), verbosity: pdfjs.VerbosityLevel.ERRORS });
+  const loadingTask = pdfjs.getDocument({ data: new Uint8Array(bytes), verbosity: pdfjs.VerbosityLevel.WARNINGS });
   const pdf = await loadingTask.promise;
   const pageCount = pdf.numPages;
   const requestedStart = options.startPage ?? 1;

--- a/source/utils/media-tools.ts
+++ b/source/utils/media-tools.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -85,6 +85,10 @@ function findPdfRasteriser(): Promise<boolean> {
   return pdfRasterPromise;
 }
 
+export async function hasImageTool(): Promise<boolean> {
+  return (await findImageTool()) !== null;
+}
+
 /** Only for tests: forget which tools were found. */
 export function resetMediaToolCache(): void {
   imageToolPromise = undefined;
@@ -146,6 +150,12 @@ async function withTempDir<T>(prefix: string, run: (directory: string) => Promis
  * sending the original bytes.
  */
 export async function downscaleImage(path: string, longEdge: number, quality: number): Promise<RasterImage | null> {
+  // Guard against command injection: ImageMagick interprets `scheme:` prefixes
+  // (e.g. https://, ephemeral:) as delegates and `[...]` suffixes as frame
+  // selectors. Verifying the path points to an existing local file prevents a
+  // crafted path from triggering remote URL fetching or other delegate abuse.
+  try { await stat(path); } catch { return null; }
+
   const tool = await findImageTool();
   if (!tool) return null;
   const source = await sourceDimensions(tool, path);
@@ -203,6 +213,11 @@ export async function rasterisePdfRange(
   longEdge: number,
   quality: number,
 ): Promise<RasterisedPages | null> {
+  // Guard against command injection: verify the path is an existing local file
+  // before passing it to pdftoppm, which could otherwise interpret crafted
+  // paths as remote resources or special directives.
+  try { await stat(pdfPath); } catch { return null; }
+
   if (!(await findPdfRasteriser())) return null;
   if (!Number.isFinite(longestPoints) || longestPoints <= 0) return null;
   // PDF user space is 72 units to the inch, so this is the DPI that lands the

--- a/source/utils/media-tools.ts
+++ b/source/utils/media-tools.ts
@@ -1,0 +1,236 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+/**
+ * Image downscaling and PDF page rasterisation through whatever the host
+ * already has.
+ *
+ * These two jobs used to be done in-process by sharp and @napi-rs/canvas.
+ * Both ship prebuilt native libraries — libvips and Skia — that together
+ * accounted for roughly a third of every release binary, and Bun's
+ * cross-compiled targets dropped them anyway, so the in-process path was
+ * already dead on three of the five platforms we publish. Shelling out to a
+ * tool that is either preinstalled (sips) or a one-line install (ImageMagick,
+ * Poppler) costs a process spawn on a path that is already doing file I/O,
+ * and it degrades to a clear message instead of a silent behaviour change.
+ */
+
+const execFileAsync = promisify(execFile);
+
+const PROBE_TIMEOUT_MS = 5_000;
+const CONVERT_TIMEOUT_MS = 60_000;
+/** Rasterised page and preview buffers stay well inside provider limits. */
+const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+
+export interface RasterImage {
+  data: Buffer;
+  mediaType: "image/jpeg";
+  width?: number;
+  height?: number;
+}
+
+/**
+ * True unless the command is absent from PATH. A probe that runs and exits
+ * non-zero still proves the tool exists — `sips` has no version flag and
+ * several ImageMagick builds exit 1 on `-version` under a restricted HOME.
+ */
+async function commandExists(command: string, args: string[]): Promise<boolean> {
+  try {
+    await execFileAsync(command, args, { timeout: PROBE_TIMEOUT_MS });
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException | null)?.code !== "ENOENT";
+  }
+}
+
+type ImageToolId = "magick" | "convert" | "sips";
+
+interface ImageTool {
+  id: ImageToolId;
+  bin: string;
+  /** Command and leading arguments that run ImageMagick's `identify`. */
+  identify: [string, ...string[]];
+}
+
+const IMAGE_TOOLS: ImageTool[] = [
+  // ImageMagick 7 folds every subcommand into one binary; 6 ships them apart.
+  { id: "magick", bin: "magick", identify: ["magick", "identify"] },
+  { id: "convert", bin: "convert", identify: ["identify"] },
+  { id: "sips", bin: "sips", identify: ["sips"] },
+];
+
+let imageToolPromise: Promise<ImageTool | null> | undefined;
+
+async function findImageTool(): Promise<ImageTool | null> {
+  imageToolPromise ??= (async () => {
+    for (const tool of IMAGE_TOOLS) {
+      // sips is macOS-only, and on Windows `convert.exe` is the filesystem
+      // converter, which would happily "exist" and then reformat nothing.
+      if (tool.id === "sips" && process.platform !== "darwin") continue;
+      if (tool.id === "convert" && process.platform === "win32") continue;
+      if (await commandExists(tool.bin, ["-version"])) return tool;
+    }
+    return null;
+  })();
+  return imageToolPromise;
+}
+
+let pdfRasterPromise: Promise<boolean> | undefined;
+
+function findPdfRasteriser(): Promise<boolean> {
+  pdfRasterPromise ??= commandExists("pdftoppm", ["-v"]);
+  return pdfRasterPromise;
+}
+
+/** Only for tests: forget which tools were found. */
+export function resetMediaToolCache(): void {
+  imageToolPromise = undefined;
+  pdfRasterPromise = undefined;
+}
+
+export function imageToolHint(): string {
+  switch (process.platform) {
+    case "win32": return "Install ImageMagick (winget install ImageMagick.ImageMagick) to have large images downscaled before they are sent.";
+    case "darwin": return "sips ships with macOS and was not found on PATH; install ImageMagick (brew install imagemagick) to have large images downscaled before they are sent.";
+    default: return "Install ImageMagick (apt install imagemagick) to have large images downscaled before they are sent.";
+  }
+}
+
+export function pdfRasterHint(): string {
+  switch (process.platform) {
+    case "win32": return "Install Poppler (winget install oschwartz10612.Poppler) to also send page images.";
+    case "darwin": return "Install Poppler (brew install poppler) to also send page images.";
+    default: return "Install Poppler (apt install poppler-utils) to also send page images.";
+  }
+}
+
+function fitInside(width: number, height: number, longEdge: number): { width: number; height: number } {
+  const scale = Math.min(1, longEdge / Math.max(width, height));
+  return { width: Math.max(1, Math.round(width * scale)), height: Math.max(1, Math.round(height * scale)) };
+}
+
+async function sourceDimensions(tool: ImageTool, path: string): Promise<{ width: number; height: number } | undefined> {
+  try {
+    if (tool.id === "sips") {
+      const { stdout } = await execFileAsync(tool.bin, ["-g", "pixelWidth", "-g", "pixelHeight", path], { timeout: PROBE_TIMEOUT_MS });
+      const width = Number(stdout.match(/pixelWidth:\s*(\d+)/)?.[1]);
+      const height = Number(stdout.match(/pixelHeight:\s*(\d+)/)?.[1]);
+      return Number.isFinite(width) && Number.isFinite(height) ? { width, height } : undefined;
+    }
+    const [bin, ...args] = tool.identify;
+    // `[0]` selects the first frame; without it an animated GIF prints one
+    // line per frame and a multi-page TIFF prints one per page.
+    const { stdout } = await execFileAsync(bin, [...args, "-format", "%w %h", `${path}[0]`], { timeout: PROBE_TIMEOUT_MS });
+    const [width, height] = stdout.trim().split(/\s+/).map(Number);
+    return Number.isFinite(width) && Number.isFinite(height) ? { width: width!, height: height! } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function withTempDir<T>(prefix: string, run: (directory: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    return await run(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Downscale `path` to a JPEG no larger than `longEdge` on its long side.
+ * Resolves to null when no image tool is installed, which callers handle by
+ * sending the original bytes.
+ */
+export async function downscaleImage(path: string, longEdge: number, quality: number): Promise<RasterImage | null> {
+  const tool = await findImageTool();
+  if (!tool) return null;
+  const source = await sourceDimensions(tool, path);
+  const target = source ? fitInside(source.width, source.height, longEdge) : undefined;
+  try {
+    return await withTempDir("agav-image-", async (directory) => {
+      const output = join(directory, "preview.jpg");
+      if (tool.id === "sips") {
+        // -Z enlarges as readily as it shrinks, so only pass it when the
+        // source is actually oversized.
+        const resize = source && Math.max(source.width, source.height) > longEdge ? ["-Z", String(longEdge)] : [];
+        await execFileAsync(tool.bin, ["-s", "format", "jpeg", "-s", "formatOptions", String(quality), ...resize, path, "--out", output], { timeout: CONVERT_TIMEOUT_MS });
+      } else {
+        await execFileAsync(tool.bin, [
+          `${path}[0]`,
+          "-auto-orient",
+          // The trailing `>` restricts the geometry to shrinking.
+          "-resize", `${longEdge}x${longEdge}>`,
+          // Transparency would otherwise flatten to black in a JPEG.
+          "-background", "white", "-alpha", "remove", "-alpha", "off",
+          "-quality", String(quality),
+          `jpg:${output}`,
+        ], { timeout: CONVERT_TIMEOUT_MS });
+      }
+      const data = await readFile(output);
+      if (data.length === 0 || data.length > MAX_OUTPUT_BYTES) return null;
+      return { data, mediaType: "image/jpeg" as const, width: target?.width, height: target?.height };
+    });
+  } catch {
+    return null;
+  }
+}
+
+export interface RasterisedPages {
+  /** JPEG bytes keyed by 1-based page number. Pages that failed are absent. */
+  pages: Map<number, Buffer>;
+  /** Resolution the range was rendered at, so callers can derive pixel sizes. */
+  dpi: number;
+}
+
+/**
+ * Render a page range of a PDF to JPEGs sized to `longEdge`. Resolves to null
+ * when Poppler is missing or the render fails; text extraction is unaffected
+ * either way.
+ *
+ * `longestPoints` is the longest edge, in PDF user-space units, of any page in
+ * the range. One resolution covers the whole range so this stays a single
+ * process spawn rather than one per page.
+ */
+export async function rasterisePdfRange(
+  pdfPath: string,
+  firstPage: number,
+  lastPage: number,
+  longestPoints: number,
+  longEdge: number,
+  quality: number,
+): Promise<RasterisedPages | null> {
+  if (!(await findPdfRasteriser())) return null;
+  if (!Number.isFinite(longestPoints) || longestPoints <= 0) return null;
+  // PDF user space is 72 units to the inch, so this is the DPI that lands the
+  // long edge on `longEdge` pixels. Cap it at 2x nominal for the same reason
+  // the old canvas renderer did: a small page is not worth upsampling.
+  const dpi = Math.max(1, Math.min(144, Math.round((72 * longEdge) / longestPoints)));
+  try {
+    return await withTempDir("agav-pdfpage-", async (directory) => {
+      const prefix = join(directory, "page");
+      await execFileAsync("pdftoppm", [
+        "-jpeg", "-jpegopt", `quality=${quality}`,
+        "-r", String(dpi),
+        "-f", String(firstPage), "-l", String(lastPage),
+        pdfPath, prefix,
+      ], { timeout: CONVERT_TIMEOUT_MS, maxBuffer: 1024 * 1024 });
+      // pdftoppm zero-pads the page number to the width of the document's page
+      // count, so the file names are not predictable from the range alone.
+      const pages = new Map<number, Buffer>();
+      for (const entry of await readdir(directory)) {
+        const pageNumber = Number(entry.match(/-(\d+)\.jpe?g$/)?.[1]);
+        if (!Number.isInteger(pageNumber)) continue;
+        const data = await readFile(join(directory, entry));
+        if (data.length === 0 || data.length > MAX_OUTPUT_BYTES) continue;
+        pages.set(pageNumber, data);
+      }
+      return pages.size > 0 ? { pages, dpi } : null;
+    });
+  } catch {
+    return null;
+  }
+}

--- a/source/utils/office-text.ts
+++ b/source/utils/office-text.ts
@@ -31,9 +31,14 @@ function decodeXml(value: string): string {
     if (entity.startsWith("#")) {
       const hex = entity[1] === "x" || entity[1] === "X";
       const code = Number.parseInt(hex ? entity.slice(2) : entity.slice(1), hex ? 16 : 10);
-      // Surrogate halves and out-of-plane values would make fromCodePoint
-      // throw, which is not worth failing a whole document over.
-      if (!Number.isInteger(code) || code < 0 || code > 0x10ffff) return match;
+      // Reject null byte, control chars, surrogates, and 0xFFFE/0xFFFF
+      // per XML spec §2.2 — fromCodePoint would throw on surrogates, and
+      // the rest are illegal in well-formed XML.
+      const xmlLegal = code === 0x9 || code === 0xa || code === 0xd
+        || (code >= 0x20 && code <= 0xd7ff)
+        || (code >= 0xe000 && code <= 0xfffd)
+        || (code >= 0x10000 && code <= 0x10ffff);
+      if (!Number.isInteger(code) || !xmlLegal) return match;
       return String.fromCodePoint(code);
     }
     return XML_ENTITIES[entity] ?? match;
@@ -76,7 +81,7 @@ function partToText(xml: string, grammar: TextGrammar): string {
 }
 
 function unzipParts(archive: Uint8Array, wanted: (name: string) => boolean): Record<string, Uint8Array> {
-  return unzipSync(archive, {
+  const parts = unzipSync(archive, {
     filter: (file) => {
       if (!wanted(file.name)) return false;
       if (file.originalSize > MAX_PART_BYTES) {
@@ -85,6 +90,15 @@ function unzipParts(archive: Uint8Array, wanted: (name: string) => boolean): Rec
       return true;
     },
   });
+
+  // Post-decompression guard: originalSize is attacker-controlled, so verify actual sizes
+  for (const [name, data] of Object.entries(parts)) {
+    if (data.length > MAX_PART_BYTES) {
+      throw new Error(`Office part "${name}" expanded to ${data.length} bytes; refusing to process it.`);
+    }
+  }
+
+  return parts;
 }
 
 const decoder = new TextDecoder("utf-8");

--- a/source/utils/office-text.ts
+++ b/source/utils/office-text.ts
@@ -1,0 +1,131 @@
+import { unzipSync } from "fflate";
+
+/**
+ * Text extraction for the modern Office formats, without a parser library.
+ *
+ * A .docx or .pptx is a ZIP of XML parts, and the readable words live in one
+ * or two of them. Recovering those needs an inflater and a regex — not a
+ * general-purpose Office reader that pulls an OCR engine and a second PDF
+ * stack into the shipped binary. Nothing here understands styling, tables, or
+ * tracked changes: it returns the words in document order and stops. When
+ * layout matters, LibreOffice is still the preferred path.
+ */
+
+/**
+ * A single part is allowed to inflate to this much. A .pptx is a few hundred
+ * KB of XML in practice, so anything near the cap is a zip bomb rather than a
+ * deck, and `unzipSync` would otherwise allocate whatever the header claims.
+ */
+const MAX_PART_BYTES = 32 * 1024 * 1024;
+
+const XML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+};
+
+function decodeXml(value: string): string {
+  return value.replace(/&(#[Xx][0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (match, entity: string) => {
+    if (entity.startsWith("#")) {
+      const hex = entity[1] === "x" || entity[1] === "X";
+      const code = Number.parseInt(hex ? entity.slice(2) : entity.slice(1), hex ? 16 : 10);
+      // Surrogate halves and out-of-plane values would make fromCodePoint
+      // throw, which is not worth failing a whole document over.
+      if (!Number.isInteger(code) || code < 0 || code > 0x10ffff) return match;
+      return String.fromCodePoint(code);
+    }
+    return XML_ENTITIES[entity] ?? match;
+  });
+}
+
+interface TextGrammar {
+  /** Closing tag that ends a paragraph, used to place line breaks. */
+  paragraphEnd: RegExp;
+  /**
+   * Run text, tabs, and hard breaks in one alternation. They have to be
+   * matched together: tabs and breaks are empty elements, so scanning for run
+   * text alone silently welds adjacent cells and lines into one word.
+   */
+  runs: RegExp;
+}
+
+const DOCX_GRAMMAR: TextGrammar = {
+  paragraphEnd: /<\/w:p>/,
+  runs: /<w:t\b[^>]*>([\s\S]*?)<\/w:t>|<w:tab\b[^>]*\/>|<w:br\b[^>]*\/>/g,
+};
+
+const PPTX_GRAMMAR: TextGrammar = {
+  paragraphEnd: /<\/a:p>/,
+  runs: /<a:t\b[^>]*>([\s\S]*?)<\/a:t>|<a:br\b[^>]*\/>/g,
+};
+
+function partToText(xml: string, grammar: TextGrammar): string {
+  const lines: string[] = [];
+  for (const paragraph of xml.split(grammar.paragraphEnd)) {
+    let line = "";
+    for (const match of paragraph.matchAll(grammar.runs)) {
+      if (match[1] !== undefined) line += decodeXml(match[1]);
+      else line += match[0].includes(":tab") ? "\t" : "\n";
+    }
+    const trimmed = line.replace(/[ \t]+$/gm, "").trim();
+    if (trimmed) lines.push(trimmed);
+  }
+  return lines.join("\n");
+}
+
+function unzipParts(archive: Uint8Array, wanted: (name: string) => boolean): Record<string, Uint8Array> {
+  return unzipSync(archive, {
+    filter: (file) => {
+      if (!wanted(file.name)) return false;
+      if (file.originalSize > MAX_PART_BYTES) {
+        throw new Error(`Office part "${file.name}" claims to expand to ${file.originalSize} bytes; refusing to decompress it.`);
+      }
+      return true;
+    },
+  });
+}
+
+const decoder = new TextDecoder("utf-8");
+
+function decodePart(parts: Record<string, Uint8Array>, name: string): string | undefined {
+  const part = parts[name];
+  return part ? decoder.decode(part) : undefined;
+}
+
+function partNumber(name: string): number {
+  return Number.parseInt(name.match(/(\d+)\.xml(?:\.rels)?$/)?.[1] ?? "0", 10);
+}
+
+export interface OfficeText {
+  /** One entry per slide for .pptx; a single entry for .docx. */
+  sections: string[];
+}
+
+export function extractDocxText(archive: Uint8Array): OfficeText {
+  const parts = unzipParts(archive, (name) => name === "word/document.xml");
+  const xml = decodePart(parts, "word/document.xml");
+  if (xml === undefined) throw new Error("This .docx has no word/document.xml part; it may be corrupt.");
+  return { sections: [partToText(xml, DOCX_GRAMMAR)] };
+}
+
+export function extractPptxText(archive: Uint8Array): OfficeText {
+  const isSlide = (name: string) => /^ppt\/slides\/slide\d+\.xml$/.test(name);
+  const isSlideRels = (name: string) => /^ppt\/slides\/_rels\/slide\d+\.xml\.rels$/.test(name);
+  const isNotes = (name: string) => /^ppt\/notesSlides\/notesSlide\d+\.xml$/.test(name);
+  const parts = unzipParts(archive, (name) => isSlide(name) || isSlideRels(name) || isNotes(name));
+
+  const slides = Object.keys(parts).filter(isSlide).sort((a, b) => partNumber(a) - partNumber(b));
+  const sections = slides.map((slide) => {
+    const body = partToText(decodePart(parts, slide) ?? "", PPTX_GRAMMAR);
+    // notesSlideN.xml is not guaranteed to line up with slideN.xml — the pairing
+    // lives in the slide's relationship part — so follow the link rather than
+    // the number and risk attaching another slide's notes.
+    const rels = decodePart(parts, slide.replace("ppt/slides/", "ppt/slides/_rels/") + ".rels") ?? "";
+    const target = rels.match(/Target="\.\.\/notesSlides\/(notesSlide\d+\.xml)"/)?.[1];
+    const notes = target ? partToText(decodePart(parts, `ppt/notesSlides/${target}`) ?? "", PPTX_GRAMMAR) : "";
+    return notes ? `${body}\n\n[Speaker notes]\n${notes}` : body;
+  });
+  return { sections };
+}


### PR DESCRIPTION
## Summary

- Cuts the macOS binary by 28.6 MiB (101.2 MB to 72.6 MB) by dropping `sharp`, `@napi-rs/canvas` and `officeparser` in favour of tools already on the box, and by always cross-compiling so every target is built the same way.
- Publishes a gzipped copy of each binary alongside the raw one, so a fresh install or auto-update transfers 37.7 MB instead of 103.7 MB on Linux. Both installers and the updater prefer it and fall back to the raw asset.
- Fixes a pre-existing bug found while testing: **PDFs were unreadable in every shipped binary on every platform.**

## Changes

**Dependencies removed** — `sharp`, `@napi-rs/canvas`, `officeparser` (which also pulled in tesseract.js, file-type, @xmldom/xmldom and a second copy of pdfjs).

- `source/utils/media-tools.ts` (new) — image downscaling and PDF page rasterisation through `sips`, ImageMagick or Poppler, discovered at runtime with a clear message when none is present.
- `source/utils/office-text.ts` (new) — `.docx`/`.pptx` text extraction on `fflate` alone, with a zip-bomb gate on each part's declared size. Covered by 6 new tests.

**PDF fix** — pdfjs looked for `./pdf.worker.mjs` on disk, which does not exist inside a compiled binary, and separately crashed at module init on a missing `DOMMatrix` (neither Node nor Bun defines one; it only ever worked from source because `@napi-rs/canvas` came in as a pdfjs optional dependency). The worker is now bundled and there is a small affine-matrix shim.

**Release** — always cross-compiles, including for the runner's own platform. A host-target build embeds whichever native addons happen to resolve locally, which is how the macOS binaries drifted ~27 MB heavier than the rest. Also drops a redundant `bun install react-devtools-core` step that was rewriting `package.json` mid-release.

**Installers and auto-update** — request `<asset>.gz` first, decompress, fall back to the raw asset on a 404 or on bytes that are not a gzip stream. The digest checked is always the raw asset's published digest, against the decompressed file, so the compressed path is not a second thing to trust. The updater gunzips in-stream and never writes a `.gz` to disk; the installers clean theirs up (`trap cleanup EXIT INT TERM` for sh, a `finally` plus a widened stale-artifact sweep for PowerShell).

**New `binary-size` CI job** — compiles `bun-linux-x64` with the release flags, reports raw and compressed size to the step summary, warns above a 110 MiB budget, and smoke-tests `--version`. It installs with pnpm only, so it is also the guard that ink's devtools import still resolves without the removed `bun install` step; a binary that cannot find it dies at startup rather than at build time.

**Deliberately not included** — `--minify`. It mangles the identifiers in stack traces, which makes bug reports materially harder to act on. The 0.7 MB it saves is not worth that.

### Measured

| Target | Before | After | Change |
| --- | ---: | ---: | ---: |
| darwin-arm64 | 101,176,034 | 72,577,250 | -28.6 MiB |
| linux-x64 | 105,748,608 | 103,655,552 | -2.0 MiB |
| linux-x64 `.gz` | n/a | 37,674,529 | 64% less to download |

Linux barely moves because ~94 MiB of it is the embedded Bun runtime, which is not ours to shrink. The compressed asset is what helps there.

### Behaviour changes

Attachments still work with no external tools installed; the tools only widen what can be sent, and Agav names the missing one when it hits a limit.

- **PDF page images** now need Poppler (`pdftoppm`). Text extraction is unaffected, and is a net improvement for binary users since it did not work at all before.
- **Images** on Linux and Windows without ImageMagick: PNG/JPEG/GIF/WebP under 3.5 MB are sent as-is, larger files and other formats are refused with an install hint. macOS is unaffected (`sips` is built in).
- **Office** — LibreOffice remains the primary path and `.doc`/`.ppt` still require it, exactly as before. The no-LibreOffice fallback still yields text, tabs and speaker notes.

`.gz` assets are published *alongside* the raw binaries, never instead of them, so installers and updaters already in the field keep working unchanged. New installers hitting an older release fall back automatically.

## Related Issues

Closes #45

## Type

<!-- Check one -->

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs
- [ ] Chore

## Testing

- [x] `npx tsc --noEmit` passes
- [x] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

`pnpm test` — 39 files, 260 tests passing. `install-sh.test.sh` 48/48 and `install-sh-path.test.sh` 13/13. The gz-first, 404-fallback and corrupt-gzip paths were exercised against a local HTTP server for the updater, and `gunzip_to` directly under dash, bash and sh. Attachment extraction was verified through both `tsx` and a Bun-compiled binary.

Not verified locally, and worth a reviewer's eye: `shellcheck` and the two PowerShell suites (neither tool is installed on the machine this was written on, CI covers both), and the Poppler, ImageMagick and LibreOffice branches, since none of those three were installed either.

## Screenshots / Terminal Output

Attachment pipeline through a Bun-compiled binary, on a machine with no Poppler, ImageMagick or LibreOffice:

```
=== fixtures/sample.pdf ===
kind=pdf pages=1 blocks=1 images=0
--- text ---
Pages 1-1 of 1
--- Page 1 ---
Hello   Agav Second   line   of   the   sample   document.
--- warnings ---
  ! Only the text of this document was read. Install Poppler (brew install poppler) to also send page images.

=== fixtures/sample.docx ===
kind=office pages=- blocks=1 images=0
--- text ---
Quarterly Report
Revenue	£1,200 & rising
Line one
line two after a break
Signed <the board>
--- warnings ---
  ! .docx was read as extracted text because LibreOffice is unavailable; page ranges and visual layout are not preserved.

=== fixtures/big.png ===
kind=image pages=- blocks=2 images=1
  image[0] image/jpeg 171557 bytes
--- text ---
Image preview: big.png (1600x1020, JPEG preview)
--- warnings ---
  (none)
```

The same run with `PATH` emptied, standing in for a Linux box with no image tooling:

```
big.png    -> sent raw, 3,077,113 bytes + warning
huge.png   -> REFUSED: huge.png is 4.4MB and no image tool was found to downscale it.
small.tiff -> REFUSED: .tiff images have to be converted before they can be sent.
```
