### PR TITLE
fix: agent marketplace install bug

### DIFF
--- a/source/agents/installer.ts
+++ b/source/agents/installer.ts
@@ -13,7 +13,7 @@ import type { AgentDefinition } from "./types.js";
 
 const SAFE_NAME = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
 
-const DEFAULT_ALLOWED_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+const DEFAULT_ALLOWED_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org", "raw.githubusercontent.com"]);
 
 function getAllowedHosts(): Set<string> {
   const extra = process.env.AGAV_ALLOWED_GIT_HOSTS;

--- a/source/agents/installer.ts
+++ b/source/agents/installer.ts
@@ -3,8 +3,8 @@
  */
 
 import { execFile } from "node:child_process";
-import { readdir, rm, cp, mkdir, stat, realpath } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { readdir, rm, cp, mkdir, stat, realpath, writeFile } from "node:fs/promises";
+import { join, resolve, dirname } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
 import { loadAgent } from "./loader.js";
@@ -308,6 +308,66 @@ export async function uninstallAgent(nameOrAlias: string, destination: "global" 
     return {
       success: false,
       error: `Failed to uninstall: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Download agent files from an HTTP-based marketplace into a temp directory.
+ * Returns the temp directory path, which can be passed to installAgent() as a local path.
+ */
+export async function downloadAgentFiles(
+  baseUrl: string,
+  files: string[],
+): Promise<{ success: boolean; path?: string; error?: string }> {
+  if (!files.length) {
+    return { success: false, error: "No files to download" };
+  }
+
+  for (const f of files) {
+    if (!f || f.includes("..") || /^[/\\]/.test(f) || /^[A-Za-z]:/.test(f)) {
+      return { success: false, error: `Invalid file path: "${f}"` };
+    }
+  }
+
+  const tempDir = join(tmpdir(), `agav-agent-${randomBytes(8).toString("hex")}`);
+
+  try {
+    await mkdir(tempDir, { recursive: true });
+
+    const results = await Promise.allSettled(
+      files.map(async (file) => {
+        const url = `${baseUrl}/${file}`;
+        const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${file}`);
+        const destPath = join(tempDir, ...file.split("/"));
+        await mkdir(dirname(destPath), { recursive: true });
+        const buffer = Buffer.from(await res.arrayBuffer());
+        await writeFile(destPath, buffer);
+      }),
+    );
+
+    const failures = results
+      .map((r, i) => (r.status === "rejected" ? `${files[i]}: ${r.reason?.message || r.reason}` : null))
+      .filter(Boolean);
+
+    if (failures.length) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      return { success: false, error: `Failed to download: ${failures.join("; ")}` };
+    }
+
+    const entries = await readdir(tempDir);
+    if (!entries.includes("AGENT.md")) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      return { success: false, error: "Downloaded files do not contain AGENT.md" };
+    }
+
+    return { success: true, path: tempDir };
+  } catch (error) {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    return {
+      success: false,
+      error: `Download failed: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }

--- a/source/agents/types.ts
+++ b/source/agents/types.ts
@@ -103,6 +103,7 @@ export interface MarketplaceAgent {
   tags: string[];
   version: string;
   path: string; // relative path in marketplace repo
+  files?: string[]; // file list for HTTP download (relative to path)
   "tool-count": number;
   "has-destructive-tools": boolean;
 }

--- a/source/components/agents-inspect.tsx
+++ b/source/components/agents-inspect.tsx
@@ -299,6 +299,7 @@ export function MarketplaceInspectView({ marketplaceAgent, marketplaceUrl, isIns
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cleanupPath: string | undefined;
     const load = async () => {
       try {
         const { loadAgent } = await import("../agents/loader.js");
@@ -306,6 +307,16 @@ export function MarketplaceInspectView({ marketplaceAgent, marketplaceUrl, isIns
         if (marketplaceUrl.startsWith("file://")) {
           const basePath = parseFileUrl(marketplaceUrl);
           agentPath = `${basePath}/${marketplaceAgent.path}`;
+        } else if (marketplaceAgent.files && marketplaceAgent.files.length > 0) {
+          const { downloadAgentFiles } = await import("../agents/installer.js");
+          const agentBaseUrl = `${marketplaceUrl}/${marketplaceAgent.path}`;
+          const downloadResult = await downloadAgentFiles(agentBaseUrl, marketplaceAgent.files);
+          if (!downloadResult.success || !downloadResult.path) {
+            setLoadError("placeholder");
+            return;
+          }
+          agentPath = downloadResult.path;
+          cleanupPath = downloadResult.path;
         } else {
           setLoadError("placeholder");
           return;
@@ -318,6 +329,11 @@ export function MarketplaceInspectView({ marketplaceAgent, marketplaceUrl, isIns
         }
       } catch {
         setLoadError("placeholder");
+      } finally {
+        if (cleanupPath) {
+          const { rm } = await import("node:fs/promises");
+          await rm(cleanupPath, { recursive: true, force: true }).catch(() => {});
+        }
       }
     };
     load();

--- a/source/components/agents-list.tsx
+++ b/source/components/agents-list.tsx
@@ -146,7 +146,10 @@ function AgentListItem({ agent, isSelected, readiness }: { agent: AgentDefinitio
         {readiness !== undefined && (
           readiness.ready
             ? <Text color="green"> Ready ✓</Text>
-            : <Text color="yellow"> ⚠ Needs config</Text>
+            : <>
+                <Text color="yellow"> ⚠ Needs config</Text>
+                {isSelected && <Text dimColor> (c)</Text>}
+              </>
         )}
       </Box>
       <Box marginLeft={2}>

--- a/source/components/agents-marketplace.tsx
+++ b/source/components/agents-marketplace.tsx
@@ -11,10 +11,14 @@ export function MarketplaceTab({
   onReloadAgents,
   onExit,
   installedAgents,
+  onBusyChange,
+  onInstallComplete,
 }: {
   onReloadAgents: () => Promise<void>;
   onExit: () => void;
   installedAgents: Map<string, { origin: string; version: string }>;
+  onBusyChange?: (busy: boolean) => void;
+  onInstallComplete?: (agentName: string) => void;
 }) {
   const [marketplaceAgents, setMarketplaceAgents] = useState<MarketplaceAgent[]>([]);
   const [loading, setLoading] = useState(true);
@@ -27,6 +31,13 @@ export function MarketplaceTab({
   const [reinstallCandidate, setReinstallCandidate] = useState<{ agent: MarketplaceAgent; destination: "global" | "project" } | null>(null);
   const [resolvedMarketplaceUrl, setResolvedMarketplaceUrl] = useState("");
   const { searchQuery, searching, handleSearchKey } = useSearch();
+
+  useEffect(() => {
+    onBusyChange?.(Boolean(
+      pendingInstallAgent || reinstallCandidate || inspecting || searching || installing
+    ));
+    return () => onBusyChange?.(false);
+  }, [pendingInstallAgent, reinstallCandidate, inspecting, searching, installing]);
 
   useEffect(() => {
     loadMarketplace();
@@ -95,6 +106,10 @@ export function MarketplaceTab({
         : `✓ Installed ${agent.name} (${destination})`;
       setInstallStatus(msg);
       await onReloadAgents();
+      if (onInstallComplete) {
+        onInstallComplete(agent.name);
+        return;
+      }
     } else if (result.error?.startsWith("Agent '") && result.error?.includes("is already installed")) {
       setInstallStatus(null);
       setReinstallCandidate({ agent, destination });

--- a/source/components/agents-marketplace.tsx
+++ b/source/components/agents-marketplace.tsx
@@ -93,13 +93,35 @@ export function MarketplaceTab({
     const marketplaceUrl =
       config.agentMarketplace || getDefaultMarketplaceUrl();
     let agentUrl: string;
+    let httpTempPath: string | undefined;
     if (marketplaceUrl.startsWith("file://")) {
       const basePath = parseFileUrl(marketplaceUrl);
       agentUrl = `${basePath}/${agent.path}`;
     } else {
-      agentUrl = `${marketplaceUrl}/${agent.path}`;
+      if (!agent.files || agent.files.length === 0) {
+        setInstallStatus("✗ Failed: marketplace agent has no file manifest");
+        setInstalling(false);
+        setPendingInstallAgent(null);
+        return;
+      }
+      const { downloadAgentFiles } = await import("../agents/installer.js");
+      const agentBaseUrl = `${marketplaceUrl}/${agent.path}`;
+      setInstallStatus("Downloading agent files...");
+      const downloadResult = await downloadAgentFiles(agentBaseUrl, agent.files);
+      if (!downloadResult.success || !downloadResult.path) {
+        setInstallStatus(`✗ Failed: ${downloadResult.error || "Download failed"}`);
+        setInstalling(false);
+        setPendingInstallAgent(null);
+        return;
+      }
+      agentUrl = downloadResult.path;
+      httpTempPath = downloadResult.path;
     }
     const result = await installAgent(agentUrl, { destination });
+    if (httpTempPath) {
+      const { rm } = await import("node:fs/promises");
+      await rm(httpTempPath, { recursive: true, force: true }).catch(() => {});
+    }
     if (result.success) {
       const msg = result.warning
         ? `✓ Installed ${agent.name} (${destination}) — ⚠ ${result.warning}`

--- a/source/components/agents-tui.tsx
+++ b/source/components/agents-tui.tsx
@@ -127,6 +127,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
     setActiveTab("list");
     setSelectedIndex(0);
     setListView("list");
+    setRemoveStatus(null);
   };
 
   const { searchQuery: listSearch, searching: listSearching, handleSearchKey: handleListSearch } = useSearch();
@@ -135,6 +136,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
   useInput(async (input, key) => {
     const isEditingConfig = listView === "config" && (configEditing || configPickerActive);
     if (!listSearching && !isEditingConfig && !marketplaceBusy && (input === "1" || input === "2")) {
+      setRemoveStatus(null);
       if (input === "1") { setActiveTab("list"); setSelectedIndex(0); setListView("list"); }
       else if (input === "2") { setActiveTab("marketplace"); setSelectedIndex(0); }
       return;
@@ -250,7 +252,9 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
           } else if (key.return) {
             await saveConfigValue(configEditBuffer);
             setConfigEditing(false);
-          } else if (key.backspace || key.delete) {
+          } else if (key.delete) {
+            setConfigEditBuffer("");
+          } else if (key.backspace) {
             setConfigEditBuffer((b) => b.slice(0, -1));
           } else if (input && input.length === 1) {
             setConfigEditBuffer((b) => b + input);
@@ -439,7 +443,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
             {configPickerActive
               ? "↑↓: Navigate | ENTER: Select | ESC: Cancel"
               : configEditing
-              ? "Type value (blank = inherit) | ENTER: Save | ESC: Cancel"
+              ? "Type value | DEL: Clear | ENTER: Save | ESC: Cancel"
               : `↑↓: Navigate | ENTER: Edit value | ESC: Back to ${configEntryPoint}`}
           </Text>
         )}

--- a/source/components/agents-tui.tsx
+++ b/source/components/agents-tui.tsx
@@ -39,6 +39,9 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
   const [configPickerIndex, setConfigPickerIndex]   = useState(0);
   const [runtimeConfigs, setRuntimeConfigs]       = useState<Record<string, Record<string, string>>>({});
 
+  const [configEntryPoint, setConfigEntryPoint]   = useState<"list" | "inspect">("inspect");
+  const [marketplaceBusy, setMarketplaceBusy]     = useState(false);
+
   const [implementingTools, setImplementingTools] = useState(false);
   const [implementStatus, setImplementStatus]     = useState<string | null>(null);
 
@@ -106,12 +109,32 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
     loadAllRuntimeConfigs(loaded);
   };
 
+  const enterConfigView = async (agent: AgentDefinition, from: "list" | "inspect") => {
+    const agentKey = agent.alias || agent.manifest.name;
+    const existingConfig = await loadAgentConfig(resolveConfigDir(agent));
+    setRuntimeConfigs((prev) => ({ ...prev, [agentKey]: existingConfig }));
+    setConfigEditIndex(0);
+    setConfigEditKey("");
+    setConfigEditBuffer("");
+    setConfigEditing(false);
+    setConfigSavedKeys({});
+    setConfigError(null);
+    setConfigEntryPoint(from);
+    setListView("config");
+  };
+
+  const handleInstallComplete = () => {
+    setActiveTab("list");
+    setSelectedIndex(0);
+    setListView("list");
+  };
+
   const { searchQuery: listSearch, searching: listSearching, handleSearchKey: handleListSearch } = useSearch();
   const filteredAgents = filterInstalledAgents(agents, listSearch);
 
   useInput(async (input, key) => {
     const isEditingConfig = listView === "config" && (configEditing || configPickerActive);
-    if (!listSearching && !isEditingConfig && (input === "1" || input === "2")) {
+    if (!listSearching && !isEditingConfig && !marketplaceBusy && (input === "1" || input === "2")) {
       if (input === "1") { setActiveTab("list"); setSelectedIndex(0); setListView("list"); }
       else if (input === "2") { setActiveTab("marketplace"); setSelectedIndex(0); }
       return;
@@ -162,6 +185,8 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
           await reloadAgents();
         } else if (input === "i" && filteredAgents[selectedIndex]) {
           setListView("inspect");
+        } else if (input === "c" && filteredAgents[selectedIndex]) {
+          await enterConfigView(filteredAgents[selectedIndex]!, "list");
         } else if (input === "d" && filteredAgents[selectedIndex]) {
           const agent = filteredAgents[selectedIndex]!;
           if (agent.origin === "bundled") {
@@ -179,16 +204,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
         if (input === "f" && agent && provider && config && agent.origin === "global" && hasTODOTools) {
           runImplementTools(agent);
         } else if (input === "e" && agent) {
-          const agentKey = agent.alias || agent.manifest.name;
-          const existingConfig = await loadAgentConfig(resolveConfigDir(agent));
-          setRuntimeConfigs((prev) => ({ ...prev, [agentKey]: existingConfig }));
-          setConfigEditIndex(0);
-          setConfigEditKey("");
-          setConfigEditBuffer("");
-          setConfigEditing(false);
-          setConfigSavedKeys({});
-          setConfigError(null);
-          setListView("config");
+          await enterConfigView(agent, "inspect");
         } else if (key.escape || input === "b") {
           setListView("list");
         }
@@ -241,7 +257,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
           }
         } else {
           if (key.escape) {
-            setListView("inspect"); setConfigError(null);
+            setListView(configEntryPoint); setConfigError(null);
           } else if (key.upArrow) {
             setConfigEditIndex((i) => Math.max(0, i - 1)); setConfigError(null);
           } else if (key.downArrow) {
@@ -398,13 +414,15 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
           onReloadAgents={reloadAgents}
           onExit={onExit}
           installedAgents={new Map(agents.map((a) => [a.alias || a.manifest.name, { origin: a.origin, version: a.manifest.version }]))}
+          onBusyChange={setMarketplaceBusy}
+          onInstallComplete={handleInstallComplete}
         />
       )}
 
       <Box marginTop={1} borderStyle="single" borderTop paddingTop={1}>
         {activeTab === "list" && listView === "list" && (
           <Text dimColor>
-            ↑↓: Navigate | ENTER: Toggle | i: Inspect | d: Remove | s: Search | ESC: Exit/clear
+            ↑↓: Navigate | ENTER: Toggle | i: Inspect | c: Configure | d: Remove | s: Search | ESC: Exit/clear
           </Text>
         )}
         {activeTab === "list" && listView === "inspect" && (
@@ -422,7 +440,7 @@ export function AgentsTUI({ onExit, provider, config }: AgentsTUIProps) {
               ? "↑↓: Navigate | ENTER: Select | ESC: Cancel"
               : configEditing
               ? "Type value (blank = inherit) | ENTER: Save | ESC: Cancel"
-              : "↑↓: Navigate | ENTER: Edit value | ESC: Back to inspect"}
+              : `↑↓: Navigate | ENTER: Edit value | ESC: Back to ${configEntryPoint}`}
           </Text>
         )}
         {activeTab === "marketplace" && (


### PR DESCRIPTION
# Summary
- Fix TUI key conflicts, stale status messages, and unintuitive config access in the agents management interface
- Add HTTP file-based marketplace install support for raw.githubusercontent.com (replaces broken git clone path)
- Add direct c shortcut from list view to configure agents, and DEL key to clear credential fields
# Changes
- Tab-switching conflict: Pressing [1]/[2] during marketplace install prompt, search, inspect, or reinstall confirmation no longer switches tabs — lifted a marketplaceBusy guard from MarketplaceTab to the parent
- Auto-switch to list after install: TUI switches to the List tab after a successful marketplace install
- Direct c configure shortcut: Press c in list view to open config editor directly (skips inspect). (c) hint shown on selected agents needing config. ESC returns to entry point (list or inspect)
- Stale remove message: "Removed X" status no longer persists across tab switches or new installs
- DEL clears credential field: In the config editor, DEL clears the entire field; Backspace removes one character
- HTTP marketplace downloads: Added downloadAgentFiles() to installer.ts — fetches agent files individually via fetch() into a temp directory when the marketplace URL is a raw file server (not a git endpoint). Requires files array in marketplace index.json
- MarketplaceInspectView HTTP support: Inspect view now downloads and loads full agent details from HTTP marketplaces instead of showing placeholder
- raw.githubusercontent.com added to default allowed installer hosts

# Related Issues
<!-- Link related issues: Closes #N, Fixes #N, or Relates to #N -->

# Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Chore
# Testing
- [ ] npx tsc --noEmit passes
- [x] Manually tested in terminal
- [x] Tested with --provider openai
- [ ] Tested with --provider anthropic
- [ ] Tested with --provider ollama
- [ ] Tested pipe mode (-P)
 