### PR TITLE
fix: --beta was broken on Windows; document pre-release installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,41 @@ For Windows Command Prompt (`cmd.exe`):
 
 Or download a specific platform binary from [Releases](../../releases).
 
+### Pre-release builds
+
+Betas ship as GitHub pre-releases, and the commands above deliberately skip them. Pass `--beta` to install the newest one instead:
+
+**macOS / Linux:**
+
+```bash
+curl -fsSL https://agav.dev/install.sh | bash -s -- --beta
+```
+
+**Windows PowerShell:**
+
+```powershell
+& ([scriptblock]::Create((irm https://www.agav.dev/install.ps1))) --beta
+```
+
+> [!NOTE]
+> `irm ... | iex -- --beta` does not work — it fails with a parameter binding
+> error. `Invoke-Expression` takes the script as its positional `-Command`
+> argument, so `--beta` claims that slot and the piped script has nowhere left
+> to bind. PowerShell has no `--` end-of-options convention. The script block
+> form above is how you pass any flag on Windows.
+
+**Windows Command Prompt (`cmd.exe`):**
+
+```bat
+curl -fsSL https://agav.dev/install.cmd -o install.cmd
+install.cmd --beta
+del install.cmd
+```
+
+Setting `AGAV_BETA=1` in the environment does the same thing, which is handy when the flag is awkward to thread through.
+
+Once you're on a pre-release, `agav update` leaves you there: it only ever looks at the latest stable release, and it compares `major.minor.patch` with the suffix stripped. From `0.2.0-beta.1` that means you won't be pulled back to `0.1.9`, but you won't move to `0.2.0` final either — you stay until `0.2.1` ships. To rejoin the stable channel sooner, re-run the installer without `--beta`.
+
 ### Staying up to date
 
 Agav checks for a newer release on startup and updates itself. Run it by hand at any time:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -134,7 +134,7 @@ foreach ($arg in $args) {
         Write-Host "  --version=<tag>    Install a specific version (default: latest)"
         Write-Host "  --dir=<path>       Install directory (default: %LOCALAPPDATA%\agav)"
         Write-Host "  --skip-checksum    Install without verifying the SHA-256 checksum"
-        Write-Host "  --beta               Install the latest pre-release (beta) version"
+        Write-Host "  --beta             Install the latest pre-release (beta) version"
         Write-Host "  --uninstall        Remove agav, keeping your settings and history"
         Write-Host "  --purge            Remove agav and delete %USERPROFILE%\.agav as well"
         Write-Host "  -h, --help         Show this help"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -255,6 +255,33 @@ if (Test-Path $FinalPath) {
     } catch {}
 }
 
+# This has to stay above the pre-release lookup below, not down with the other
+# helpers. A script is executed top to bottom, and `function` is a statement
+# like any other, so a call placed earlier in the file than the definition hits
+# a "term is not recognized" error rather than resolving late. That is exactly
+# what --beta and AGAV_BETA=1 did on every Windows install.
+function Get-RemoteText {
+    param([Parameter(Mandatory = $true)][string]$Url)
+
+    Add-Type -AssemblyName System.Net.Http
+    $Handler = New-Object System.Net.Http.HttpClientHandler
+    try {
+        $Handler.DefaultProxyCredentials = [System.Net.CredentialCache]::DefaultCredentials
+    } catch {}
+    $Client = New-Object System.Net.Http.HttpClient($Handler)
+    $Client.DefaultRequestHeaders.UserAgent.ParseAdd("agav-installer")
+    $Response = $null
+    try {
+        $Response = $Client.GetAsync($Url).GetAwaiter().GetResult()
+        $Response.EnsureSuccessStatusCode() | Out-Null
+        return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    } finally {
+        if ($Response) { $Response.Dispose() }
+        $Client.Dispose()
+        $Handler.Dispose()
+    }
+}
+
 # --- Resolve download URL ---
 # Normalize: strip a leading v/V so we can re-add it consistently, matching
 # install.sh's normalize_version.  Both `--version=0.3.0` and `--version=v0.3.0`
