### PR TITLE
fix: repoint the current symlink on upgrade

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -518,6 +518,15 @@ replace_symlink() {
 
   rm -f "$tmp_link"
   ln -s "$link_target" "$tmp_link"
+  # `mv -f` resolves a destination that is a symlink to a directory and moves
+  # the source *inside* it — with exit 0, so nothing downstream notices. That is
+  # how an upgrade left `current` aimed at the previous release, dropped the
+  # temp link into that release's directory, and then verified and announced the
+  # old binary as freshly installed. Both BSD and GNU mv do this, and neither
+  # has a portable spelling of `mv -T`, so clear a link destination first.
+  if [ -L "$link_path" ]; then
+    rm -f "$link_path"
+  fi
   mv -f "$tmp_link" "$link_path" 2>/dev/null || {
     rm -f "$link_path"
     mv -f "$tmp_link" "$link_path"

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -221,6 +221,47 @@ check "no temp files in HOME" $? "$(find "$H" -name '*agav-*')"
 [ -z "$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'agav-uninstall.*' -o -maxdepth 1 -name 'agav-profile.*' 2>/dev/null)" ]
 check "no temp files in TMPDIR" $?
 
+echo "== replace_symlink survives an upgrade =="
+# The only case that ever broke: `mv -f` onto a destination that is already a
+# symlink to a directory resolves it and moves the source *inside* that
+# directory, exit 0. `current` stayed on the old release, the installer then
+# verified the old binary and announced it as the new version. Exercised by
+# extracting the function rather than running the installer, so this stays
+# offline like the rest of the suite.
+LINKS="$ROOT/links"
+rm -rf "$LINKS"
+mkdir -p "$LINKS/releases/1.0.0" "$LINKS/releases/2.0.0"
+: >"$LINKS/releases/1.0.0/agav"
+: >"$LINKS/releases/2.0.0/agav"
+sed -n '/^replace_symlink() {/,/^}/p' "$SRC" >"$ROOT/replace_symlink.sh"
+[ -s "$ROOT/replace_symlink.sh" ]; check "extracted replace_symlink from the installer" $?
+
+(
+  set -eu
+  . "$ROOT/replace_symlink.sh"
+  replace_symlink "$LINKS/current" "$LINKS/releases/1.0.0"   # fresh install
+  replace_symlink "$LINKS/current" "$LINKS/releases/2.0.0"   # upgrade
+)
+check "a fresh install then an upgrade both exit 0" $?
+[ "$(readlink "$LINKS/current")" = "$LINKS/releases/2.0.0" ]
+check "current points at the new release" $? "got=$(readlink "$LINKS/current" 2>/dev/null)"
+[ -z "$(ls -A "$LINKS/releases/1.0.0" | grep -v '^agav$')" ]
+check "no temp link stranded inside the old release" $? "found=$(ls -A "$LINKS/releases/1.0.0")"
+
+# The visible command is a symlink to a *file*, which never hit the bug. Kept
+# so a fix aimed at the directory case cannot quietly break this one.
+(
+  set -eu
+  . "$ROOT/replace_symlink.sh"
+  replace_symlink "$LINKS/bin-agav" "$LINKS/releases/1.0.0/agav"
+  replace_symlink "$LINKS/bin-agav" "$LINKS/releases/2.0.0/agav"
+)
+check "swapping a symlink to a file still exits 0" $?
+[ "$(readlink "$LINKS/bin-agav")" = "$LINKS/releases/2.0.0/agav" ]
+check "the command symlink follows the upgrade" $? "got=$(readlink "$LINKS/bin-agav" 2>/dev/null)"
+[ -z "$(find "$LINKS" -name '*.tmp.*')" ]
+check "no .tmp.PID links left anywhere" $? "$(find "$LINKS" -name '*.tmp.*')"
+
 echo "== --help =="
 fresh help
 run --help

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -238,6 +238,7 @@ sed -n '/^replace_symlink() {/,/^}/p' "$SRC" >"$ROOT/replace_symlink.sh"
 
 (
   set -eu
+  # shellcheck source=/dev/null
   . "$ROOT/replace_symlink.sh"
   replace_symlink "$LINKS/current" "$LINKS/releases/1.0.0"   # fresh install
   replace_symlink "$LINKS/current" "$LINKS/releases/2.0.0"   # upgrade
@@ -245,13 +246,15 @@ sed -n '/^replace_symlink() {/,/^}/p' "$SRC" >"$ROOT/replace_symlink.sh"
 check "a fresh install then an upgrade both exit 0" $?
 [ "$(readlink "$LINKS/current")" = "$LINKS/releases/2.0.0" ]
 check "current points at the new release" $? "got=$(readlink "$LINKS/current" 2>/dev/null)"
-[ -z "$(ls -A "$LINKS/releases/1.0.0" | grep -v '^agav$')" ]
-check "no temp link stranded inside the old release" $? "found=$(ls -A "$LINKS/releases/1.0.0")"
+stranded="$(find "$LINKS/releases/1.0.0" -mindepth 1 ! -name agav)"
+[ -z "$stranded" ]
+check "no temp link stranded inside the old release" $? "found=$stranded"
 
 # The visible command is a symlink to a *file*, which never hit the bug. Kept
 # so a fix aimed at the directory case cannot quietly break this one.
 (
   set -eu
+  # shellcheck source=/dev/null
   . "$ROOT/replace_symlink.sh"
   replace_symlink "$LINKS/bin-agav" "$LINKS/releases/1.0.0/agav"
   replace_symlink "$LINKS/bin-agav" "$LINKS/releases/2.0.0/agav"


### PR DESCRIPTION
## The bug

Upgrading through `install.sh` is a no-op. The new release downloads and passes checksum verification, but `current` never moves off the old release — and the installer reports success with the *old* version number.

Reproduced on 0.1.9 → 0.2.0-beta.1:

```
==> Downloading agav-darwin-arm64.gz...
######################################################## 100.0%
==> Verifying checksum...
==> Checksum verified.
==> Agav 0.1.9 installed to ~/.local/bin/agav     <-- 0.1.9, not 0.2.0-beta.1
```

Filesystem afterwards:

```
current                                   -> releases/0.1.9          <-- never moved
releases/0.2.0-beta.1/agav                                           <-- verified, unused
releases/0.1.9/current.tmp.12199          -> releases/0.2.0-beta.1   <-- the lost link
```

## Cause

`replace_symlink` creates `current.tmp.$$` and then does `mv -f "$tmp_link" "$link_path"`. When `$link_path` is a symlink **to a directory** — which `current` always is after the first install — `mv` resolves it and moves the source *inside* that directory instead of replacing the link, and exits 0. The `|| { rm -f; mv }` fallback never fires because nothing reported failure.

```
$ mv -f current.tmp.999 current    # current -> relA
exit=0
$ readlink current
relA                               # unchanged
$ ls relA
current.tmp.999 -> relB            # moved inside
```

Both BSD and GNU `mv` behave this way, so Linux is affected too. The first install works because `current` does not exist yet.

Everything downstream then confirms the wrong thing: `"$BIN_PATH" --version` succeeds (it is the old binary), `version_from_binary` returns the old version, and `install.sh:769` prints it as the success line.

## Fix

Clear the destination first when it is a link. There is no portable spelling of `mv -T`, and `ln -sfn` is not atomic either, so an explicit unlink under the existing install lock is the straightforward option.

## Not affected

- **In-app updater** — `auto-update.ts:288` uses `rename(2)`, which does not follow symlinks.
- **`install.ps1`** — Windows writes a single `agav.exe` with no versioned tree and no links, and a failed `Move-Item` throws rather than silently succeeding.

## Tests

Nothing in the suite covered the upgrade path, which is why this shipped. Adds 7 assertions exercising `replace_symlink` directly, so the suite stays offline. Three of them fail against the previous implementation:

```
$ sh scripts/tests/install-sh.test.sh .oldinstall.sh
  FAIL  current points at the new release
  FAIL  no temp link stranded inside the old release
  FAIL  no .tmp.PID links left anywhere
  52 passed, 3 failed

$ sh scripts/tests/install-sh.test.sh
  55 passed, 0 failed
```

Green under `sh`, `dash`, `zsh`, and `bash`.

## Rollout

`install.sh` ships outside the release pipeline (hand-copied to agav.dev), so this needs no version bump or new release — deploying the file makes it live. agav.dev serves it with `cache-control: max-age=0, must-revalidate`, so there is no cache to purge.

Users already stuck on the old version can unstick themselves without waiting:

```sh
ln -sfn ~/.agav/packages/standalone/releases/<new-version> ~/.agav/packages/standalone/current
```