### PR TITLE
fix: session-scoped plans, plan detail panel, and internal message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Agav reads, searches and edits the repository you run it in, and runs the comman
 - **Five providers** — Anthropic, OpenAI, Gemini, Vertex AI and Ollama, switchable mid-session with `/model`.
 - **Sandboxed commands** — shell tools run under Seatbelt on macOS and Bubblewrap on Linux where either is available.
 - **Non-interactive mode** — `agav run` and `agav --print` make the same agent scriptable from CI, with per-tool permissions and optional JSON Schema output.
-- **Sessions that survive** — resume, branch, name, search and export past conversations; `/compact` reclaims context without starting over.
+- **Sessions that survive** — resume, branch, name, search and export past conversations; `/compact` reclaims context without starting over. Plans are saved per-session and picked back up on resume.
 - **Extensible** — MCP servers, plugins, skills and subagents.
 - **Repository-aware editing** — LSP-backed queries, notebook support, test running, and `/undo` for the last file change.
 
@@ -79,7 +79,7 @@ agav update
 ## Slash commands
 
 <details>
-<summary>26 commands, available in any session</summary>
+<summary>27 commands, available in any session</summary>
 
 | Command | What it does |
 | --- | --- |
@@ -90,7 +90,7 @@ agav update
 | `/effort` | Show or change reasoning effort |
 | `/context` | Show context window usage |
 | `/compact` | Compact conversation history to free up context |
-| `/plan` | Show or manage the active plan |
+| `/plan` | Show, list, or update the active plan (`/plan list`, `/plan <n> <status>`, `/plan clear`) |
 | `/steer` | Add context or direction to guide the agent |
 | `/undo` | Revert the last file change |
 | `/memory` | Manage persistent memories |
@@ -107,6 +107,7 @@ agav update
 | `/loop` | Repeat a prompt on an interval |
 | `/schedule` | Manage persistent scheduled tasks |
 | `/changelog` | Show release notes for the current version |
+| `/ps` | Run a brief side query without interrupting the main task |
 | `/debug` | Show internal state for debugging |
 | `/exit` | Exit Agav |
 
@@ -360,6 +361,20 @@ Either of these recovers a dedicated key:
 For Shift+Enter with no setup at all, use a terminal that implements the protocol: Kitty, Ghostty, WezTerm, foot, Alacritty, or a recent iTerm2.
 
 </details>
