### PR TITLE
chore: align package.json description with product positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agav-cli",
   "version": "0.1.8",
-  "description": "A terminal-native environment for running local AI systems",
+  "description": "Terminal-native AI coding assistant for real repositories",
   "type": "module",
   "bin": {
     "agav": "./build/cli.js"


### PR DESCRIPTION
## Summary

- Aligns the `package.json` description with how the product is described everywhere else. The repo description, README subtitle and agav.dev all say "terminal-native AI coding assistant for real repositories"; `package.json` said "A terminal-native environment for running local AI systems", which is vaguer and reads like a different product.
- This field is what npm renders as the package subtitle and what feeds npm search, so it is worth having it match the positioning before the first publish.

## Changes

- `package.json` — `description` is now `Terminal-native AI coding assistant for real repositories`.

## Related Issues

<!-- none -->

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [x] Chore

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

Metadata-only change — no code paths touched.

## Screenshots / Terminal Output

```diff
-  "description": "A terminal-native environment for running local AI systems",
+  "description": "Terminal-native AI coding assistant for real repositories",
```

Follow-ups not included here: `package.json` still has no `keywords`, `homepage`, `repository` or `bugs` fields, all of which feed npm search ranking and the sidebar links on the package page.
