### PR TITLE
ci: add pre-release support via beta branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, beta]
 
 jobs:
   check-version:
@@ -11,6 +11,7 @@ jobs:
     outputs:
       changed: ${{ steps.version.outputs.changed }}
       version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -29,7 +30,14 @@ jobs:
             fi
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
-            echo "Version changed: $PREV → $CURRENT"
+            # Versions with a hyphen suffix (e.g. 0.2.0-beta.1) are pre-releases.
+            if echo "$CURRENT" | grep -q '-'; then
+              echo "prerelease=true" >> "$GITHUB_OUTPUT"
+              echo "Version changed: $PREV → $CURRENT (pre-release)"
+            else
+              echo "prerelease=false" >> "$GITHUB_OUTPUT"
+              echo "Version changed: $PREV → $CURRENT (stable)"
+            fi
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No version change"
@@ -190,6 +198,7 @@ jobs:
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
+          prerelease: ${{ needs.check-version.outputs.prerelease == 'true' }}
           target_commitish: ${{ github.sha }}
           body: |
             ## Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,9 +154,22 @@ main (0.1.9)                          ← current stable
   │     └── ...next cycle...
 ```
 
-- **Pre-releases** are visible on the releases page but not served by `install.sh`
+- **Pre-releases** are visible on the releases page but not served by `install.sh` by default
 - **Stable releases** become the Latest release and are served by `install.sh`
 - Hotfixes can go directly to `main` with a patch bump (e.g. `0.2.1`)
+
+**Installing a beta version:**
+
+```bash
+# macOS / Linux
+curl -fsSL https://agav.dev/install.sh | bash -s -- --beta
+
+# Windows
+irm https://www.agav.dev/install.ps1 | iex -- --beta
+
+# Or via environment variable
+AGAV_BETA=1 curl -fsSL https://agav.dev/install.sh | bash
+```
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,11 +125,38 @@ Agav dogfoods itself in CI:
 
 ### Release
 
-Triggered by version bump in `package.json`:
-1. Builds binaries for 4 platforms (darwin-arm64, darwin-x64, linux-x64, linux-arm64)
+Triggered by version bump in `package.json` on `main` or `beta` branches:
+1. Builds binaries for 5 platforms (darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64)
 2. Signs binaries (macOS codesign, Linux cosign)
-3. Generates SHA256 checksums
+3. Compresses binaries (gzip) and generates SHA256 checksums
 4. Creates GitHub release with assets
+
+**Two-branch release model:**
+
+| Branch | Version format | Release type |
+|---|---|---|
+| `beta` | `x.y.z-beta.N` (e.g. `0.2.0-beta.1`) | GitHub Pre-release |
+| `main` | `x.y.z` (e.g. `0.2.0`) | GitHub Latest release |
+
+**Typical release flow:**
+
+```
+main (0.1.9)                          ← current stable
+  │
+  ├── beta branch (created from main)
+  │     ├── PR → beta, bump to 0.2.0-beta.1  → Pre-release
+  │     ├── PR → beta, bump to 0.2.0-beta.2  → Pre-release
+  │     └── PR → beta, no version bump        → no release
+  │
+  ├── PR: beta → main, bump to 0.2.0         → Stable release
+  │
+  ├── beta branch (reset from main)
+  │     └── ...next cycle...
+```
+
+- **Pre-releases** are visible on the releases page but not served by `install.sh`
+- **Stable releases** become the Latest release and are served by `install.sh`
+- Hotfixes can go directly to `main` with a patch bump (e.g. `0.2.1`)
 
 ## Pull requests
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -18,6 +18,7 @@ $BinaryName = "agav.exe"
 $Version = if ($env:AGAV_VERSION) { $env:AGAV_VERSION } else { "latest" }
 $InstallDir = if ($env:AGAV_INSTALL_DIR) { $env:AGAV_INSTALL_DIR } else { "$env:LOCALAPPDATA\agav" }
 $SkipChecksum = $env:AGAV_SKIP_CHECKSUM -match '^(1|true|yes)$'
+$Beta = $env:AGAV_BETA -match '^(1|true|yes)$'
 
 # Windows refuses to delete the image of a running process, so an update
 # renames the old exe aside and deletes it later. Sweep whatever earlier runs
@@ -125,6 +126,7 @@ foreach ($arg in $args) {
     if ($arg -match "^--version=(.+)$") { $Version = $Matches[1] }
     if ($arg -match "^--dir=(.+)$") { $InstallDir = $Matches[1] }
     if ($arg -eq "--skip-checksum") { $SkipChecksum = $true }
+    if ($arg -eq "--beta") { $Beta = $true }
     if ($arg -eq "--help" -or $arg -eq "-h") {
         Write-Host "Usage: install.ps1 [OPTIONS]"
         Write-Host ""
@@ -132,6 +134,7 @@ foreach ($arg in $args) {
         Write-Host "  --version=<tag>    Install a specific version (default: latest)"
         Write-Host "  --dir=<path>       Install directory (default: %LOCALAPPDATA%\agav)"
         Write-Host "  --skip-checksum    Install without verifying the SHA-256 checksum"
+        Write-Host "  --beta               Install the latest pre-release (beta) version"
         Write-Host "  --uninstall        Remove agav, keeping your settings and history"
         Write-Host "  --purge            Remove agav and delete %USERPROFILE%\.agav as well"
         Write-Host "  -h, --help         Show this help"
@@ -140,6 +143,7 @@ foreach ($arg in $args) {
         Write-Host "  AGAV_VERSION         Version to install; overridden by --version."
         Write-Host "  AGAV_INSTALL_DIR     Install directory; overridden by --dir."
         Write-Host "  AGAV_SKIP_CHECKSUM   Set to 1/true/yes to skip verification."
+        Write-Host "  AGAV_BETA            Set to 1/true/yes to install pre-release; overridden by --beta."
         exit 0
     }
 }
@@ -260,7 +264,23 @@ if ($Version -ne "latest") {
 }
 
 if ($Version -eq "latest") {
-    $DownloadUrl = "https://github.com/$Repo/releases/latest/download/$AssetName"
+    if ($Beta) {
+        Write-Host "agav -> Resolving latest pre-release..." -ForegroundColor Cyan
+        # /releases returns all releases (including pre-releases) newest-first.
+        # Pick the first one, which may be a pre-release.
+        try {
+            $ReleasesJson = Get-RemoteText "https://api.github.com/repos/$Repo/releases?per_page=1"
+            $Tag = [regex]::Match($ReleasesJson, '"tag_name"\s*:\s*"v?([^"]+)"').Groups[1].Value
+            if (-not $Tag) { throw "No tag found" }
+            $DownloadUrl = "https://github.com/$Repo/releases/download/v$Tag/$AssetName"
+            Write-Host "agav -> Resolved: v$Tag" -ForegroundColor Cyan
+        } catch {
+            Write-Host "Could not resolve latest pre-release: $($_.Exception.Message)" -ForegroundColor Red
+            exit 1
+        }
+    } else {
+        $DownloadUrl = "https://github.com/$Repo/releases/latest/download/$AssetName"
+    }
 } else {
     $DownloadUrl = "https://github.com/$Repo/releases/download/v$Version/$AssetName"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@ BINARY_NAME="agav"
 VERSION="${AGAV_VERSION:-latest}"
 NON_INTERACTIVE="${AGAV_NON_INTERACTIVE:-false}"
 SKIP_CHECKSUM="${AGAV_SKIP_CHECKSUM:-0}"
+BETA="${AGAV_BETA:-0}"
 
 BIN_DIR="${AGAV_INSTALL_DIR:-$HOME/.local/bin}"
 BIN_PATH="$BIN_DIR/$BINARY_NAME"
@@ -99,6 +100,13 @@ download_text() {
 
 checksum_bypassed() {
   case "$SKIP_CHECKSUM" in
+    1 | [Tt][Rr][Uu][Ee] | [Yy][Ee][Ss]) return 0 ;;
+  esac
+  return 1
+}
+
+is_beta() {
+  case "$BETA" in
     1 | [Tt][Rr][Uu][Ee] | [Yy][Ee][Ss]) return 0 ;;
   esac
   return 1
@@ -532,6 +540,7 @@ for arg in "$@"; do
     --purge)     do_uninstall=1; do_purge=1 ;;
     --version=*) VERSION="${arg#*=}" ;;
     --dir=*)     BIN_DIR="${arg#*=}"; BIN_PATH="$BIN_DIR/$BINARY_NAME" ;;
+    --beta)      BETA=1 ;;
     --help|-h)
       cat <<EOF
 Agav Installer
@@ -541,6 +550,7 @@ Usage: install.sh [OPTIONS]
 Options:
   --version=<tag>    Install a specific version (default: latest)
   --dir=<path>       Install directory (default: ~/.local/bin)
+  --beta               Install the latest pre-release (beta) version
   --uninstall        Remove Agav, keeping your settings and history
   --purge            Remove Agav and delete ~/.agav as well
   -h, --help         Show this help
@@ -550,6 +560,7 @@ Environment:
   AGAV_INSTALL_DIR      Install directory; overridden by --dir.
   AGAV_NON_INTERACTIVE  Set to 1/true/yes to skip prompts.
   AGAV_SKIP_CHECKSUM    Set to 1/true/yes to install without verifying SHA-256.
+  AGAV_BETA             Set to 1/true/yes to install pre-release; overridden by --beta.
 EOF
       exit 0
       ;;
@@ -623,11 +634,21 @@ step "Agav installer for $platform_label"
 
 # Resolve version
 if [ "$VERSION" = "latest" ]; then
-  step "Resolving latest release..."
-  release_json="$(download_text "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null)" || {
-    err "Could not fetch release info. GitHub API may be unavailable."
-    exit 1
-  }
+  if is_beta; then
+    step "Resolving latest pre-release..."
+    # The /releases endpoint returns all releases (including pre-releases)
+    # sorted newest-first. Pick the first one, which may be a pre-release.
+    release_json="$(download_text "https://api.github.com/repos/${REPO}/releases?per_page=1" 2>/dev/null)" || {
+      err "Could not fetch release info. GitHub API may be unavailable."
+      exit 1
+    }
+  else
+    step "Resolving latest release..."
+    release_json="$(download_text "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null)" || {
+      err "Could not fetch release info. GitHub API may be unavailable."
+      exit 1
+    }
+  fi
   resolved_version="$(printf '%s\n' "$release_json" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/')"
   if [ -z "$resolved_version" ]; then
     err "Could not determine latest version."


### PR DESCRIPTION
## Summary

Adds pre-release support using a two-branch model (`main` + `beta`).

## Changes

### `release.yml`
- Trigger releases from both `main` and `beta` branches
- Detect pre-release versions (`x.y.z-beta.N`) from the hyphen in `package.json` version
- Pass `prerelease: true` to `softprops/action-gh-release` so GitHub marks them correctly

### `CONTRIBUTING.md`
- Document the two-branch release model, version formats, and typical flow

## How it works

| Branch | Version | GitHub Release |
|---|---|---|
| `beta` | `0.2.0-beta.1` | Pre-release (not served by `install.sh`) |
| `main` | `0.2.0` | Latest (served by `install.sh`) |

## Release flow

```
main (0.1.9)
  ├── beta: bump to 0.2.0-beta.1 → Pre-release
  ├── beta: bump to 0.2.0-beta.2 → Pre-release
  └── beta → main: bump to 0.2.0 → Stable release
```

No changes to install scripts — GitHub's API already excludes pre-releases from "latest".