@@ -390,28 +417,6 @@ function Expand-GzipFile {
         if ($Output) { $Output.Dispose() }
         if ($Gzip) { $Gzip.Dispose() }
         if ($Compressed) { $Compressed.Dispose() }
-    }
-}
-
-function Get-RemoteText {
-    param([Parameter(Mandatory = $true)][string]$Url)
-
-    Add-Type -AssemblyName System.Net.Http
-    $Handler = New-Object System.Net.Http.HttpClientHandler
-    try {
-        $Handler.DefaultProxyCredentials = [System.Net.CredentialCache]::DefaultCredentials
-    } catch {}
-    $Client = New-Object System.Net.Http.HttpClient($Handler)
-    $Client.DefaultRequestHeaders.UserAgent.ParseAdd("agav-installer")
-    $Response = $null
-    try {
-        $Response = $Client.GetAsync($Url).GetAwaiter().GetResult()
-        $Response.EnsureSuccessStatusCode() | Out-Null
-        return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-    } finally {
-        if ($Response) { $Response.Dispose() }
-        $Client.Dispose()
-        $Handler.Dispose()
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -559,7 +559,7 @@ Usage: install.sh [OPTIONS]
 Options:
   --version=<tag>    Install a specific version (default: latest)
   --dir=<path>       Install directory (default: ~/.local/bin)
-  --beta               Install the latest pre-release (beta) version
+  --beta             Install the latest pre-release (beta) version
   --uninstall        Remove Agav, keeping your settings and history
   --purge            Remove Agav and delete ~/.agav as well
   -h, --help         Show this help

--- a/scripts/tests/install-ps1-lint.test.ps1
+++ b/scripts/tests/install-ps1-lint.test.ps1
@@ -25,8 +25,34 @@ function Check([string]$Name, [bool]$Cond, [string]$Detail = "") {
 Write-Host "== it parses =="
 $Errors = $null
 $Tokens = $null
-[System.Management.Automation.Language.Parser]::ParseFile($Installer, [ref]$Tokens, [ref]$Errors) | Out-Null
+$Ast = [System.Management.Automation.Language.Parser]::ParseFile($Installer, [ref]$Tokens, [ref]$Errors)
 Check "no parse errors" (-not $Errors -or $Errors.Count -eq 0) ($Errors | Out-String)
+
+Write-Host "== every function is defined above its first top-level call =="
+# A script runs top to bottom and `function` is a statement like any other, so a
+# call written above the definition fails with "term is not recognized" instead
+# of resolving late. --beta shipped broken on Windows for exactly this: the
+# pre-release lookup called Get-RemoteText 130 lines before it existed, and
+# nothing here noticed because the failure needs a flag and a network call to
+# reach. A call from inside another function body is fine - that one resolves
+# when the enclosing function is invoked, not where it is written.
+$Defs = @{}
+foreach ($Fn in $Ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)) {
+    if (-not $Defs.ContainsKey($Fn.Name)) { $Defs[$Fn.Name] = $Fn.Extent.EndOffset }
+}
+$Early = @()
+foreach ($Cmd in $Ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+    $Name = $Cmd.GetCommandName()
+    if (-not $Name -or -not $Defs.ContainsKey($Name)) { continue }
+    $Enclosing = $Cmd.Parent
+    while ($Enclosing -and -not ($Enclosing -is [System.Management.Automation.Language.FunctionDefinitionAst])) {
+        $Enclosing = $Enclosing.Parent
+    }
+    if (-not $Enclosing -and $Cmd.Extent.StartOffset -lt $Defs[$Name]) {
+        $Early += "$Name called at line $($Cmd.Extent.StartLineNumber) but defined below it"
+    }
+}
+Check "no function is called before it is defined" ($Early.Count -eq 0) ($Early -join "; ")
 
 Write-Host "== it is pure ASCII =="
 # install.cmd fetches this with Invoke-WebRequest, which writes raw bytes, and


### PR DESCRIPTION
Two things, both reached from the same starting point: trying to install a beta.

## `--beta` never worked on Windows

`install.ps1` defines `Get-RemoteText` at the bottom of the file, but the pre-release lookup calls it near the top. A script executes top to bottom and `function` is a statement like any other, so the call ran before the definition did:

```
agav -> Resolving latest pre-release...
Could not resolve latest pre-release: The term 'Get-RemoteText' is not recognized
as the name of a cmdlet, function, script file, or operable program.
```

...then `exit 1`. This hit every Windows install that passed `--beta` or set `AGAV_BETA=1`, through both `iex` and `install.cmd` — there was no way to install a pre-release on Windows at all. The checksum call site already sat below the definition, which is why only the beta path broke.

Moving the function above its caller is the whole fix. To catch the next one statically, the lint suite now walks the AST and asserts every locally defined function appears above its first *top-level* call; calls from inside another function body are exempt, since those resolve at invocation rather than where they're written.

## README: pre-release builds

`--beta` was only discoverable from `--help`. Adds a section under Installation covering macOS/Linux, Windows PowerShell, and `cmd.exe`, plus the `AGAV_BETA` env var. Two things it spells out:

- **`irm ... | iex -- --beta` does not work** — it fails with a `ParameterBindingException`. `Invoke-Expression`'s `-Command` is positional at index 0, so `--beta` binds to it and the piped script has no parameter left. PowerShell has no `--` end-of-options convention. The README already used the `& ([scriptblock]::Create((irm ...)))` form for `--uninstall`; this reuses it and explains why it's required.
- **`agav update` won't move you off a pre-release onto the matching final.** It only queries `releases/latest` (pre-releases excluded), and `isNewer` strips the suffix, so `0.2.0-beta.1` compares equal to `0.2.0` and returns false — you stay until `0.2.1`. Documented rather than changed; re-running the installer without `--beta` is the escape hatch.

Also realigns the `--beta` line in both help texts, which sat two columns past every other option.

## Verifying

The Windows fix is exercised by the `installer-ps1` job here. End to end, against this branch:

```powershell
& ([scriptblock]::Create((irm https://raw.githubusercontent.com/prapaa-ai/agav/docs/beta-install/scripts/install.ps1))) --beta
```