+
+## Keyboard shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| `Esc` | Cancel a streaming response |
+| `Ctrl+D` | Toggle tool detail panel |
+| `Ctrl+G` | Toggle plan detail panel |
+| `Tab` | Cycle subagent focus |
+| `Ctrl+R` | Retry last turn |
+| `Ctrl+L` | Clear screen |
+| `Ctrl+Q` | Exit |
+
+Shortcuts are customisable in `~/.agav/keybindings.json` or `.agav/keybindings.json`. See the [keybindings reference](https://docs.agav.dev/reference/keybindings) for the full list.
 
 ## Extending
 

--- a/README.md
+++ b/README.md
@@ -369,12 +369,25 @@ For Shift+Enter with no setup at all, use a terminal that implements the protoco
 | `Esc` | Cancel a streaming response |
 | `Ctrl+D` | Toggle tool detail panel |
 | `Ctrl+G` | Toggle plan detail panel |
+| `Ctrl+J` | Insert newline (works on every terminal) |
+| `Ctrl+V` | Paste an image from clipboard |
 | `Tab` | Cycle subagent focus |
 | `Ctrl+R` | Retry last turn |
+| `Ctrl+C` | Interrupt the agent |
 | `Ctrl+L` | Clear screen |
 | `Ctrl+Q` | Exit |
 
 Shortcuts are customisable in `~/.agav/keybindings.json` or `.agav/keybindings.json`. See the [keybindings reference](https://docs.agav.dev/reference/keybindings) for the full list.
+
+### Copying output
+
+Agav runs inside your terminal, so copying uses your terminal's own selection mechanism:
+
+- **macOS** — select text with the mouse, then `Cmd+C`. In Terminal.app and iTerm2 this works out of the box.
+- **Linux** — select text, then `Ctrl+Shift+C` (or middle-click to paste a selection).
+- **Windows Terminal** — select text, then `Ctrl+C` (when nothing is running) or `Ctrl+Shift+C`.
+
+To save a full conversation to a file instead, use `/export` — it writes the entire session as Markdown.
 
 ## Extending
 

--- a/source/__tests__/agent-planner-state.test.ts
+++ b/source/__tests__/agent-planner-state.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, readFile, readdir, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  savePlan,
+  loadPlan,
+  clearPlan,
+  ensurePlanFile,
+  isPlanActive,
+  updatePlanStep,
+  planFilePath,
+  setPlanScope,
+  getPlanScope,
+  adoptPlanScope,
+  listPlans,
+  prunePlans,
+  type Plan,
+} from "../agent/planner.js";
+
+function makePlan(overrides: Partial<Plan> = {}): Plan {
+  return {
+    goal: "Ship the feature",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    currentStep: 0,
+    steps: [
+      { id: 1, title: "Design", description: "Sketch it", status: "pending" },
+      { id: 2, title: "Build", description: "Write it", status: "pending" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("plan state", () => {
+  let originalCwd: string;
+  let root: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    // Resolve symlinks (macOS maps /var to /private/var) so the paths the
+    // planner derives from process.cwd() compare equal to the ones built here.
+    root = await realpath(await mkdtemp(join(tmpdir(), "agav-plan-state-")));
+    process.chdir(root);
+    setPlanScope(null);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("round-trips a plan through disk", async () => {
+    const plan = makePlan();
+    await savePlan(plan);
+    expect(await loadPlan()).toEqual(plan);
+  });
+
+  it("survives a simulated restart", async () => {
+    await savePlan(makePlan());
+    // A fresh process would call ensurePlanFile before reading.
+    await ensurePlanFile();
+    expect((await loadPlan())?.goal).toBe("Ship the feature");
+  });
+
+  it("ensurePlanFile creates the directory but no unparseable state file", async () => {
+    await ensurePlanFile();
+    expect(await readdir(join(root, ".agav", "plans"))).toEqual([]);
+    expect(await loadPlan()).toBeNull();
+  });
+
+  it("resolves the plan file from the repo root, not the launch directory", async () => {
+    await mkdir(join(root, ".git"));
+    await savePlan(makePlan());
+
+    const nested = join(root, "packages", "api");
+    await mkdir(nested, { recursive: true });
+    process.chdir(nested);
+
+    expect(planFilePath()).toBe(join(root, ".agav", "plans", "draft.json"));
+    expect((await loadPlan())?.goal).toBe("Ship the feature");
+  });
+
+  it("treats a corrupt state file as no plan", async () => {
+    await ensurePlanFile();
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(planFilePath(), "# Plan\n\nNot JSON at all.\n");
+    expect(await loadPlan()).toBeNull();
+  });
+
+  it("reports a plan as active only while work remains", () => {
+    expect(isPlanActive(null)).toBe(false);
+    expect(isPlanActive(makePlan())).toBe(true);
+    expect(
+      isPlanActive(
+        makePlan({
+          steps: [
+            { id: 1, title: "a", description: "a", status: "done" },
+            { id: 2, title: "b", description: "b", status: "failed" },
+          ],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("updatePlanStep persists the status and advances the cursor", async () => {
+    await savePlan(makePlan());
+
+    const first = await updatePlanStep(1, "done");
+    expect("error" in first).toBe(false);
+    expect(await readFile(planFilePath(), "utf-8")).toContain('"done"');
+    expect((await loadPlan())?.currentStep).toBe(1);
+
+    const second = await updatePlanStep(2, "done");
+    expect(second).toMatchObject({ allDone: true, doneCount: 2, totalCount: 2 });
+    expect((await loadPlan())?.currentStep).toBe(-1);
+  });
+
+  it("updatePlanStep reports missing plans and steps", async () => {
+    expect(await updatePlanStep(1, "done")).toEqual({ error: "No active plan found." });
+    await savePlan(makePlan());
+    expect(await updatePlanStep(9, "done")).toEqual({
+      error: "Step 9 not found. Plan has 2 steps.",
+    });
+  });
+
+  it("clearPlan removes the state file", async () => {
+    await savePlan(makePlan());
+    await clearPlan();
+    expect(await loadPlan()).toBeNull();
+    await expect(clearPlan()).resolves.toBeUndefined();
+  });
+
+  it("keeps each session's plan separate", async () => {
+    setPlanScope("session-a");
+    await savePlan(makePlan({ goal: "Plan A" }));
+
+    setPlanScope("session-b");
+    expect(await loadPlan()).toBeNull();
+    await savePlan(makePlan({ goal: "Plan B" }));
+
+    // Switching back shows A again, and B was not overwritten.
+    setPlanScope("session-a");
+    expect((await loadPlan())?.goal).toBe("Plan A");
+    setPlanScope("session-b");
+    expect((await loadPlan())?.goal).toBe("Plan B");
+  });
+
+  it("clearing one session's plan leaves the others alone", async () => {
+    setPlanScope("session-a");
+    await savePlan(makePlan({ goal: "Plan A" }));
+    setPlanScope("session-b");
+    await savePlan(makePlan({ goal: "Plan B" }));
+
+    await clearPlan();
+    expect(await loadPlan()).toBeNull();
+    setPlanScope("session-a");
+    expect((await loadPlan())?.goal).toBe("Plan A");
+  });
+
+  it("adopts a draft plan onto the session id once one is assigned", async () => {
+    await savePlan(makePlan({ goal: "Drafted" }));
+    expect(getPlanScope()).toBe("draft");
+
+    adoptPlanScope("session-a");
+
+    expect(getPlanScope()).toBe("session-a");
+    expect((await loadPlan())?.goal).toBe("Drafted");
+    expect(await readdir(join(root, ".agav", "plans"))).toEqual(["session-a.json"]);
+  });
+
+  it("adoption never steals a plan from an established session", async () => {
+    setPlanScope("session-a");
+    await savePlan(makePlan({ goal: "Plan A" }));
+
+    adoptPlanScope("session-b");
+
+    expect(getPlanScope()).toBe("session-b");
+    expect(await loadPlan()).toBeNull();
+    setPlanScope("session-a");
+    expect((await loadPlan())?.goal).toBe("Plan A");
+  });
+
+  it("lists every saved plan, newest first", async () => {
+    setPlanScope("session-a");
+    await savePlan(makePlan({ goal: "Plan A" }));
+    setPlanScope("session-b");
+    await savePlan(makePlan({ goal: "Plan B" }));
+
+    const listed = await listPlans();
+    expect(listed.map((p) => p.scope).sort()).toEqual(["session-a", "session-b"]);
+    expect(listed[0]!.updatedAt.getTime()).toBeGreaterThanOrEqual(listed[1]!.updatedAt.getTime());
+  });
+
+  it("listPlans skips corrupt files and returns empty when there are none", async () => {
+    expect(await listPlans()).toEqual([]);
+    await ensurePlanFile();
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(join(root, ".agav", "plans", "broken.json"), "{oops");
+    expect(await listPlans()).toEqual([]);
+  });
+
+  it("prunes stale plans but never the current session's", async () => {
+    setPlanScope("session-old");
+    await savePlan(makePlan({ goal: "Ancient" }));
+    setPlanScope("session-now");
+    await savePlan(makePlan({ goal: "Current" }));
+
+    // Pretend we are two months on; only the other session's plan should go.
+    await prunePlans(Date.now() + 60 * 24 * 60 * 60 * 1000);
+
+    expect((await listPlans()).map((p) => p.scope)).toEqual(["session-now"]);
+  });
+});

--- a/source/__tests__/agent.internal-prompts.test.ts
+++ b/source/__tests__/agent.internal-prompts.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import type { Message } from "../providers/types.js";
+import {
+  NEEDS_VERIFY_PROMPT,
+  MAX_STEPS_PROMPT,
+  isInternalUserMessage,
+  testsFailedPrompt,
+} from "../agent/internal-prompts.js";
+import { ConversationState } from "../agent/conversation.js";
+import { messagesToDisplay } from "../hooks/use-agent.js";
+
+const userMessage = (text: string, extra: Partial<Message> = {}): Message => ({
+  role: "user",
+  content: [{ type: "text", text }],
+  ...extra,
+});
+
+describe("internal user messages", () => {
+  it("recognises a flagged message whatever it says", () => {
+    const conversation = new ConversationState();
+    conversation.addInternalUserMessage("anything at all");
+    expect(isInternalUserMessage(conversation.getMessages()[0]!)).toBe(true);
+  });
+
+  // Sessions written before the flag existed carry no marker, so the only
+  // handle on them is the text the loop injected.
+  it("recognises unflagged injections in sessions saved before the flag", () => {
+    expect(isInternalUserMessage(userMessage(NEEDS_VERIFY_PROMPT))).toBe(true);
+    expect(isInternalUserMessage(userMessage(MAX_STEPS_PROMPT))).toBe(true);
+    expect(isInternalUserMessage(userMessage(testsFailedPrompt(2, 3)))).toBe(true);
+    expect(isInternalUserMessage(userMessage("[Earlier conversation (4 exchanges) was compacted"))).toBe(true);
+  });
+
+  // Text matching is a fallback for old sessions only — a user is free to
+  // paste one of these strings back in, and that turn is theirs.
+  it("leaves a real user turn alone even when it quotes an injected prompt", () => {
+    expect(isInternalUserMessage(userMessage(NEEDS_VERIFY_PROMPT, { sourceText: NEEDS_VERIFY_PROMPT }))).toBe(false);
+    expect(isInternalUserMessage(userMessage("why did you say: " + NEEDS_VERIFY_PROMPT))).toBe(false);
+  });
+
+  it("never treats an assistant turn as internal", () => {
+    expect(isInternalUserMessage({ role: "assistant", content: [{ type: "text", text: MAX_STEPS_PROMPT }] })).toBe(false);
+  });
+
+  it("flags the compaction summary so it is not shown as something the user said", async () => {
+    const conversation = new ConversationState();
+    for (let i = 0; i < 12; i++) {
+      conversation.addUserMessage(`turn ${i} `.repeat(400));
+      conversation.addAssistantMessage([{ type: "text", text: `reply ${i} `.repeat(400) }]);
+    }
+
+    const result = await conversation.compactIfNeeded(true);
+    expect(result.compacted).toBe(true);
+    expect(isInternalUserMessage(conversation.getMessages()[0]!)).toBe(true);
+  });
+});
+
+describe("messagesToDisplay", () => {
+  // The reported bug: resuming after an abrupt exit printed the verification
+  // re-prompt as though the user had typed it, right under their own prompt.
+  it("omits prompts the agent injected to steer itself", () => {
+    const conversation = new ConversationState();
+    conversation.addUserMessage("refactor the auth module", undefined, "refactor the auth module", "refactor the auth module");
+    conversation.addAssistantMessage([{ type: "text", text: "Done." }]);
+    conversation.addInternalUserMessage(NEEDS_VERIFY_PROMPT);
+    conversation.addAssistantMessage([{ type: "text", text: "Verified." }]);
+
+    expect(messagesToDisplay(conversation.getMessages()).map((m) => m.content)).toEqual([
+      "refactor the auth module",
+      "Done.",
+      "Verified.",
+    ]);
+  });
+
+  it("omits unflagged injections restored from an older session file", () => {
+    const restored: Message[] = [
+      userMessage("fix the parser", { displayText: "fix the parser", sourceText: "fix the parser" }),
+      { role: "assistant", content: [{ type: "text", text: "Fixed." }] },
+      userMessage(NEEDS_VERIFY_PROMPT),
+    ];
+    expect(messagesToDisplay(restored).map((m) => m.content)).toEqual(["fix the parser", "Fixed."]);
+  });
+
+  // Per-turn context is appended to the user's message as a second text block,
+  // so rendering every block would print the environment dump under the prompt.
+  it("shows a user turn as typed, not as sent", () => {
+    const conversation = new ConversationState();
+    conversation.addUserMessage("explain @src/a.ts", undefined, "explain @src/a.ts", "explain @src/a.ts");
+    conversation.appendToLastUserMessage("<turn-context>cwd: /repo</turn-context>");
+
+    expect(messagesToDisplay(conversation.getMessages()).map((m) => m.content)).toEqual(["explain @src/a.ts"]);
+  });
+
+  // The headless path records sourceText but no displayText; without it the
+  // transcript would show the prompt with its @mentions already expanded.
+  it("falls back to the source text when there is no display text", () => {
+    const restored: Message[] = [userMessage("read the file <contents...>", { sourceText: "read @a.ts" })];
+    expect(messagesToDisplay(restored).map((m) => m.content)).toEqual(["read @a.ts"]);
+  });
+});

--- a/source/__tests__/commands.model-routing.test.ts
+++ b/source/__tests__/commands.model-routing.test.ts
@@ -12,6 +12,7 @@ const createContext = (provider: AgavConfig["provider"]): CommandContext => ({
   setProvider: vi.fn(),
   setEffort: vi.fn(),
   clearMessages: vi.fn(),
+  refreshPlan: vi.fn(),
   showStatus: vi.fn(),
   saveSession: vi.fn(),
   refreshDisplay: vi.fn(),

--- a/source/__tests__/commands.model.test.ts
+++ b/source/__tests__/commands.model.test.ts
@@ -43,6 +43,7 @@ function createContext(config: Partial<AgavConfig>): CommandContext {
     setProvider: vi.fn(),
     setEffort: vi.fn(),
     clearMessages: vi.fn(),
+    refreshPlan: vi.fn(),
     showStatus: vi.fn(),
     saveSession: vi.fn(),
     refreshDisplay: vi.fn(),

--- a/source/__tests__/commands.plan.test.ts
+++ b/source/__tests__/commands.plan.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { planCommand } from "../commands/plan.js";
+import type { CommandContext } from "../commands/types.js";
+import { savePlan, loadPlan, setPlanScope, type Plan } from "../agent/planner.js";
+
+const createContext = (): CommandContext => ({
+  conversation: {} as any,
+  config: {} as any,
+  setModel: vi.fn(),
+  setProvider: vi.fn(),
+  setEffort: vi.fn(),
+  clearMessages: vi.fn(),
+  refreshPlan: vi.fn(),
+  showStatus: vi.fn(),
+  saveSession: vi.fn(),
+  refreshDisplay: vi.fn(),
+  loadSession: vi.fn(),
+  activateSession: vi.fn(),
+  renameSession: vi.fn(),
+  exit: vi.fn(),
+  getDebugState: vi.fn(),
+  submit: vi.fn(),
+  handleSubmit: vi.fn(),
+  toolRegistry: {} as any,
+  addTokenUsage: vi.fn(),
+  setRunningSkill: vi.fn(),
+  setPickerActive: vi.fn(),
+});
+
+function makePlan(): Plan {
+  return {
+    goal: "Ship the feature",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    currentStep: 0,
+    steps: [
+      { id: 1, title: "Design", description: "Sketch it", status: "pending" },
+      { id: 2, title: "Build", description: "Write it", status: "pending" },
+    ],
+  };
+}
+
+describe("commands/plan", () => {
+  let originalCwd: string;
+  let root: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    root = await realpath(await mkdtemp(join(tmpdir(), "agav-plan-cmd-")));
+    process.chdir(root);
+    setPlanScope(null);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // The plan panel renders from hook state, so deleting the file is only half
+  // the job — without the refresh the cleared plan stays on screen.
+  it("refreshes the panel after clearing the plan", async () => {
+    await savePlan(makePlan());
+    const context = createContext();
+
+    const result = await planCommand.execute("clear", context);
+
+    expect(result).toEqual({ type: "message", text: "Plan cleared." });
+    expect(await loadPlan()).toBeNull();
+    expect(context.refreshPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes the panel after a step status change", async () => {
+    await savePlan(makePlan());
+    const context = createContext();
+
+    const result = await planCommand.execute("1 done", context);
+
+    expect(result).toMatchObject({ text: expect.stringContaining("1/2 steps done") });
+    expect((await loadPlan())?.steps[0]?.status).toBe("done");
+    expect(context.refreshPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the panel alone for read-only actions", async () => {
+    await savePlan(makePlan());
+    const context = createContext();
+
+    await planCommand.execute("", context);
+    await planCommand.execute("list", context);
+
+    expect(context.refreshPlan).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh when the step update fails", async () => {
+    await savePlan(makePlan());
+    const context = createContext();
+
+    const result = await planCommand.execute("9 done", context);
+
+    expect(result).toEqual({ type: "message", text: "Step 9 not found. Plan has 2 steps." });
+    expect(context.refreshPlan).not.toHaveBeenCalled();
+  });
+});

--- a/source/__tests__/commands.registry.test.ts
+++ b/source/__tests__/commands.registry.test.ts
@@ -10,6 +10,7 @@ const createContext = (): CommandContext => ({
   setProvider: vi.fn(),
   setEffort: vi.fn(),
   clearMessages: vi.fn(),
+  refreshPlan: vi.fn(),
   showStatus: vi.fn(),
   saveSession: vi.fn(),
   refreshDisplay: vi.fn(),

--- a/source/__tests__/config-keybindings.test.ts
+++ b/source/__tests__/config-keybindings.test.ts
@@ -96,6 +96,49 @@ describe("keybindings", () => {
     expect(resolver.feed("u", { ctrl: true, meta: false, shift: false, return: false, escape: false, tab: false, upArrow: false, downArrow: false, leftArrow: false, rightArrow: false, backspace: false, delete: false })).toMatchObject({ action: "clearInput" });
     expect(resolver.feed("w", { ctrl: true, meta: false, shift: false, return: false, escape: false, tab: false, upArrow: false, downArrow: false, leftArrow: false, rightArrow: false, backspace: false, delete: false })).toMatchObject({ action: "deleteWordBackward" });
   });
+
+  // Ctrl+V is the clipboard-image paste and Ctrl+D the tool detail panel, so
+  // the plan shortcut has to be a stroke of its own and must not fire on those.
+  it("binds the plan detail panel to a single free stroke", async () => {
+    const mod = await import("../config/keybindings.js");
+    const resolver = new mod.KeybindingResolver(
+      mod.DEFAULT_KEYBINDINGS,
+      ["togglePlanDetail", "toggleToolDetail"],
+    );
+    const ctrl = (input: string) => resolver.feed(input, { ...NO_KEY, ctrl: true });
+
+    expect(mod.DEFAULT_KEYBINDINGS.togglePlanDetail).toEqual(["ctrl+g"]);
+    expect(mod.formatKeybinding(mod.DEFAULT_KEYBINDINGS, "togglePlanDetail")).toBe("Ctrl+G");
+
+    expect(ctrl("g")).toMatchObject({ action: "togglePlanDetail", pending: false });
+    expect(ctrl("v")).toMatchObject({ action: null });
+    expect(ctrl("d")).toMatchObject({ action: "toggleToolDetail" });
+  });
+
+  // A resolver only reports actions it was constructed with, so an action in
+  // neither list is configurable but dead — the binding simply does nothing.
+  it("routes every action to a resolver", async () => {
+    const mod = await import("../config/keybindings.js");
+    const routed = new Set([...mod.GLOBAL_ACTIONS, ...mod.PROMPT_ACTIONS]);
+
+    for (const action of Object.keys(mod.DEFAULT_KEYBINDINGS)) {
+      expect(routed.has(action as never), `"${action}" is not resolved by any consumer`).toBe(true);
+    }
+  });
+
+  // Every stroke belongs to at most one action, or a keypress would fire two.
+  it("keeps the default bindings free of duplicate strokes", async () => {
+    const mod = await import("../config/keybindings.js");
+    const seen = new Map<string, string>();
+
+    for (const [action, bindings] of Object.entries(mod.DEFAULT_KEYBINDINGS)) {
+      for (const binding of bindings) {
+        const owner = seen.get(binding);
+        expect(owner, `"${binding}" is bound to both ${owner} and ${action}`).toBeUndefined();
+        seen.set(binding, action);
+      }
+    }
+  });
 });
 
 /** A key event with nothing pressed, so each test only states the bits it cares about. */

--- a/source/__tests__/skills.commands.test.ts
+++ b/source/__tests__/skills.commands.test.ts
@@ -50,6 +50,7 @@ describe("skills/commands", () => {
       setProvider: vi.fn(),
       setEffort: vi.fn(),
       clearMessages: vi.fn(),
+      refreshPlan: vi.fn(),
       showStatus: vi.fn(),
       saveSession: vi.fn(),
       refreshDisplay: vi.fn(),

--- a/source/__tests__/utils.tool-labels.test.ts
+++ b/source/__tests__/utils.tool-labels.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { getToolLabel, getToolSummary } from "../utils/tool-labels.js";
+import { getToolLabel, getToolSummary, isBookkeepingTool } from "../utils/tool-labels.js";
 
 describe("utils/tool-labels", () => {
   it("returns known labels", () => {
@@ -14,6 +14,23 @@ describe("utils/tool-labels", () => {
     expect(getToolSummary("grep_search", { pattern: "foo", include: "*.ts" })).toBe("foo (*.ts)");
     expect(getToolSummary("subagent", { title: "Task" })).toBe("Task");
     expect(getToolSummary("subagent", { task: "x".repeat(80) })).toMatch(/\.\.\.$/);
+  });
+
+  // update_plan only ticks a step in .agav/plans, but "Update Plan step 3 →
+  // in_progress" reads as the agent rewriting its plan and losing the thread.
+  it("describes a plan tick as progress rather than as a change of plan", () => {
+    expect(getToolLabel("update_plan")).toBe("Plan Progress");
+    expect(getToolSummary("update_plan", { step: 3, status: "done" })).toBe("step 3 complete");
+    expect(getToolSummary("update_plan", { step: 3, status: "in_progress" })).toBe("starting step 3");
+    expect(getToolSummary("update_plan", { step: 3, status: "failed" })).toBe("step 3 failed");
+  });
+
+  // Drives the muted styling: a progress tick must not carry the same weight as
+  // an edit or a shell command.
+  it("marks only progress-recording tools as bookkeeping", () => {
+    expect(isBookkeepingTool("update_plan")).toBe(true);
+    expect(isBookkeepingTool("edit_file")).toBe(false);
+    expect(isBookkeepingTool("custom_tool")).toBe(false);
   });
 
   it("falls back for unknown tools", () => {

--- a/source/agent/conversation.ts
+++ b/source/agent/conversation.ts
@@ -1,4 +1,5 @@
 import type { Message, ContentBlock, InvocationReason } from "../providers/types.js";
+import { COMPACTION_PLACEHOLDER_PREFIX } from "./internal-prompts.js";
 import {
   estimateConversationTokens,
   estimateMessageTokens,
@@ -52,6 +53,14 @@ export class ConversationState {
       ...(sourceText ? { sourceText } : {}),
       ...(invocationReason ? { invocationReason } : {}),
     });
+  }
+
+  /**
+   * A user turn the agent injects to steer itself. Flagged so the transcript
+   * can leave it out — the model needs to see it, the user should not.
+   */
+  addInternalUserMessage(text: string): void {
+    this.messages.push({ role: "user", content: [{ type: "text", text }], internal: true });
   }
 
   /**
@@ -218,7 +227,7 @@ export class ConversationState {
     const droppedMessages = this.messages.slice(0, keepFrom);
     const userMsgCount = droppedMessages.filter((m) => m.role === "user").length;
 
-    const placeholder = `[Earlier conversation (${userMsgCount} exchanges) was compacted to save context. Continue from here.]`;
+    const placeholder = `${COMPACTION_PLACEHOLDER_PREFIX} (${userMsgCount} exchanges) was compacted to save context. Continue from here.]`;
     let summaryText = placeholder;
 
     if (summarize) {
@@ -234,9 +243,13 @@ export class ConversationState {
     // sent after the compaction fails, not just this one.
     if (!summaryText.trim()) summaryText = placeholder;
 
+    // The summary stands in for turns the user did type, but it is written by
+    // the agent — showing it verbatim as a user message is how a resumed
+    // transcript ends up quoting instructions back at the user.
     const summary: Message = {
       role: "user",
       content: [{ type: "text", text: summaryText }],
+      internal: true,
     };
 
     this.messages = this.sanitizeMessages([summary, ...this.messages.slice(keepFrom)]);

--- a/source/agent/internal-prompts.ts
+++ b/source/agent/internal-prompts.ts
@@ -22,6 +22,8 @@ export const MAX_STEPS_PROMPT =
   "You have reached the maximum number of steps. Summarize what you have accomplished, " +
   "list any remaining work, and stop. Do not call any more tools.";
 
+// Extracted as a constant so LEGACY_PREFIXES (below) can match this dynamic
+// prompt by its fixed opening — the full string varies per attempt number.
 export const TESTS_FAILED_PREFIX = "Tests failed (attempt ";
 
 export function testsFailedPrompt(attempt: number, maxAttempts: number): string {
@@ -35,13 +37,17 @@ export function testsFailedPrompt(attempt: number, maxAttempts: number): string 
 export const NO_EDITS_PROMPT =
   "You analyzed the code but did not make any changes. Now write the actual fix. Use edit_file or write_file to modify the source code. Do not just explain — implement the fix.";
 
+// Same as TESTS_FAILED_PREFIX — the full prompt is dynamic (includes error
+// details), so only the fixed opening is extracted for legacy prefix matching.
 export const SCHEMA_RETRY_PREFIX = "Your previous response was invalid.";
 
 export function schemaRetryPrompt(details: string): string {
   return `${SCHEMA_RETRY_PREFIX} ${details}\nCorrect it and return ONLY valid JSON matching the required schema, with no markdown fences or commentary.`;
 }
 
-/** The placeholder compaction falls back to when no summary could be produced. */
+// The placeholder compaction falls back to when no summary could be produced.
+// Needed in LEGACY_PREFIXES so resumed sessions that went through compaction
+// don't display "[Earlier conversation was compacted...]" as a user message.
 export const COMPACTION_PLACEHOLDER_PREFIX = "[Earlier conversation";
 
 /**

--- a/source/agent/internal-prompts.ts
+++ b/source/agent/internal-prompts.ts
@@ -1,0 +1,75 @@
+import type { Message } from "../providers/types.js";
+
+/**
+ * Prompts the agent injects into the conversation as user turns to steer
+ * itself — verification nudges, test-repair retries, the step-limit wind-down.
+ * They have to be user turns for the model to act on them, but the user never
+ * typed them, so the visible transcript has to leave them out.
+ *
+ * They live here rather than at their call sites so the legacy matcher below
+ * cannot drift out of sync with the text actually being written.
+ */
+export const NEEDS_VERIFY_PROMPT =
+  "You made changes but did not verify they work. Run the program to check your changes produce the correct output. " +
+  "If there are expected output files, compare your output against them. If the task requires compilation, compile and check for errors/warnings. " +
+  "Do not stop until you have verified your solution.";
+
+export const VERIFY_FAILED_PROMPT =
+  "Your last verification command failed or produced errors/warnings. Read the output carefully, identify the specific issue, fix it, and verify again. " +
+  "Do not stop until verification passes cleanly.";
+
+export const MAX_STEPS_PROMPT =
+  "You have reached the maximum number of steps. Summarize what you have accomplished, " +
+  "list any remaining work, and stop. Do not call any more tools.";
+
+export const TESTS_FAILED_PREFIX = "Tests failed (attempt ";
+
+export function testsFailedPrompt(attempt: number, maxAttempts: number): string {
+  return (
+    `${TESTS_FAILED_PREFIX}${attempt}/${maxAttempts}). ` +
+    "Analyze the test failures above carefully. Fix the code and run tests again. " +
+    (attempt > 1 ? "Try a different approach — your previous fix didn't work." : "")
+  );
+}
+
+export const NO_EDITS_PROMPT =
+  "You analyzed the code but did not make any changes. Now write the actual fix. Use edit_file or write_file to modify the source code. Do not just explain — implement the fix.";
+
+export const SCHEMA_RETRY_PREFIX = "Your previous response was invalid.";
+
+export function schemaRetryPrompt(details: string): string {
+  return `${SCHEMA_RETRY_PREFIX} ${details}\nCorrect it and return ONLY valid JSON matching the required schema, with no markdown fences or commentary.`;
+}
+
+/** The placeholder compaction falls back to when no summary could be produced. */
+export const COMPACTION_PLACEHOLDER_PREFIX = "[Earlier conversation";
+
+/**
+ * Openings of every injected prompt. Sessions saved before `internal` existed
+ * carry no marker, so resuming one would still print these as if the user had
+ * typed them; matching the text is the only way to recognise them. New
+ * sessions never reach this — the flag settles it first.
+ */
+const LEGACY_PREFIXES = [
+  NEEDS_VERIFY_PROMPT,
+  VERIFY_FAILED_PROMPT,
+  MAX_STEPS_PROMPT,
+  NO_EDITS_PROMPT,
+  TESTS_FAILED_PREFIX,
+  SCHEMA_RETRY_PREFIX,
+  COMPACTION_PLACEHOLDER_PREFIX,
+];
+
+/**
+ * Whether a message is the agent talking to itself. Anything the user actually
+ * sent carries `displayText` or `sourceText`, so a message with either is left
+ * alone no matter what it starts with — a user is free to paste one of these
+ * strings back in.
+ */
+export function isInternalUserMessage(msg: Message): boolean {
+  if (msg.role !== "user") return false;
+  if (msg.internal) return true;
+  if (msg.displayText || msg.sourceText) return false;
+  const text = msg.content.find((block) => block.type === "text")?.text;
+  return !!text && LEGACY_PREFIXES.some((prefix) => text.startsWith(prefix));
+}

--- a/source/agent/loop.test.ts
+++ b/source/agent/loop.test.ts
@@ -789,4 +789,56 @@ describe("runAgentLoop", () => {
     expect(saved?.steps.map((step) => step.status)).toEqual(["done", "done"]);
     expect(saved?.currentStep).toBe(-1);
   });
+
+  it("does not re-prompt for a tool call the user already denied", async () => {
+    const writeCall = (id: string): StreamEvent[] => [
+      { type: "tool_call_start", toolCallId: id, toolName: "risky_write" },
+      {
+        type: "tool_call_delta",
+        toolCallId: id,
+        argsJson: '{"path":"out.txt"}',
+      },
+      { type: "message_end", stopReason: "tool_use" },
+    ];
+
+    const provider = new MockProvider([
+      writeCall("deny-1"),
+      writeCall("deny-2"),
+      [
+        { type: "text_delta", text: "giving up" },
+        { type: "message_end", stopReason: "end_turn" },
+      ],
+    ]);
+
+    const conversation = new ConversationState();
+    conversation.setModel("gpt-4");
+    conversation.addUserMessage("write the file");
+
+    const execute = vi.fn(async () => ({ output: "written", isError: false }));
+    const toolRegistry = new ToolRegistry();
+    toolRegistry.register(createTool("risky_write", execute));
+
+    const confirmTool = vi.fn(async () => "no" as const);
+
+    const events = await collectEvents(
+      runAgentLoop({
+        provider,
+        conversation,
+        toolRegistry,
+        model: "gpt-4",
+        confirmTool,
+      }),
+    );
+
+    // The user is asked exactly once; the identical retry is refused for them.
+    expect(confirmTool).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+
+    const denials = events.filter(
+      (event) => event.type === "tool_result" && event.toolName === "risky_write",
+    );
+    expect(denials).toHaveLength(2);
+    expect(denials.every((event) => (event as { isError?: boolean }).isError)).toBe(true);
+    expect((denials[1] as { output: string }).output).toContain("already denied");
+  });
 });

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -121,9 +121,11 @@ export async function* runAgentLoop(
   let verifyReprompts = 0;
   const MAX_VERIFY_REPROMPTS = 2;
   const maxIterations = params.maxIterations ?? 100;
-  // Calls the user has already refused this turn, keyed by name + arguments.
-  // Nothing else records a refusal, so without this the model can reissue the
-  // identical call every iteration and the user is asked to approve it again.
+  // Calls the user has already refused, keyed by name + arguments. Scoped to
+  // the full loop invocation (not per-turn) so the model cannot retry a denied
+  // call later in the same session. This is intentionally conservative: if the
+  // user changes their mind, they can say so in a new message and the submit()
+  // call starts a fresh loop with an empty set.
   const deniedCalls = new Set<string>();
 
   let pendingSummarizeUsage: Record<string, number> | null = null;

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -6,6 +6,12 @@ import type {
 } from "../providers/types.js";
 import type { ConversationState } from "./conversation.js";
 import type { ToolRegistry } from "../tools/registry.js";
+import {
+  MAX_STEPS_PROMPT,
+  NEEDS_VERIFY_PROMPT,
+  VERIFY_FAILED_PROMPT,
+  testsFailedPrompt,
+} from "./internal-prompts.js";
 
 export type AgentEvent =
   | { type: "planning"; plan: string }
@@ -181,10 +187,7 @@ export async function* runAgentLoop(
     // Graceful shutdown: on the last step, ask for a summary instead of hard-erroring
     const isLastStep = iteration === maxIterations - 1;
     if (isLastStep) {
-      conversation.addUserMessage(
-        "You have reached the maximum number of steps. Summarize what you have accomplished, " +
-        "list any remaining work, and stop. Do not call any more tools."
-      );
+      conversation.addInternalUserMessage(MAX_STEPS_PROMPT);
     }
 
     let textAccum = "";
@@ -310,13 +313,7 @@ export async function* runAgentLoop(
       const verifyFailed = madeEdits && ranShellAfterEdit && lastShellFailed;
       if ((needsVerify || verifyFailed) && verifyReprompts < MAX_VERIFY_REPROMPTS) {
         verifyReprompts++;
-        const msg = needsVerify
-          ? "You made changes but did not verify they work. Run the program to check your changes produce the correct output. " +
-            "If there are expected output files, compare your output against them. If the task requires compilation, compile and check for errors/warnings. " +
-            "Do not stop until you have verified your solution."
-          : "Your last verification command failed or produced errors/warnings. Read the output carefully, identify the specific issue, fix it, and verify again. " +
-            "Do not stop until verification passes cleanly.";
-        conversation.addUserMessage(msg);
+        conversation.addInternalUserMessage(needsVerify ? NEEDS_VERIFY_PROMPT : VERIFY_FAILED_PROMPT);
         continue;
       }
       yield { type: "assistant_message_complete", text: textAccum };
@@ -464,11 +461,7 @@ export async function* runAgentLoop(
     if (hasTestFailure) {
       testRepairAttempts++;
       if (testRepairAttempts <= MAX_REPAIR_ATTEMPTS) {
-        conversation.addUserMessage(
-          `Tests failed (attempt ${testRepairAttempts}/${MAX_REPAIR_ATTEMPTS}). ` +
-          "Analyze the test failures above carefully. Fix the code and run tests again. " +
-          (testRepairAttempts > 1 ? "Try a different approach — your previous fix didn't work." : ""),
-        );
+        conversation.addInternalUserMessage(testsFailedPrompt(testRepairAttempts, MAX_REPAIR_ATTEMPTS));
       }
     } else if (hasTestRun) {
       testRepairAttempts = 0;

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -115,6 +115,10 @@ export async function* runAgentLoop(
   let verifyReprompts = 0;
   const MAX_VERIFY_REPROMPTS = 2;
   const maxIterations = params.maxIterations ?? 100;
+  // Calls the user has already refused this turn, keyed by name + arguments.
+  // Nothing else records a refusal, so without this the model can reissue the
+  // identical call every iteration and the user is asked to approve it again.
+  const deniedCalls = new Set<string>();
 
   let pendingSummarizeUsage: Record<string, number> | null = null;
 
@@ -367,6 +371,13 @@ export async function* runAgentLoop(
         yield { type: "tool_result", toolName: call.name, output: reason, isError: true };
         continue;
       }
+      const denialKey = `${call.name}:${JSON.stringify(input)}`;
+      if (needsConfirm && deniedCalls.has(denialKey)) {
+        const reason = `User already denied '${call.name}' with these exact arguments. Do not request it again — take a different approach, or stop and explain what you need.`;
+        toolResults.push({ type: "tool_result", toolCallId: id, toolResult: reason, isError: true });
+        yield { type: "tool_result", toolName: call.name, toolCallId: id, output: reason, isError: true };
+        continue;
+      }
       if (needsConfirm && confirmTool) {
         // Compute diff preview for file-modifying tools
         let previewDiff: DiffLine[] | undefined;
@@ -390,8 +401,10 @@ export async function* runAgentLoop(
           permissionMode = "auto-accept";
         }
         if (choice === "no") {
-          toolResults.push({ type: "tool_result", toolCallId: id, toolResult: "User denied this tool call.", isError: true });
-          yield { type: "tool_result", toolName: call.name, toolCallId: id, output: "User denied this tool call.", isError: true };
+          deniedCalls.add(denialKey);
+          const reason = "User denied this tool call. Do not retry it with the same arguments — take a different approach, or stop and explain what you need.";
+          toolResults.push({ type: "tool_result", toolCallId: id, toolResult: reason, isError: true });
+          yield { type: "tool_result", toolName: call.name, toolCallId: id, output: reason, isError: true };
           continue;
         }
       }

--- a/source/agent/planner.ts
+++ b/source/agent/planner.ts
@@ -1,5 +1,6 @@
-import { writeFile, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { writeFile, readFile, readdir, stat } from "node:fs/promises";
+import { existsSync, renameSync } from "node:fs";
+import { basename, dirname, join, parse as parsePath } from "node:path";
 import { ensureDir } from "../utils/fs.js";
 
 export interface PlanStep {
@@ -17,38 +18,208 @@ export interface Plan {
   currentStep: number;
 }
 
-const PLAN_DIR = join(process.cwd(), ".agav");
-const PLAN_FILE = join(PLAN_DIR, ".plan-state.json");
+let cachedCwd: string | undefined;
+let cachedPlanDir: string | undefined;
+
+/**
+ * A plan describes a project, not a directory, so it is anchored at the repo
+ * root when there is one. Resolving from `process.cwd()` alone meant launching
+ * agav from a subdirectory hid the plan that was created one level up.
+ */
+function planDir(): string {
+  const cwd = process.cwd();
+  if (cachedCwd === cwd && cachedPlanDir) return cachedPlanDir;
+
+  let dir = cwd;
+  const { root } = parsePath(cwd);
+  let resolved = join(cwd, ".agav");
+  while (true) {
+    if (existsSync(join(dir, ".git"))) {
+      resolved = join(dir, ".agav");
+      break;
+    }
+    if (dir === root) break;
+    dir = dirname(dir);
+  }
+
+  cachedCwd = cwd;
+  cachedPlanDir = resolved;
+  return resolved;
+}
+
+/**
+ * A plan belongs to the session that created it, so each session gets its own
+ * file. A session has no id until it is first written to history, so plans
+ * created on the opening turn land under the draft key and are re-keyed by
+ * `adoptPlanScope` once the real id exists.
+ */
+const DRAFT_SCOPE = "draft";
+let planScope: string = DRAFT_SCOPE;
+
+export function setPlanScope(sessionId?: string | null): void {
+  planScope = sessionId || DRAFT_SCOPE;
+}
+
+export function getPlanScope(): string {
+  return planScope;
+}
+
+/**
+ * Move the draft plan onto the session id the session was just assigned.
+ *
+ * Synchronous on purpose: the rename and the scope change must not be
+ * separated by an await, or a concurrent read can land in the gap where the
+ * draft file has moved but the scope still points at it.
+ */
+export function adoptPlanScope(sessionId: string): void {
+  if (!sessionId || planScope === sessionId) return;
+  if (planScope === DRAFT_SCOPE) {
+    try {
+      renameSync(planFile(DRAFT_SCOPE), planFile(sessionId));
+    } catch {
+      // No draft plan to carry over.
+    }
+  }
+  setPlanScope(sessionId);
+}
+
+function plansDir(): string {
+  return join(planDir(), "plans");
+}
+
+function planFile(scope: string = planScope): string {
+  return join(plansDir(), `${scope}.json`);
+}
+
+export function planFilePath(): string {
+  return planFile();
+}
 
 export async function savePlan(plan: Plan): Promise<string> {
-  await ensureDir(PLAN_DIR);
-  await writeFile(PLAN_FILE, JSON.stringify(plan, null, 2));
-  return PLAN_FILE;
+  const file = planFile();
+  await ensureDir(plansDir());
+  await writeFile(file, JSON.stringify(plan, null, 2));
+  return file;
 }
 
 export async function loadPlan(): Promise<Plan | null> {
   try {
-    const raw = await readFile(PLAN_FILE, "utf-8");
-    return JSON.parse(raw) as Plan;
+    const raw = await readFile(planFile(), "utf-8");
+    const parsed = JSON.parse(raw) as Plan;
+    if (!parsed || !Array.isArray(parsed.steps)) return null;
+    return parsed;
   } catch {
     return null;
   }
 }
 
-export async function clearPlan(): Promise<void> {
+/** True when the plan still has work left — the test for "show this to the user". */
+export function isPlanActive(plan: Plan | null): plan is Plan {
+  return !!plan && plan.steps.some((s) => s.status !== "done" && s.status !== "failed");
+}
+
+export async function clearPlan(scope?: string): Promise<void> {
   try {
     const { unlink } = await import("node:fs/promises");
-    await unlink(PLAN_FILE);
+    await unlink(planFile(scope ?? planScope));
   } catch {}
 }
 
+/**
+ * Make sure the plan directory exists. Deliberately does not create the state
+ * file: an absent file is how `loadPlan` reports "no plan", and writing a
+ * placeholder into a `.json` path only produced a file that failed to parse.
+ */
 export async function ensurePlanFile(): Promise<void> {
-  await ensureDir(PLAN_DIR);
+  await ensureDir(plansDir());
+}
+
+export interface StoredPlan {
+  /** Session id that owns this plan, or "draft" for one not yet written to history. */
+  scope: string;
+  plan: Plan;
+  updatedAt: Date;
+}
+
+/**
+ * Every plan saved for this project, newest first. A plan outlives the session
+ * that made it, so this is how you find one again after moving on.
+ */
+export async function listPlans(): Promise<StoredPlan[]> {
+  let entries: string[];
   try {
-    await readFile(PLAN_FILE, "utf-8");
+    entries = await readdir(plansDir());
   } catch {
-    await writeFile(PLAN_FILE, "# Plan\n\nNo active plan. Use `plan:` prefix or a complex prompt to create one.\n");
+    return [];
   }
+
+  const stored: StoredPlan[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const file = join(plansDir(), entry);
+    try {
+      const [raw, info] = await Promise.all([readFile(file, "utf-8"), stat(file)]);
+      const plan = JSON.parse(raw) as Plan;
+      if (!plan || !Array.isArray(plan.steps)) continue;
+      stored.push({ scope: basename(entry, ".json"), plan, updatedAt: info.mtime });
+    } catch {
+      // Unreadable or corrupt plan files are simply not listed.
+    }
+  }
+  return stored.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+const PLAN_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Drop plans nobody has touched in a month. Completed plans delete themselves,
+ * but abandoned ones would otherwise accumulate one file per session forever.
+ */
+export async function prunePlans(now: number = Date.now()): Promise<void> {
+  const { unlink } = await import("node:fs/promises");
+  for (const { scope, updatedAt } of await listPlans()) {
+    if (scope === planScope) continue;
+    if (now - updatedAt.getTime() < PLAN_MAX_AGE_MS) continue;
+    try {
+      await unlink(planFile(scope));
+    } catch {}
+  }
+}
+
+export interface PlanStepUpdate {
+  plan: Plan;
+  step: PlanStep;
+  doneCount: number;
+  totalCount: number;
+  allDone: boolean;
+}
+
+/**
+ * Apply a status change to one step and move the plan cursor to the next piece
+ * of outstanding work. Shared by the `update_plan` tool and the `/plan` command
+ * so a hand-edited plan behaves exactly like a model-edited one.
+ */
+export async function updatePlanStep(
+  stepNum: number,
+  status: PlanStep["status"],
+): Promise<PlanStepUpdate | { error: string }> {
+  const plan = await loadPlan();
+  if (!plan) return { error: "No active plan found." };
+
+  const step = plan.steps.find((s) => s.id === stepNum);
+  if (!step) return { error: `Step ${stepNum} not found. Plan has ${plan.steps.length} steps.` };
+
+  step.status = status;
+
+  const doneCount = plan.steps.filter((s) => s.status === "done").length;
+  const totalCount = plan.steps.length;
+  const allDone = doneCount === totalCount;
+  plan.currentStep = allDone
+    ? -1
+    : plan.steps.findIndex((s) => s.status === "pending" || s.status === "in_progress");
+
+  await savePlan(plan);
+  return { plan, step, doneCount, totalCount, allDone };
 }
 
 

--- a/source/agent/planner.ts
+++ b/source/agent/planner.ts
@@ -1,5 +1,5 @@
 import { writeFile, readFile, readdir, stat } from "node:fs/promises";
-import { existsSync, renameSync } from "node:fs";
+import { renameSync, statSync } from "node:fs";
 import { basename, dirname, join, parse as parsePath } from "node:path";
 import { ensureDir } from "../utils/fs.js";
 
@@ -25,6 +25,10 @@ let cachedPlanDir: string | undefined;
  * A plan describes a project, not a directory, so it is anchored at the repo
  * root when there is one. Resolving from `process.cwd()` alone meant launching
  * agav from a subdirectory hid the plan that was created one level up.
+ *
+ * Synchronous because `planFilePath()`, `adoptPlanScope()`, and the callers
+ * that build paths from it are all synchronous. The result is cached by cwd
+ * so the filesystem walk only runs once per directory change.
  */
 function planDir(): string {
   const cwd = process.cwd();
@@ -34,9 +38,13 @@ function planDir(): string {
   const { root } = parsePath(cwd);
   let resolved = join(cwd, ".agav");
   while (true) {
-    if (existsSync(join(dir, ".git"))) {
-      resolved = join(dir, ".agav");
-      break;
+    try {
+      if (statSync(join(dir, ".git")).isDirectory()) {
+        resolved = join(dir, ".agav");
+        break;
+      }
+    } catch {
+      // No .git here, keep walking up.
     }
     if (dir === root) break;
     dir = dirname(dir);
@@ -45,6 +53,12 @@ function planDir(): string {
   cachedCwd = cwd;
   cachedPlanDir = resolved;
   return resolved;
+}
+
+/** Force re-resolution on the next call (e.g. after `git init`). */
+export function resetPlanDirCache(): void {
+  cachedCwd = undefined;
+  cachedPlanDir = undefined;
 }
 
 /**
@@ -58,6 +72,10 @@ let planScope: string = DRAFT_SCOPE;
 
 export function setPlanScope(sessionId?: string | null): void {
   planScope = sessionId || DRAFT_SCOPE;
+  // Also invalidate the directory cache so the next operation resolves from
+  // the current cwd — important when tests change directories between calls.
+  cachedCwd = undefined;
+  cachedPlanDir = undefined;
 }
 
 export function getPlanScope(): string {
@@ -126,12 +144,38 @@ export async function clearPlan(scope?: string): Promise<void> {
 }
 
 /**
+ * One-time migration: the old single-file scheme stored plans at
+ * `.agav/.plan-state.json`. Move it to the new per-session directory so
+ * users upgrading with an active plan don't silently lose it.
+ */
+async function migrateOldPlanFile(): Promise<void> {
+  const oldFile = join(planDir(), ".plan-state.json");
+  try {
+    const content = await readFile(oldFile, "utf-8");
+    const plan = JSON.parse(content) as Plan;
+    if (plan && Array.isArray(plan.steps) && plan.steps.length > 0) {
+      const draftFile = planFile(DRAFT_SCOPE);
+      // Only migrate if no draft already exists — don't overwrite a real plan.
+      try { await stat(draftFile); } catch {
+        await ensureDir(plansDir());
+        await writeFile(draftFile, content);
+      }
+    }
+    const { unlink } = await import("node:fs/promises");
+    await unlink(oldFile);
+  } catch {
+    // No old file, or already migrated — nothing to do.
+  }
+}
+
+/**
  * Make sure the plan directory exists. Deliberately does not create the state
  * file: an absent file is how `loadPlan` reports "no plan", and writing a
  * placeholder into a `.json` path only produced a file that failed to parse.
  */
 export async function ensurePlanFile(): Promise<void> {
   await ensureDir(plansDir());
+  await migrateOldPlanFile();
 }
 
 export interface StoredPlan {

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -10,6 +10,7 @@ import { renderMarkdown } from "./components/markdown-text.js";
 import ToolCallDisplay from "./components/tool-call-display.js";
 import ToolConfirm from "./components/tool-confirm.js";
 import ToolDetailPanel from "./components/tool-detail-panel.js";
+import PlanDetailPanel from "./components/plan-detail-panel.js";
 import SubagentDisplay from "./components/subagent-display.js";
 import Spinner from "ink-spinner";
 import type { AgavConfig } from "./config/config.js";
@@ -17,6 +18,7 @@ import type { LLMProvider } from "./providers/types.js";
 import { createProvider } from "./providers/registry.js";
 import type { ContentBlock, InvocationReason } from "./providers/types.js";
 import { useAgent } from "./hooks/use-agent.js";
+import { isInternalUserMessage } from "./agent/internal-prompts.js";
 import { CommandRegistry } from "./commands/registry.js";
 import { saveSession } from "./config/history.js";
 import {
@@ -27,7 +29,7 @@ import { getRandomHint } from "./utils/hints.js";
 import { fileLink } from "./utils/hyperlink.js";
 import { getClipboardImage, type ClipboardImage } from "./utils/clipboard-image.js";
 import { useClipboardImageDetector } from "./hooks/use-paste-handler.js";
-import { KeybindingResolver, formatKeybinding, formatKeybindings, normalizeKeyEvent, type Keybindings } from "./config/keybindings.js";
+import { KeybindingResolver, GLOBAL_ACTIONS, formatKeybinding, formatKeybindings, normalizeKeyEvent, type Keybindings } from "./config/keybindings.js";
 import { getLoopStatus, stopActiveLoop } from "./commands/loop.js";
 import { loadScheduledTasks, cronMatches, markTaskRun } from "./config/scheduler.js";
 import { getSandboxName } from "./utils/sandbox.js";
@@ -69,6 +71,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
     try { return createProvider(config); } catch { return null; }
   }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.vertexAICredentialsPath, config.vertexAILocation, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
   const [showToolDetail, setShowToolDetail] = useState(false);
+  const [showPlanDetail, setShowPlanDetail] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [focusedSubagentId, setFocusedSubagentId] = useState<string | null>(null);
   const [inlineTranscript, setInlineTranscript] = useState(false);
@@ -81,10 +84,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
     exitInk();
   }, [exitInk]);
   const commandRegistryRef = useRef(new CommandRegistry());
-  const keyResolverRef = useRef(new KeybindingResolver(keybindings, [
-    "cancel", "interrupt", "cycleSubagents", "toggleToolDetail", "retryLastTurn",
-    "showKeybindings", "clearScreen", "exit",
-  ]));
+  const keyResolverRef = useRef(new KeybindingResolver(keybindings, GLOBAL_ACTIONS));
 
   const {
     messages,
@@ -251,12 +251,15 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
     const texts: string[] = [];
     for (const msg of resumeMessages) {
       if (msg.role !== "user") continue;
+      // Recalling a prompt the agent wrote to itself is never what the arrow
+      // key is for. "Do Step " is the plan runner's own continuation.
+      if (isInternalUserMessage(msg)) continue;
       if (msg.sourceText) {
         if (!msg.sourceText.startsWith("Do Step ")) texts.push(msg.sourceText);
         continue;
       }
       for (const block of msg.content) {
-        if (block.type === "text" && block.text && !block.text.startsWith("[Earlier conversation") && !block.text.startsWith("Do Step ")) {
+        if (block.type === "text" && block.text && !block.text.startsWith("Do Step ")) {
           texts.push(block.text);
         }
       }
@@ -289,6 +292,12 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   }, [submit]);
 
   const hasSubagents = isLoading && subagentStates.length > 0;
+
+  // Drop the detail view when the plan it was showing is cleared or finished,
+  // so a later plan does not reopen it without being asked.
+  useEffect(() => {
+    if (!activePlan) setShowPlanDetail(false);
+  }, [activePlan]);
 
   useEffect(() => {
     if (!isLoading) {
@@ -336,6 +345,17 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
         return;
       }
     }
+    // Deliberately not gated on `isLoading`: reading the plan mid-run is the
+    // point. It only reads state the panel already renders, so it cannot
+    // interfere with the turn in flight.
+    if (match.action === "togglePlanDetail" && !pendingConfirmation) {
+      if (activePlan) {
+        setShowPlanDetail((prev) => !prev);
+      } else {
+        setSystemMessages([{ id: `sys-${++sysMessageId}`, role: "system", content: "No active plan to show." }]);
+      }
+      return;
+    }
     if (match.action === "retryLastTurn" && !isLoading && !pendingConfirmation && input.length === 0) {
       const lastMessage = [...messages].reverse().find((message) => message.role === "user");
       const lastPrompt = lastMessage?.sourceText ?? lastMessage?.content;
@@ -354,6 +374,10 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
       && !messages.some((message) => message.role === "tool")) {
       exit();
     }
+    // These two read the raw stroke rather than a bound action, so a keybinding
+    // that happens to use the same stroke would otherwise fire both. Ignoring
+    // strokes the resolver already claimed keeps the two schemes from overlapping.
+    if (match.action) return;
     if (key.ctrl && char === "o" && !pendingConfirmation) {
       setShowCompactionSummary((prev) => !prev);
     }
@@ -584,10 +608,16 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
           {(() => {
             const done = activePlan.steps.filter((s) => s.status === "done").length;
             const total = activePlan.steps.length;
-            if (done === total) {
-              return <Text color="green">{`  ✓ All ${total} steps complete`}</Text>;
-            }
-            return <Text dimColor>{`  ${done}/${total} complete`}</Text>;
+            const progress = done === total
+              ? <Text color="green">{`  ✓ All ${total} steps complete`}</Text>
+              : <Text dimColor>{`  ${done}/${total} complete`}</Text>;
+            if (showPlanDetail) return progress;
+            return (
+              <>
+                {progress}
+                <Text dimColor italic>{`  ${formatKeybinding(keybindings, "togglePlanDetail")}: full plan`}</Text>
+              </>
+            );
           })()}
         </Box>
       )}
@@ -645,6 +675,10 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
 
       {showToolDetail && toolMessages.length > 0 && (
         <ToolDetailPanel tools={toolMessages} closeKey={formatKeybinding(keybindings, "toggleToolDetail")} />
+      )}
+
+      {showPlanDetail && activePlan && (
+        <PlanDetailPanel plan={activePlan} closeKey={formatKeybinding(keybindings, "togglePlanDetail")} />
       )}
 
       {!pendingConfirmation && (

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -103,6 +103,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
     mcpPromptCount,
     subagentStates,
     activePlan,
+    refreshPlan,
     submit,
     addDisplayMessage,
     cancel,
@@ -445,6 +446,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
             setSystemMessages([]);
             process.stdout.write("\x1Bc");
           },
+          refreshPlan,
           saveSession: saveNow,
           refreshDisplay,
           loadSession,
@@ -505,7 +507,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
       setPsResponse(undefined);
       setSystemMessages([]);
     },
-    [config, conversation, clearMessages, exit, submit, attachments, tokenUsage, loadedPlugins, mcpServers, mcpResourceCount, mcpPromptCount, runPsQuery, refreshDisplay, loadSession, activateSession, renameSession, sessionId],
+    [config, conversation, clearMessages, refreshPlan, exit, submit, attachments, tokenUsage, loadedPlugins, mcpServers, mcpResourceCount, mcpPromptCount, runPsQuery, refreshDisplay, loadSession, activateSession, renameSession, sessionId],
   );
 
   const displayError = error;

--- a/source/commands/export.ts
+++ b/source/commands/export.ts
@@ -26,7 +26,8 @@ export const exportCommand: SlashCommand = {
       if (msg.role === "user") {
         // Prompts the agent injected to steer itself are not the user speaking,
         // so exporting them under "You" misattributes them.
-        const text = isInternalUserMessage(msg) ? "" : stripTerminalLinks(msg.displayText ?? msg.content
+        if (isInternalUserMessage(msg)) continue;
+        const text = stripTerminalLinks(msg.displayText ?? msg.content
           .filter((b) => b.type === "text")
           .map((b) => b.text)
           .join("\n"));

--- a/source/commands/export.ts
+++ b/source/commands/export.ts
@@ -2,6 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { SlashCommand, CommandResult, CommandContext } from "./types.js";
 import { stripTerminalLinks } from "../utils/hyperlink.js";
+import { isInternalUserMessage } from "../agent/internal-prompts.js";
 
 /** Handles the /export command. */
 export const exportCommand: SlashCommand = {
@@ -23,7 +24,9 @@ export const exportCommand: SlashCommand = {
 
     for (const msg of messages) {
       if (msg.role === "user") {
-        const text = stripTerminalLinks(msg.displayText ?? msg.content
+        // Prompts the agent injected to steer itself are not the user speaking,
+        // so exporting them under "You" misattributes them.
+        const text = isInternalUserMessage(msg) ? "" : stripTerminalLinks(msg.displayText ?? msg.content
           .filter((b) => b.type === "text")
           .map((b) => b.text)
           .join("\n"));

--- a/source/commands/plan.ts
+++ b/source/commands/plan.ts
@@ -1,25 +1,94 @@
-import type { SlashCommand, CommandResult } from "./types.js"
-import { loadPlan, clearPlan } from "../agent/planner.js"
+import type { SlashCommand, CommandResult, CommandContext } from "./types.js"
+import {
+  loadPlan,
+  clearPlan,
+  listPlans,
+  updatePlanStep,
+  planFilePath,
+  getPlanScope,
+  type PlanStep,
+} from "../agent/planner.js"
 
-/** Show the active plan, its progress, or clear it. */
+const STATUSES: PlanStep["status"][] = ["pending", "in_progress", "done", "failed"]
+
+/** Render "3d ago" style ages for the plan list. */
+function relativeAge(when: Date): string {
+  const minutes = Math.max(0, Math.round((Date.now() - when.getTime()) / 60_000))
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 48) return `${hours}h ago`
+  return `${Math.round(hours / 24)}d ago`
+}
+
+/** Show the active plan, list saved ones, update a step, or clear it. */
 export const planCommand: SlashCommand = {
   name: "plan",
   description: "Show or manage the active plan",
-  usage: "Usage: /plan [action]\n\n  /plan          Show the current plan and step status\n  /plan clear    Delete the active plan\n\nPlans are auto-created for complex multi-step tasks.\nUse 'no plan' in your prompt to skip auto-planning.",
-  async execute(args: string): Promise<CommandResult> {
+  usage: "Usage: /plan [action]\n\n  /plan                    Show this session's plan and step status\n  /plan list               List every plan saved for this project\n  /plan <n> <status>       Set step <n> to pending, in_progress, done or failed\n  /plan clear              Delete this session's plan\n\nPlans belong to the session that created them and survive restarts.\nResume that session with 'agav --resume <id>' to pick a plan back up.\nUse 'no plan' in your prompt to skip auto-planning.",
+  async execute(args: string, context: CommandContext): Promise<CommandResult> {
     const sub = args.trim().toLowerCase()
 
     if (sub === "clear") {
       await clearPlan()
+      // The panel renders from hook state, not from disk — tell it to re-read.
+      context.refreshPlan()
       return { type: "message", text: "Plan cleared." }
+    }
+
+    // Plans outlive their session, so there has to be a way to find one again.
+    if (sub === "list") {
+      const stored = await listPlans()
+      if (stored.length === 0) {
+        return { type: "message", text: "No saved plans for this project." }
+      }
+
+      const current = getPlanScope()
+      const lines: string[] = [`Saved plans (${stored.length}):`, ""]
+      for (const { scope, plan, updatedAt } of stored) {
+        const done = plan.steps.filter((s) => s.status === "done").length
+        const marker = scope === current ? "▸" : " "
+        const label = scope === "draft" ? "unsaved session" : scope.slice(0, 8)
+        lines.push(`${marker} ${label}  ${done}/${plan.steps.length}  ${relativeAge(updatedAt)}  ${plan.goal}`)
+      }
+      lines.push("")
+      lines.push("▸ marks this session. Resume another with: agav --resume <id>")
+      return { type: "message", text: lines.join("\n") }
+    }
+
+    // /plan <step> <status> — the only way to correct a plan by hand; without it
+    // step status could only ever be changed by the model.
+    const setMatch = sub.match(/^(\d+)\s+([a-z_]+)$/)
+    if (setMatch) {
+      const stepNum = Number(setMatch[1])
+      const status = setMatch[2] as PlanStep["status"]
+      if (!STATUSES.includes(status)) {
+        return { type: "message", text: `Unknown status '${status}'. Use one of: ${STATUSES.join(", ")}.` }
+      }
+      const result = await updatePlanStep(stepNum, status)
+      if ("error" in result) {
+        return { type: "message", text: result.error }
+      }
+      context.refreshPlan()
+      return {
+        type: "message",
+        text: `Step ${stepNum} marked ${status}. Progress: ${result.doneCount}/${result.totalCount} steps done.`,
+      }
+    }
+
+    if (sub) {
+      return { type: "message", text: planCommand.usage ?? "" }
     }
 
     const plan = await loadPlan()
 
     if (!plan) {
+      const others = (await listPlans()).filter((p) => p.scope !== getPlanScope())
+      const hint = others.length > 0
+        ? `\n\n${others.length} plan(s) saved for this project — see /plan list.`
+        : ""
       return {
         type: "message",
-        text: "No active plan. Send a complex task to auto-create one, or prefix with 'plan:' to force.",
+        text: "No active plan for this session. Send a complex task to auto-create one, or prefix with 'plan:' to force." + hint,
       }
     }
 
@@ -29,10 +98,10 @@ export const planCommand: SlashCommand = {
 
     const doneCount = plan.steps.filter((s) => s.status === "done").length
     const totalCount = plan.steps.length
-    const pct = Math.round((doneCount / totalCount) * 100)
+    const pct = totalCount === 0 ? 0 : Math.round((doneCount / totalCount) * 100)
 
     const barLen = 20
-    const filled = Math.round((doneCount / totalCount) * barLen)
+    const filled = totalCount === 0 ? 0 : Math.round((doneCount / totalCount) * barLen)
     const bar = "█".repeat(filled) + "░".repeat(barLen - filled)
     lines.push(`Progress: [${bar}] ${pct}% (${doneCount}/${totalCount})`)
     lines.push("")
@@ -50,7 +119,8 @@ export const planCommand: SlashCommand = {
     }
 
     lines.push("")
-    lines.push("Use /plan clear to remove this plan.")
+    lines.push(`Saved at ${planFilePath()}`)
+    lines.push("Use /plan <n> <status> to update a step, /plan list to see other plans, or /plan clear to remove this one.")
 
     return { type: "message", text: lines.join("\n") }
   },

--- a/source/commands/plan.ts
+++ b/source/commands/plan.ts
@@ -14,6 +14,7 @@ const STATUSES: PlanStep["status"][] = ["pending", "in_progress", "done", "faile
 /** Render "3d ago" style ages for the plan list. */
 function relativeAge(when: Date): string {
   const minutes = Math.max(0, Math.round((Date.now() - when.getTime()) / 60_000))
+  if (minutes < 1) return "just now"
   if (minutes < 60) return `${minutes}m ago`
   const hours = Math.round(minutes / 60)
   if (hours < 48) return `${hours}h ago`

--- a/source/commands/types.ts
+++ b/source/commands/types.ts
@@ -31,6 +31,8 @@ export interface CommandContext {
   setProvider: (provider: AgavConfig["provider"]) => void
   setEffort: (effort: import("../config/config.js").EffortLevel) => void
   clearMessages: () => void
+  /** Re-read the plan from disk so the on-screen plan panel matches it. */
+  refreshPlan: () => void
   showStatus: (text: string) => void
   saveSession: () => void
   refreshDisplay: () => void

--- a/source/components/input-prompt.tsx
+++ b/source/components/input-prompt.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Box, Text, useInput, useStdin } from "ink";
-import { KeybindingResolver, formatKeybinding, formatUsableKeybinding, normalizeKeyEvent, type Keybindings } from "../config/keybindings.js";
+import { KeybindingResolver, PROMPT_ACTIONS, formatKeybinding, formatUsableKeybinding, normalizeKeyEvent, type Keybindings } from "../config/keybindings.js";
 import { loadPromptHistory, savePromptHistory } from "../config/prompt-history.js";
 import { readdir, realpath } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
@@ -85,10 +85,7 @@ export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemo
   const [fileSuggestions, setFileSuggestions] = useState<FileSuggestion[]>([]);
   const valueRef = useRef(value);
   const cursorPosRef = useRef(cursorPos);
-  const keyResolverRef = useRef(new KeybindingResolver(keybindings, [
-    "cancel", "newline", "submit", "historyUp", "historyDown", "clearInput",
-    "deleteWordBackward", "editLastPrompt", "openCommandPalette",
-  ]));
+  const keyResolverRef = useRef(new KeybindingResolver(keybindings, PROMPT_ACTIONS));
   valueRef.current = value;
   cursorPosRef.current = cursorPos;
 

--- a/source/components/message-list.tsx
+++ b/source/components/message-list.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Static, Text } from "ink";
 import { renderMarkdown } from "./markdown-text.js";
-import { getToolLabel, getToolSummary } from "../utils/tool-labels.js";
+import { getToolLabel, getToolSummary, isBookkeepingTool } from "../utils/tool-labels.js";
 import { getTheme } from "../config/theme.js";
 import { fileLink } from "../utils/hyperlink.js";
 import type { DiffLine } from "../utils/diff.js";
@@ -122,12 +122,16 @@ function ToolResultLine({ message }: { message: DisplayMessage }) {
   const preview = lines[0]?.slice(0, 120) ?? "";
   const lineCount = lines.length;
   const suffix = lineCount > 1 ? ` (${lineCount} lines)` : "";
+  // Progress ticks stay in the scrollback for the rest of the session, so this
+  // is where they most need to read as notes rather than as work. A failed one
+  // still goes red — that one is worth stopping on.
+  const muted = !message.isError && !!message.toolName && isBookkeepingTool(message.toolName);
 
   return (
     <Box flexDirection="column">
       <Text>
         <Text dimColor>{"  └─ "}</Text>
-        <Text bold color={message.isError ? "red" : "yellow"}>{label}</Text>
+        <Text bold={!muted} color={message.isError ? "red" : muted ? undefined : "yellow"} dimColor={muted}>{label}</Text>
         {summary ? <Text dimColor> {summary}</Text> : null}
         <Text dimColor>{suffix}</Text>
       </Text>

--- a/source/components/plan-detail-panel.tsx
+++ b/source/components/plan-detail-panel.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { Plan } from "../agent/planner.js";
+import { terminalRelativePaths } from "../utils/display-path.js";
+
+interface Props {
+  plan: Plan;
+  closeKey: string;
+}
+
+const BAR_LENGTH = 20;
+
+const STEP_ICON: Record<Plan["steps"][number]["status"], string> = {
+  done: "✓",
+  in_progress: "◉",
+  failed: "✗",
+  pending: "○",
+};
+
+const STEP_COLOR: Record<Plan["steps"][number]["status"], string | undefined> = {
+  done: "green",
+  in_progress: "cyan",
+  failed: "red",
+  pending: undefined,
+};
+
+/**
+ * The full plan — descriptions and verify commands included — so the steps can
+ * be read without leaving the session for `.agav/plans`. Purely a view over the
+ * plan already in state: it never touches disk and never interacts with the
+ * agent loop, so opening it mid-run cannot disturb the run.
+ */
+export default function PlanDetailPanel({ plan, closeKey }: Props) {
+  const done = plan.steps.filter((step) => step.status === "done").length;
+  const total = plan.steps.length;
+  const filled = total === 0 ? 0 : Math.round((done / total) * BAR_LENGTH);
+  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} marginBottom={1}>
+      <Text bold dimColor>Plan Details <Text>({closeKey} to close)</Text></Text>
+      <Text bold>{terminalRelativePaths(plan.goal)}</Text>
+      <Text dimColor>
+        {`[${"█".repeat(filled)}${"░".repeat(BAR_LENGTH - filled)}] ${pct}% (${done}/${total})`}
+      </Text>
+
+      {plan.steps.map((step) => {
+        // The cursor only means anything while there is outstanding work;
+        // `currentStep` is -1 once every step has been closed out.
+        const isCurrent = plan.currentStep >= 0 && plan.steps[plan.currentStep]?.id === step.id;
+        return (
+          <Box key={step.id} flexDirection="column" marginTop={1}>
+            <Text color={STEP_COLOR[step.status] as any} bold={isCurrent}>
+              {`${STEP_ICON[step.status]} Step ${step.id}: ${terminalRelativePaths(step.title)}`}
+              {isCurrent ? "  ← current" : ""}
+            </Text>
+            {step.description && (
+              <Text dimColor>{`    ${terminalRelativePaths(step.description)}`}</Text>
+            )}
+            {step.verifyCommand && (
+              <Text dimColor>{`    verify: ${terminalRelativePaths(step.verifyCommand)}`}</Text>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/source/components/plan-detail-panel.tsx
+++ b/source/components/plan-detail-panel.tsx
@@ -50,7 +50,7 @@ export default function PlanDetailPanel({ plan, closeKey }: Props) {
         const isCurrent = plan.currentStep >= 0 && plan.steps[plan.currentStep]?.id === step.id;
         return (
           <Box key={step.id} flexDirection="column" marginTop={1}>
-            <Text color={STEP_COLOR[step.status] as any} bold={isCurrent}>
+            <Text color={STEP_COLOR[step.status]} bold={isCurrent}>
               {`${STEP_ICON[step.status]} Step ${step.id}: ${terminalRelativePaths(step.title)}`}
               {isCurrent ? "  ← current" : ""}
             </Text>

--- a/source/components/subagent-display.tsx
+++ b/source/components/subagent-display.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import type { SubagentProgress } from "../agent/subagent-types.js";
-import { getToolLabel, getToolSummary } from "../utils/tool-labels.js";
+import { getToolLabel, getToolSummary, isBookkeepingTool } from "../utils/tool-labels.js";
 import { terminalRelativePaths, terminalToolValue } from "../utils/display-path.js";
 import type { DiffLine } from "../utils/diff.js";
 
@@ -123,6 +123,7 @@ function DetailView({ progress, elapsed }: {
         const branch = isLast ? "└─" : "├─";
         const label = getToolLabel(tc.toolName);
         const summary = getToolSummary(tc.toolName, tc.input);
+        const bookkeeping = isBookkeepingTool(tc.toolName);
 
         return (
           <Box key={`${tc.toolName}-${i}`} flexDirection="column">
@@ -135,7 +136,7 @@ function DetailView({ progress, elapsed }: {
               ) : (
                 <Text color="green">{"✓ "}</Text>
               )}
-              <Text bold color="yellow">{label}</Text>
+              <Text bold={!bookkeeping} color={bookkeeping ? undefined : "yellow"} dimColor={bookkeeping}>{label}</Text>
               {summary ? <Text dimColor> {summary}</Text> : null}
             </Box>
             <ToolInput input={tc.input} argsJson={tc.argsJson} />

--- a/source/components/tool-call-display.tsx
+++ b/source/components/tool-call-display.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
-import { getToolLabel, getToolSummary } from "../utils/tool-labels.js";
+import { getToolLabel, getToolSummary, isBookkeepingTool } from "../utils/tool-labels.js";
 import type { DiffLine } from "../utils/diff.js";
 
 /** Describes a tool invocation shown in the UI. */
@@ -23,6 +23,9 @@ interface Props {
 export default function ToolCallDisplay({ toolCall }: Props) {
   const label = getToolLabel(toolCall.toolName);
   const summary = getToolSummary(toolCall.toolName, toolCall.input);
+  // A progress tick carries the same bold yellow as an edit or a shell command,
+  // which is what makes it look like the agent doing something to the project.
+  const bookkeeping = isBookkeepingTool(toolCall.toolName);
 
   return (
     <Box>
@@ -37,7 +40,7 @@ export default function ToolCallDisplay({ toolCall }: Props) {
       ) : (
         <Text color="green">{"✓ "}</Text>
       )}
-      <Text bold color="yellow">{label}</Text>
+      <Text bold={!bookkeeping} color={bookkeeping ? undefined : "yellow"} dimColor={bookkeeping}>{label}</Text>
       {summary ? <Text dimColor> {summary}</Text> : null}
     </Box>
   );

--- a/source/config/history.ts
+++ b/source/config/history.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import crypto from "node:crypto";
 import type { Message } from "../providers/types.js";
 import { getAgavDir } from "./config.js";
+import { isInternalUserMessage } from "../agent/internal-prompts.js";
 import { ensureDir } from "../utils/fs.js";
 
 export interface SessionTokenUsage {
@@ -37,7 +38,11 @@ function generateId(): string {
 
 /** Derive a short human-readable title from the first user message in a session. */
 function extractTitle(messages: Message[]): string {
-  const firstUser = messages.find((m) => m.role === "user");
+  // A session whose history was compacted starts with the summary the agent
+  // wrote, not with anything the user said — titling it from that names the
+  // session after its own boilerplate.
+  const firstUser = messages.find((m) => m.role === "user" && !isInternalUserMessage(m))
+    ?? messages.find((m) => m.role === "user");
   if (!firstUser) return "Empty session";
   if (firstUser.sourceText) return firstUser.sourceText.slice(0, 80);
   if (firstUser.displayText) return firstUser.displayText.slice(0, 80);

--- a/source/config/keybindings.ts
+++ b/source/config/keybindings.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 export type KeybindingAction =
   | "cancel"
   | "toggleToolDetail"
+  | "togglePlanDetail"
   | "cycleSubagents"
   | "newline"
   | "submit"
@@ -25,6 +26,7 @@ export type Keybindings = Record<KeybindingAction, string[]>;
 const ACTIONS: KeybindingAction[] = [
   "cancel",
   "toggleToolDetail",
+  "togglePlanDetail",
   "cycleSubagents",
   "newline",
   "submit",
@@ -41,9 +43,28 @@ const ACTIONS: KeybindingAction[] = [
   "exit",
 ];
 
+/**
+ * Which consumer resolves which action. A resolver only reports actions it was
+ * constructed with, so an action missing from both lists is bound in config yet
+ * dead at the keyboard. Keep them exhaustive over `ACTIONS` — a test enforces it.
+ */
+export const GLOBAL_ACTIONS: KeybindingAction[] = [
+  "cancel", "interrupt", "cycleSubagents", "toggleToolDetail", "togglePlanDetail",
+  "retryLastTurn", "showKeybindings", "clearScreen", "exit",
+];
+
+export const PROMPT_ACTIONS: KeybindingAction[] = [
+  "cancel", "newline", "submit", "historyUp", "historyDown", "clearInput",
+  "deleteWordBackward", "editLastPrompt", "openCommandPalette",
+];
+
 export const DEFAULT_KEYBINDINGS: Keybindings = {
   cancel: ["escape"],
   toggleToolDetail: ["ctrl+d"],
+  // Modified rather than a bare "v": the prompt keeps focus while the agent
+  // works, so an unmodified letter is typed into it instead of reaching a
+  // shortcut. Ctrl+G because Ctrl+V is the clipboard-image paste.
+  togglePlanDetail: ["ctrl+g"],
   cycleSubagents: ["tab"],
   // Shift+Enter only survives an enhanced keyboard protocol; the other two are
   // the fallbacks every terminal can send. See normalizeKeyEvent below.

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -1,10 +1,11 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { DisplayMessage } from "../components/message-list.js";
 import type { ToolCallInfo } from "../components/tool-call-display.js";
-import type { LLMProvider, ContentBlock, InvocationReason } from "../providers/types.js";
+import type { LLMProvider, ContentBlock, InvocationReason, Message } from "../providers/types.js";
 import type { AgavConfig } from "../config/config.js";
 import { ConversationState } from "../agent/conversation.js";
 import { runAgentLoop } from "../agent/loop.js";
+import { isInternalUserMessage } from "../agent/internal-prompts.js";
 import { createToolRegistry } from "../tools/registry-factory.js";
 import type { ToolRegistry } from "../tools/registry.js";
 import { saveSession, type SessionRecord } from "../config/history.js";
@@ -39,6 +40,45 @@ let messageId = 0;
 /** Generate incremental display ids so transient UI rows have stable React keys. */
 function nextId(): string {
   return String(++messageId);
+}
+
+/**
+ * Rebuild the visible transcript from the conversation the model sees — on
+ * resume, and whenever the screen is redrawn. The two are not the same list:
+ * the conversation also carries prompts the agent wrote to steer itself, and
+ * carries the user's turns as they were sent rather than as they were typed.
+ */
+export function messagesToDisplay(msgs: Message[]): DisplayMessage[] {
+  const displayMsgs: DisplayMessage[] = [];
+  for (const msg of msgs) {
+    // Prompts the agent injected to steer itself are user turns to the model
+    // only; rebuilding the transcript from them is what made a resumed session
+    // quote its own instructions back at the user.
+    if (isInternalUserMessage(msg)) continue;
+    // Falling through to the raw blocks would show the text as sent rather
+    // than as typed — @mentions expanded, per-turn context appended.
+    const rendered = msg.displayText ?? msg.sourceText;
+    if (rendered) {
+      displayMsgs.push({
+        id: nextId(),
+        role: msg.role === "user" ? "user" : "assistant",
+        content: rendered,
+        sourceText: msg.sourceText,
+        invocationReason: msg.invocationReason,
+      });
+      continue;
+    }
+    for (const block of msg.content) {
+      if (block.type === "text" && block.text) {
+        displayMsgs.push({
+          id: nextId(),
+          role: msg.role === "user" ? "user" : "assistant",
+          content: block.text,
+        });
+      }
+    }
+  }
+  return displayMsgs;
 }
 
 /**
@@ -148,32 +188,6 @@ export function useAgent(
   const confirmationQueueRef = useRef(new ConfirmationQueue());
   const conversationRef = useRef(new ConversationState());
   conversationRef.current.setModel(config.model);
-
-  function messagesToDisplay(msgs: import("../providers/types.js").Message[]): DisplayMessage[] {
-    const displayMsgs: DisplayMessage[] = [];
-    for (const msg of msgs) {
-      if (msg.displayText) {
-        displayMsgs.push({
-          id: nextId(),
-          role: msg.role === "user" ? "user" : "assistant",
-          content: msg.displayText,
-          sourceText: msg.sourceText,
-          invocationReason: msg.invocationReason,
-        });
-        continue;
-      }
-      for (const block of msg.content) {
-        if (block.type === "text" && block.text) {
-          displayMsgs.push({
-            id: nextId(),
-            role: msg.role === "user" ? "user" : "assistant",
-            content: block.text,
-          });
-        }
-      }
-    }
-    return displayMsgs;
-  }
 
   const refreshDisplay = useCallback(() => {
     process.stdout.write("\x1Bc");

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -14,6 +14,10 @@ import {
   savePlan,
   loadPlan,
   clearPlan,
+  isPlanActive,
+  setPlanScope,
+  adoptPlanScope,
+  prunePlans,
   formatPlanForPrompt,
   ensurePlanFile,
   type Plan,
@@ -36,6 +40,12 @@ let messageId = 0;
 function nextId(): string {
   return String(++messageId);
 }
+
+/**
+ * How many times the plan auto-continue may resubmit a step that has not moved
+ * off `pending`/`in_progress` before it stops and hands control back.
+ */
+const MAX_PLAN_STEP_ATTEMPTS = 3;
 
 import type { ConfirmResult } from "../agent/loop.js";
 import type { DiffLine } from "../utils/diff.js";
@@ -73,6 +83,7 @@ interface UseAgentReturn {
   mcpPromptCount: number;
   subagentStates: SubagentProgress[];
   activePlan: Plan | null;
+  refreshPlan: () => void;
   submit: (input: string, extraBlocks?: ContentBlock[], displayText?: string, followUpMessages?: DisplayMessage[], invocationReason?: InvocationReason) => Promise<boolean>;
   addDisplayMessage: (msg: DisplayMessage) => void;
   cancel: () => void;
@@ -126,6 +137,12 @@ export function useAgent(
   const toolInputsRef = useRef(new Map<string, Record<string, unknown>>());
   const turnCountRef = useRef(0);
   const [planContinueMsg, setPlanContinueMsg] = useState<string | null>(null);
+  // Tracks how many times the plan auto-continue has resubmitted the same step
+  // without it completing, so a step that can never finish cannot loop forever.
+  const planContinueRef = useRef<{ stepId: number; attempts: number }>({ stepId: -1, attempts: 0 });
+  // "Always" is a session decision, not a per-turn one; the loop's own
+  // permission mode is rebuilt on every turn, so remember it out here.
+  const sessionPermissionModeRef = useRef<AgavConfig["permissionMode"] | undefined>(undefined);
   const resumedRef = useRef(false);
 
   const confirmationQueueRef = useRef(new ConfirmationQueue());
@@ -235,21 +252,24 @@ export function useAgent(
     mcpManagerRef.current.setOnChange(syncMcpState);
 
     (async () => {
-      // Clear stale/completed plans; only show active plans on resume
-      if (resumeMessages && resumeMessages.length > 0) {
-        await ensurePlanFile();
+      // Restore this session's plan. Resuming a session brings its own plan
+      // back; a brand-new session starts on the draft slot, so any plan left
+      // there by the previous unsaved session is discarded rather than shown.
+      setPlanScope(sessionIdRef.current);
+      await ensurePlanFile();
+      if (!sessionIdRef.current) {
+        await clearPlan();
+      } else {
         const existing = await loadPlan();
         if (existing) {
-          const allDone = existing.steps.every((s) => s.status === "done" || s.status === "failed");
-          if (allDone) {
-            await clearPlan();
-          } else {
+          if (isPlanActive(existing)) {
             setActivePlan(existing);
+          } else {
+            await clearPlan();
           }
         }
-      } else {
-        await clearPlan();
       }
+      prunePlans().catch(() => {});
 
       // Load plugins
       const pluginTools = await loadPlugins();
@@ -333,11 +353,30 @@ export function useAgent(
     setSessionId(undefined);
     sessionNameRef.current = undefined;
     setSessionName(undefined);
+    sessionPermissionModeRef.current = undefined;
+    planContinueRef.current = { stepId: -1, attempts: 0 };
+    // Back to the draft slot, and drop whatever the last unsaved session left
+    // there so the new session does not inherit a plan it never made.
+    setPlanScope(null);
+    setActivePlan(null);
+    clearPlan().catch(() => {});
     setTranscriptRevision((revision) => revision + 1);
+  }, []);
+
+  /**
+   * Re-read the plan for the current scope into the panel. Slash commands write
+   * straight to disk, so without this the panel keeps rendering a plan the user
+   * has already cleared or edited.
+   */
+  const refreshPlan = useCallback(() => {
+    loadPlan()
+      .then((plan) => setActivePlan(isPlanActive(plan) ? plan : null))
+      .catch(() => {});
   }, []);
 
   /** Resolve the oldest pending tool confirmation with the user's decision. */
   const confirmTool = useCallback((choice: ConfirmResult) => {
+    if (choice === "always") sessionPermissionModeRef.current = "auto-accept";
     confirmationQueueRef.current.resolve(choice);
   }, []);
 
@@ -368,7 +407,11 @@ export function useAgent(
         merged,
         conversationRef.current.wasCompacted,
         sessionNameRef.current,
-      ).then((id) => { sessionIdRef.current = id; setSessionId(id); }).catch(() => {});
+      ).then((id) => {
+        sessionIdRef.current = id;
+        setSessionId(id);
+        adoptPlanScope(id);
+      }).catch(() => {});
       return merged;
     });
   }, [config.model, config.provider]);
@@ -381,8 +424,14 @@ export function useAgent(
     setSessionName(session.name);
     setTokenUsage(session.tokenUsage ?? { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 });
     setError(null);
+    // Show the plan belonging to the session being loaded — not whichever plan
+    // happened to be on screen, and without deleting either one.
+    planContinueRef.current = { stepId: -1, attempts: 0 };
     setActivePlan(null);
-    clearPlan().catch(() => {});
+    setPlanScope(session.id);
+    loadPlan()
+      .then((plan) => setActivePlan(isPlanActive(plan) ? plan : null))
+      .catch(() => {});
     refreshDisplay();
   }, [refreshDisplay]);
 
@@ -391,6 +440,10 @@ export function useAgent(
     setSessionId(id);
     sessionNameRef.current = name;
     setSessionName(name);
+    setPlanScope(id);
+    loadPlan()
+      .then((plan) => setActivePlan(isPlanActive(plan) ? plan : null))
+      .catch(() => {});
   }, []);
 
   const renameSession = useCallback((name: string) => {
@@ -432,6 +485,9 @@ export function useAgent(
       // If the plan is still active, turn_complete will reload it.
       if (!displayText) {
         setActivePlan(null);
+        // A real message from the user is fresh input for the current step, so
+        // the no-progress budget starts over.
+        planContinueRef.current = { stepId: -1, attempts: 0 };
       }
 
       setMessages((prev) => [
@@ -485,18 +541,14 @@ export function useAgent(
           if (volatileCtx) turnContextParts.push(volatileCtx);
 
           const existingPlan = await loadPlan();
-          const hasActivePlan = existingPlan && existingPlan.steps.some((s) => s.status !== "done");
+          // A plan-worthy prompt at the start of a fresh conversation supersedes
+          // whatever plan is on disk; anything else carries the existing one
+          // forward. The superseded plan is only deleted once a replacement has
+          // actually been saved, so a failed re-plan does not lose it.
+          const supersedesPlan = shouldAutoPlan(trimmed) && conversationRef.current.length <= 1;
+          const carriedPlan = !supersedesPlan && isPlanActive(existingPlan) ? existingPlan : null;
 
-          // Clear stale plan if user is asking for something completely different
-          if (hasActivePlan && shouldAutoPlan(trimmed) && conversationRef.current.length <= 1) {
-            const { clearPlan } = await import("../agent/planner.js");
-            await clearPlan();
-          }
-
-          const planAfterClear = await loadPlan();
-          const stillHasPlan = planAfterClear && planAfterClear.steps.some((s) => s.status !== "done");
-
-          if (shouldAutoPlan(trimmed) && !stillHasPlan) {
+          if (shouldAutoPlan(trimmed) && !carriedPlan) {
             setMessages((prev) => [
               ...prev,
               { id: nextId(), role: "system", content: "Creating plan..." },
@@ -536,47 +588,56 @@ export function useAgent(
             try {
               // Extract JSON from response (might be wrapped in markdown)
               const jsonMatch = planJson.match(/\{[\s\S]*\}/);
-              if (jsonMatch) {
-                const parsed = JSON.parse(jsonMatch[0]);
-                const plan: Plan = {
-                  goal: parsed.goal ?? trimmed,
-                  steps: (parsed.steps ?? []).map((s: any, i: number) => ({
-                    id: s.id ?? i + 1,
-                    title: String(s.title ?? ""),
-                    description: String(s.description ?? ""),
-                    status: "pending" as const,
-                    verifyCommand: s.verifyCommand || undefined,
-                  })),
-                  createdAt: new Date().toISOString(),
-                  currentStep: 0,
-                };
+              if (!jsonMatch) throw new Error("no JSON object in planning response");
 
-                await savePlan(plan);
-                setActivePlan(plan);
-                const planText = formatPlanForPrompt(plan);
+              const parsed = JSON.parse(jsonMatch[0]);
+              const plan: Plan = {
+                goal: parsed.goal ?? trimmed,
+                steps: (parsed.steps ?? []).map((s: any, i: number) => ({
+                  id: s.id ?? i + 1,
+                  title: String(s.title ?? ""),
+                  description: String(s.description ?? ""),
+                  status: "pending" as const,
+                  verifyCommand: s.verifyCommand || undefined,
+                })),
+                createdAt: new Date().toISOString(),
+                currentStep: 0,
+              };
+              // A stepless plan is indistinguishable from a finished one, so
+              // treat it as a failed parse rather than saving it over a good plan.
+              if (plan.steps.length === 0) throw new Error("planning response had no steps");
 
-                setMessages((prev) => [
-                  ...prev,
-                  {
-                    id: nextId(),
-                    role: "system",
-                    content: `Plan created: ${plan.goal} (${plan.steps.length} steps)`,
-                  },
-                ]);
+              await savePlan(plan);
+              planContinueRef.current = { stepId: -1, attempts: 0 };
+              setActivePlan(plan);
 
-                turnContextParts.push(planText);
-              }
-            } catch {
               setMessages((prev) => [
                 ...prev,
-                { id: nextId(), role: "system", content: "Plan creation failed — proceeding without a plan." },
+                {
+                  id: nextId(),
+                  role: "system",
+                  content: `Plan created: ${plan.goal} (${plan.steps.length} steps)`,
+                },
+              ]);
+
+              turnContextParts.push(formatPlanForPrompt(plan));
+            } catch {
+              // Nothing was saved, so any superseded plan is still on disk.
+              const kept = isPlanActive(existingPlan);
+              if (kept) setActivePlan(existingPlan);
+              setMessages((prev) => [
+                ...prev,
+                {
+                  id: nextId(),
+                  role: "system",
+                  content: kept
+                    ? "Plan creation failed — keeping the previous plan. Use /plan to view it."
+                    : "Plan creation failed — proceeding without a plan.",
+                },
               ]);
             }
-          } else {
-            // Inject active plan if one exists
-            if (stillHasPlan && planAfterClear) {
-              turnContextParts.push(formatPlanForPrompt(planAfterClear));
-            }
+          } else if (carriedPlan) {
+            turnContextParts.push(formatPlanForPrompt(carriedPlan));
           }
 
           // Attach volatile context to the tail of this turn's user message. It is
@@ -600,7 +661,7 @@ export function useAgent(
             maxIterations: config.maxIterations,
             signal: abortController.signal,
             confirmTool: confirmToolCallback,
-            permissionMode: config.permissionMode,
+            permissionMode: sessionPermissionModeRef.current ?? config.permissionMode,
             allowedTools: config.allowedTools,
             hooks: config.hooks,
           });
@@ -750,7 +811,13 @@ export function useAgent(
                     currentUsage,
                     conversationRef.current.wasCompacted,
                     sessionNameRef.current,
-                  ).then((id) => { sessionIdRef.current = id; setSessionId(id); }).catch(() => {});
+                  ).then((id) => {
+                    sessionIdRef.current = id;
+                    setSessionId(id);
+                    // Re-key the plan the moment this session gets an identity,
+                    // so it is still findable after the session ends.
+                    adoptPlanScope(id);
+                  }).catch(() => {});
                   return currentUsage;
                 });
                 saveSessionState(
@@ -765,18 +832,47 @@ export function useAgent(
                 }).catch(() => {});
 
                 // Auto-continue if the active plan has pending steps
-                loadPlan().then((latestPlan) => {
+                loadPlan().then(async (latestPlan) => {
                   if (!latestPlan) return;
                   const pendingSteps = latestPlan.steps.filter((s) => s.status === "pending" || s.status === "in_progress");
-                  if (pendingSteps.length > 0) {
-                    setActivePlan(latestPlan);
-                    const next = pendingSteps[0]!;
-                    setPlanContinueMsg(`Do Step ${next.id} only: ${next.title}. Mark it in_progress, do the work, mark it done, then end your response silently — no commentary about stopping or pausing.`);
-                  } else {
+                  if (pendingSteps.length === 0) {
                     // Plan is complete — clear display and delete the file
+                    planContinueRef.current = { stepId: -1, attempts: 0 };
                     setActivePlan(null);
-                    import("../agent/planner.js").then((m) => m.clearPlan()).catch(() => {});
+                    await clearPlan().catch(() => {});
+                    return;
                   }
+
+                  const next = pendingSteps[0]!;
+                  // A step only leaves the pending list once the model marks it
+                  // done or failed. If it never can — the user declined the tool
+                  // it needs, say — resubmitting it forever re-asks for the same
+                  // confirmation on every turn. Give up after a few tries.
+                  const tracker = planContinueRef.current;
+                  tracker.attempts = tracker.stepId === next.id ? tracker.attempts + 1 : 1;
+                  tracker.stepId = next.id;
+
+                  if (tracker.attempts > MAX_PLAN_STEP_ATTEMPTS) {
+                    next.status = "failed";
+                    latestPlan.currentStep = latestPlan.steps.findIndex(
+                      (s) => s.status === "pending" || s.status === "in_progress",
+                    );
+                    await savePlan(latestPlan).catch(() => {});
+                    planContinueRef.current = { stepId: -1, attempts: 0 };
+                    setActivePlan(latestPlan);
+                    setMessages((prev) => [
+                      ...prev,
+                      {
+                        id: nextId(),
+                        role: "system",
+                        content: `Plan paused: step ${next.id} ("${next.title}") made no progress after ${MAX_PLAN_STEP_ATTEMPTS} attempts and has been marked failed. Send a message to carry on, or use /plan clear to drop the plan.`,
+                      },
+                    ]);
+                    return;
+                  }
+
+                  setActivePlan(latestPlan);
+                  setPlanContinueMsg(`Do Step ${next.id} only: ${next.title}. Mark it in_progress, do the work, mark it done, then end your response silently — no commentary about stopping or pausing.`);
                 }).catch(() => {});
                 break;
 
@@ -864,6 +960,7 @@ export function useAgent(
     mcpPromptCount,
     subagentStates,
     activePlan,
+    refreshPlan,
     submit,
     addDisplayMessage,
     cancel,

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -182,7 +182,10 @@ export function useAgent(
   const planContinueRef = useRef<{ stepId: number; attempts: number }>({ stepId: -1, attempts: 0 });
   // "Always" is a session decision, not a per-turn one; the loop's own
   // permission mode is rebuilt on every turn, so remember it out here.
+  // Separate concern from plans — fixes the "always approve" choice not
+  // persisting across turns within the same session.
   const sessionPermissionModeRef = useRef<AgavConfig["permissionMode"] | undefined>(undefined);
+  const resetPlanContinue = () => { planContinueRef.current = { stepId: -1, attempts: 0 }; };
   const resumedRef = useRef(false);
 
   const confirmationQueueRef = useRef(new ConfirmationQueue());
@@ -368,7 +371,7 @@ export function useAgent(
     sessionNameRef.current = undefined;
     setSessionName(undefined);
     sessionPermissionModeRef.current = undefined;
-    planContinueRef.current = { stepId: -1, attempts: 0 };
+    resetPlanContinue();
     // Back to the draft slot, and drop whatever the last unsaved session left
     // there so the new session does not inherit a plan it never made.
     setPlanScope(null);
@@ -440,7 +443,7 @@ export function useAgent(
     setError(null);
     // Show the plan belonging to the session being loaded — not whichever plan
     // happened to be on screen, and without deleting either one.
-    planContinueRef.current = { stepId: -1, attempts: 0 };
+    resetPlanContinue();
     setActivePlan(null);
     setPlanScope(session.id);
     loadPlan()
@@ -501,7 +504,7 @@ export function useAgent(
         setActivePlan(null);
         // A real message from the user is fresh input for the current step, so
         // the no-progress budget starts over.
-        planContinueRef.current = { stepId: -1, attempts: 0 };
+        resetPlanContinue();
       }
 
       setMessages((prev) => [
@@ -622,7 +625,7 @@ export function useAgent(
               if (plan.steps.length === 0) throw new Error("planning response had no steps");
 
               await savePlan(plan);
-              planContinueRef.current = { stepId: -1, attempts: 0 };
+              resetPlanContinue();
               setActivePlan(plan);
 
               setMessages((prev) => [
@@ -851,7 +854,7 @@ export function useAgent(
                   const pendingSteps = latestPlan.steps.filter((s) => s.status === "pending" || s.status === "in_progress");
                   if (pendingSteps.length === 0) {
                     // Plan is complete — clear display and delete the file
-                    planContinueRef.current = { stepId: -1, attempts: 0 };
+                    resetPlanContinue();
                     setActivePlan(null);
                     await clearPlan().catch(() => {});
                     return;
@@ -872,7 +875,7 @@ export function useAgent(
                       (s) => s.status === "pending" || s.status === "in_progress",
                     );
                     await savePlan(latestPlan).catch(() => {});
-                    planContinueRef.current = { stepId: -1, attempts: 0 };
+                    resetPlanContinue();
                     setActivePlan(latestPlan);
                     setMessages((prev) => [
                       ...prev,

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -10,6 +10,7 @@ import { loadSessionState, markCleanExit } from "./config/session-state.js";
 import { loadTheme } from "./config/theme.js";
 import { ConversationState } from "./agent/conversation.js";
 import { runAgentLoop } from "./agent/loop.js";
+import { NO_EDITS_PROMPT, schemaRetryPrompt } from "./agent/internal-prompts.js";
 import { createToolRegistry } from "./tools/registry-factory.js";
 import { getToolLabel } from "./utils/tool-labels.js";
 import { loadKeybindings } from "./config/keybindings.js";
@@ -280,9 +281,7 @@ export async function runPipeMode(
 
       // Re-prompt: agent analyzed but didn't edit
       process.stderr.write(`  ${icons.warning} No edits made — re-prompting (attempt ${attempt + 2}/${maxRetries + 1})...\n`);
-      conversation.addUserMessage(
-        "You analyzed the code but did not make any changes. Now write the actual fix. Use edit_file or write_file to modify the source code. Do not just explain — implement the fix."
-      );
+      conversation.addInternalUserMessage(NO_EDITS_PROMPT);
     }
 
     return { finalText, exitCode, wroteStreamText };
@@ -305,9 +304,7 @@ export async function runPipeMode(
     if (!validation.valid) {
       const details = formatValidationErrors(validation);
       process.stderr.write(`Schema validation failed; retrying once: ${details}\n`);
-      conversation.addUserMessage(
-        `Your previous response was invalid. ${details}\nCorrect it and return ONLY valid JSON matching the required schema, with no markdown fences or commentary.`,
-      );
+      conversation.addInternalUserMessage(schemaRetryPrompt(details));
       result = await runTurn(false);
       if (result.exitCode !== 0) return result.exitCode;
       validation = validateOutput(result.finalText, validate);

--- a/source/providers/types.ts
+++ b/source/providers/types.ts
@@ -29,6 +29,12 @@ export interface Message {
   displayText?: string;
   sourceText?: string;
   invocationReason?: InvocationReason;
+  /**
+   * A user turn the agent injected to steer itself rather than one the user
+   * typed. The model has to see it as a user turn, so it cannot be told apart
+   * by role alone — but the transcript must never attribute it to the user.
+   */
+  internal?: boolean;
 }
 
 export type StreamEvent =

--- a/source/tools/plan.ts
+++ b/source/tools/plan.ts
@@ -1,5 +1,5 @@
 import type { ToolDefinition, ToolResult } from "./types.js";
-import { loadPlan, savePlan } from "../agent/planner.js";
+import { updatePlanStep } from "../agent/planner.js";
 
 export const updatePlanTool: ToolDefinition = {
   schema: {
@@ -27,27 +27,12 @@ export const updatePlanTool: ToolDefinition = {
     const stepNum = Number(input.step);
     const status = String(input.status) as "in_progress" | "done" | "failed";
 
-    const plan = await loadPlan();
-    if (!plan) {
-      return { output: "No active plan found.", isError: true };
+    const result = await updatePlanStep(stepNum, status);
+    if ("error" in result) {
+      return { output: result.error, isError: true };
     }
 
-    const step = plan.steps.find((s) => s.id === stepNum);
-    if (!step) {
-      return { output: `Step ${stepNum} not found. Plan has ${plan.steps.length} steps.`, isError: true };
-    }
-
-    step.status = status;
-
-    // Advance currentStep
-    const doneCount = plan.steps.filter((s) => s.status === "done").length;
-    const totalCount = plan.steps.length;
-    const allDone = doneCount === totalCount;
-    plan.currentStep = allDone
-      ? -1
-      : plan.steps.findIndex((s) => s.status === "pending" || s.status === "in_progress");
-
-    await savePlan(plan);
+    const { doneCount, totalCount, allDone } = result;
 
     return {
       output: allDone

--- a/source/utils/hints.ts
+++ b/source/utils/hints.ts
@@ -62,6 +62,7 @@ export function getRandomHint(keybindings: Keybindings = DEFAULT_KEYBINDINGS, en
     `${formatUsableKeybinding(keybindings, "newline", enhancedKeyboard)} for multiline input`,
     `${formatKeybinding(keybindings, "historyUp")}/${formatKeybinding(keybindings, "historyDown")} to recall previous messages`,
     `${formatKeybinding(keybindings, "toggleToolDetail")} expands tool output details`,
+    `${formatKeybinding(keybindings, "togglePlanDetail")} shows the full plan while it runs`,
     `${formatKeybinding(keybindings, "cancel")} cancels a streaming response`,
     // Seatbelt and Bubblewrap are POSIX-only, so Windows resolves to "none".
     // Stating the sandbox unconditionally would promise isolation we do not have.

--- a/source/utils/tool-labels.ts
+++ b/source/utils/tool-labels.ts
@@ -3,6 +3,12 @@ import { projectRelativePath, terminalRelativePaths, toolPathValues } from "./di
 interface ToolMeta {
   label: string;
   formatSummary: (input: Record<string, unknown>) => string;
+  /**
+   * The tool records the agent's own progress rather than doing anything to the
+   * project. Shown without the emphasis real work gets, so it reads as a note
+   * in the margin instead of another action to scan.
+   */
+  bookkeeping?: boolean;
 }
 
 const TOOL_META: Record<string, ToolMeta> = {
@@ -62,8 +68,17 @@ const TOOL_META: Record<string, ToolMeta> = {
     formatSummary: (input) => String(input.url ?? ""),
   },
   update_plan: {
-    label: "Update Plan",
-    formatSummary: (input) => `step ${input.step} → ${input.status}`,
+    // "Update Plan step 3 → in_progress" reads as the agent rewriting its plan
+    // and going off track. All it does is tick a box in .agav/plans, so both
+    // the label and the summary say where it is, not that something changed.
+    label: "Plan Progress",
+    formatSummary: (input) => {
+      const step = `step ${input.step}`;
+      if (input.status === "done") return `${step} complete`;
+      if (input.status === "failed") return `${step} failed`;
+      return `starting ${step}`;
+    },
+    bookkeeping: true,
   },
   image: {
     label: "Image",
@@ -102,6 +117,11 @@ const DEFAULT_META: ToolMeta = {
 
 export function getToolLabel(name: string): string {
   return (TOOL_META[name] ?? DEFAULT_META).label;
+}
+
+/** See `ToolMeta.bookkeeping`. Unknown tools are treated as real work. */
+export function isBookkeepingTool(name: string): boolean {
+  return TOOL_META[name]?.bookkeeping === true;
 }
 
 export function getToolSummary(


### PR DESCRIPTION
## Summary

- Plans are now scoped per-session and anchored at the repo root, so switching directories or sessions no longer loses or cross-contaminates plans
- Adds a toggleable plan detail panel (keybinding: `togglePlanDetail`) for viewing full step descriptions mid-run
- Agent-injected prompts (verify nudges, test-repair retries, max-step wind-downs) are now marked as internal and excluded from the visible transcript and prompt history recall

## Changes

- **Plan scoping** (`source/agent/planner.ts`): Plans are stored under `.agav/plans/<sessionId>.json` instead of a single `.plan-state.json`. Plans resolve from the git root (not `cwd`), so subdirectory launches find the same plan. Draft plans are renamed once the session gets an ID (`adoptPlanScope`). Added `listPlans`, `prunePlans` (30-day TTL), `updatePlanStep` (shared by tool and `/plan` command), and `isPlanActive` helpers
- **`/plan` command** (`source/commands/plan.ts`): New subcommands — `/plan list` shows all saved plans for the project, `/plan <n> <status>` lets users manually update step status. Fixed division-by-zero on empty plans
- **Plan detail panel** (`source/components/plan-detail-panel.tsx`): Full plan view with step icons, descriptions, verify commands, and progress bar. Toggled via keybinding, read-only (never touches disk or the agent loop)
- **Internal message system** (`source/agent/internal-prompts.ts`): All agent self-steering prompts (verify, test-repair, max-steps, schema retry) are centralized and marked with `internal: true` on the `Message` type. `isInternalUserMessage()` filters them from display and history recall, with legacy prefix matching for pre-existing sessions
- **Denied tool call tracking** (`source/agent/loop.ts`): Refused tool calls are tracked per-turn so the model cannot re-request the same call after denial
- **Conversation state** (`source/agent/conversation.ts`): Added `addInternalUserMessage()` that sets the `internal` flag
- **Keybindings** (`source/config/keybindings.ts`): Added `togglePlanDetail` to global actions
- **`refreshPlan` plumbing** (`source/commands/types.ts`, `source/app.tsx`, `source/hooks/use-agent.ts`): CommandContext exposes `refreshPlan()` so `/plan clear` and step updates sync the on-screen panel immediately

## Related Issues

Fixes plan state loss when switching directories or sessions. Fixes resumed sessions displaying agent-internal prompts as user messages.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing

- [x] `npx tsc --noEmit` passes
- [x] Manually tested in terminal
- [x] New test suites: `agent-planner-state.test.ts` (plan scoping, pruning, step updates), `agent.internal-prompts.test.ts` (internal message detection), `commands.plan.test.ts` (`/plan` subcommands), `config-keybindings.test.ts`, `loop.test.ts` (denied call tracking)

## Screenshots / Terminal Output

