### PR TITLE
feat: add new llm provider - openrouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Agav reads, searches and edits the repository you run it in, and runs the commands you'd otherwise run yourself.
 
-- **Five providers** — Anthropic, OpenAI, Gemini, Vertex AI and Ollama, switchable mid-session with `/model`.
+- **Six providers** — Anthropic, OpenAI, OpenRouter, Gemini, Vertex AI and Ollama, switchable mid-session with `/model`.
 - **Sandboxed commands** — shell tools run under Seatbelt on macOS and Bubblewrap on Linux where either is available.
 - **Non-interactive mode** — `agav run` and `agav --print` make the same agent scriptable from CI, with per-tool permissions and optional JSON Schema output.
 - **Sessions that survive** — resume, branch, name, search and export past conversations; `/compact` reclaims context without starting over. Plans are saved per-session and picked back up on resume.
@@ -38,6 +38,7 @@ Pick a provider and model, or take the defaults:
 
 ```bash
 agav --provider openai --model gpt-4o
+agav --provider openrouter --model openrouter/auto
 agav --provider vertex-ai --model vertex/gemini-3.5-flash
 agav -r                                  # resume a session (lists them if no id)
 ```
@@ -62,7 +63,7 @@ agav update
 
 | Flag | Meaning |
 | --- | --- |
-| `--provider`, `-p` | `anthropic`, `openai`, `gemini`, `vertex-ai` or `ollama` (default: `anthropic`) |
+| `--provider`, `-p` | `anthropic`, `openai`, `openrouter`, `gemini`, `vertex-ai` or `ollama` (default: `anthropic`) |
 | `--model`, `-m` | Model name |
 | `--effort` | Reasoning effort: `low`, `medium`, `high` or `max` (default: `high`) |
 | `--print`, `-P` | Run the prompt, print the result, exit |
@@ -291,7 +292,34 @@ Agav says which tool is missing when it hits one of these limits, so there is no
 
 ## Provider setup
 
-Anthropic, OpenAI, and Gemini need nothing more than their API key in the environment — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` — and Ollama just needs a local server running. Vertex AI takes a little more.
+Anthropic, OpenAI, and Gemini need nothing more than their API key in the environment — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` — and Ollama just needs a local server running. OpenRouter needs one key for every model on its platform; Vertex AI takes a little more.
+
+### OpenRouter
+
+OpenRouter fronts hundreds of models from Anthropic, OpenAI, Google, Meta, DeepSeek, Qwen and others behind a single API — one key, one bill, no vendor lock-in. Agav talks to it through its OpenAI-compatible Chat Completions endpoint, so tool calling works as usual.
+
+Create a key at [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys) (they start with `sk-or-v1-`) and export it:
+
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-...
+agav --provider openrouter --model openrouter/auto
+```
+
+The default model is `openrouter/auto`, which lets OpenRouter pick a suitable model per request. Any slug from the [model catalog](https://openrouter.ai/models) can be passed with `--model` or `/model`:
+
+```bash
+agav -p openrouter -m anthropic/claude-sonnet-4.5
+agav -p openrouter -m deepseek/deepseek-chat-v3.1
+```
+
+IDs ending in `-latest` prefixed with a tilde (`~anthropic/claude-sonnet-latest`) are OpenRouter aliases that always resolve to the newest version of a family — that's what `/fast` and `/deep` select:
+
+| Command | Model |
+| --- | --- |
+| `/fast` | `~google/gemini-flash-latest` |
+| `/deep` | `~anthropic/claude-sonnet-latest` |
+
+Like the other providers' keys, an `openrouterApiKey` field in `.agav/config.json` or `~/.agav/config.json` is accepted and encrypted at rest — prefer the environment variable. `/model` lists live models straight from your account, and context-window sizes are looked up from OpenRouter so `/context` stays accurate across the whole catalog.
 
 ### Ollama
 
@@ -351,6 +379,7 @@ Drop an `AGAV.md` (or `.agavrc`) in a repository to add project-specific instruc
 | Variable | Effect |
 | --- | --- |
 | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | Provider credentials |
+| `OPENROUTER_API_KEY` | OpenRouter credential (`sk-or-v1-...`) |
 | `VERTEX_AI_CREDENTIALS_PATH` / `VERTEX_AI_LOCATION` | Vertex AI service account and region |
 | `OLLAMA_HOST` / `OLLAMA_PORT` / `OLLAMA_ENDPOINT` / `OLLAMA_API_KEY` | Ollama connection |
 | `AGAV_OLLAMA_NUM_CTX` | Override the per-model Ollama context cap |

--- a/source/__tests__/agent-core.test.ts
+++ b/source/__tests__/agent-core.test.ts
@@ -84,7 +84,8 @@ describe("hooks", () => {
     expect(getHookForTool("edit_file", { path: "a" }, { afterEdit: "echo $path" })).toMatchObject({ hook: "echo $path" });
     expect(getHookForTool("run_command", { command: "git commit -m hi" }, { preCommit: "echo pre" })).toMatchObject({ hook: "echo pre" });
     expect(getHookForTool("run_command", { command: "ls" }, { afterShell: "echo shell" })).toMatchObject({ hook: "echo shell" });
-    expect(await runHook("printf hello", {})).toBe("hello");
+    const hookCmd = process.platform === "win32" ? "echo hello" : "printf hello";
+    expect(await runHook(hookCmd, {})).toBe("hello");
   });
 });
 

--- a/source/__tests__/commands.model-routing.test.ts
+++ b/source/__tests__/commands.model-routing.test.ts
@@ -44,6 +44,7 @@ describe("commands/model-routing", () => {
   it("/fast routes each provider to its own model", async () => {
     await expect(route(fastCommand, "anthropic")).resolves.toBe("claude-haiku-4-5-20251001");
     await expect(route(fastCommand, "openai")).resolves.toBe("gpt-4o-mini");
+    await expect(route(fastCommand, "openrouter")).resolves.toBe("~google/gemini-flash-latest");
     await expect(route(fastCommand, "gemini")).resolves.toBe("gemini-3.5-flash-lite");
     await expect(route(fastCommand, "vertex-ai")).resolves.toBe("vertex/gemini-3.5-flash-lite");
   });
@@ -51,6 +52,7 @@ describe("commands/model-routing", () => {
   it("/deep routes each provider to its own model", async () => {
     await expect(route(deepCommand, "anthropic")).resolves.toBe("claude-sonnet-4-20250514");
     await expect(route(deepCommand, "openai")).resolves.toBe("gpt-4o");
+    await expect(route(deepCommand, "openrouter")).resolves.toBe("~anthropic/claude-sonnet-latest");
     await expect(route(deepCommand, "gemini")).resolves.toBe("gemini-3.5-pro");
     await expect(route(deepCommand, "vertex-ai")).resolves.toBe("vertex/gemini-3.5-pro");
   });

--- a/source/__tests__/commands.model.test.ts
+++ b/source/__tests__/commands.model.test.ts
@@ -146,6 +146,20 @@ describe("commands/model", () => {
     expect(messageText(result)).toContain("Model changed to: deepseek/deepseek-chat-v3.1 (switched to openrouter)");
   });
 
+  it("keeps the direct provider for an OpenRouter slug with the same provider prefix", async () => {
+    stubFetch([], ["anthropic/claude-sonnet-4.5"]);
+
+    const context = createContext({
+      provider: "anthropic",
+      openrouterApiKey: "sk-or-v1-test",
+    });
+    const result = await modelCommand.execute("anthropic/claude-sonnet-4.5", context);
+
+    expect(context.setModel).toHaveBeenCalledWith("anthropic/claude-sonnet-4.5");
+    expect(context.setProvider).not.toHaveBeenCalled();
+    expect(messageText(result)).toBe("Model changed to: anthropic/claude-sonnet-4.5");
+  });
+
   it("swallows OpenRouter API errors gracefully when fetching models", async () => {
     globalThis.fetch = vi.fn(async (input: any) => {
       if (String(input).includes("openrouter.ai")) {

--- a/source/__tests__/commands.model.test.ts
+++ b/source/__tests__/commands.model.test.ts
@@ -14,15 +14,22 @@ import type { AgavConfig } from "../config/config.js";
 const originalFetch = globalThis.fetch;
 
 /**
- * Answer only the Anthropic listing; every other endpoint (Ollama in
+ * Answer Anthropic and OpenRouter listings; every other endpoint (Ollama in
  * particular) is treated as unreachable so the tests never touch the network.
  */
-function stubFetch(anthropicModels: string[]): void {
+function stubFetch(anthropicModels: string[] = [], openrouterModels: string[] = []): void {
   globalThis.fetch = vi.fn(async (input: any) => {
-    if (String(input).includes("api.anthropic.com")) {
+    const url = String(input);
+    if (url.includes("api.anthropic.com")) {
       return {
         ok: true,
         json: async () => ({ data: anthropicModels.map((id) => ({ id })) }),
+      } as any;
+    }
+    if (url.includes("openrouter.ai/api/v1/models")) {
+      return {
+        ok: true,
+        json: async () => ({ data: openrouterModels.map((id) => ({ id })) }),
       } as any;
     }
     throw new Error("unreachable");
@@ -123,5 +130,33 @@ describe("commands/model", () => {
 
     expect(fetchVertexAIModelsMock).not.toHaveBeenCalled();
     expect(messageText(result)).not.toContain("Vertex AI models unavailable");
+  });
+
+  it("lists OpenRouter models and auto-switches provider when an OpenRouter model is selected", async () => {
+    stubFetch([], ["anthropic/claude-sonnet-4.5", "deepseek/deepseek-chat-v3.1"]);
+
+    const context = createContext({
+      provider: "anthropic",
+      openrouterApiKey: "sk-or-v1-test",
+    });
+    const result = await modelCommand.execute("deepseek/deepseek-chat-v3.1", context);
+
+    expect(context.setModel).toHaveBeenCalledWith("deepseek/deepseek-chat-v3.1");
+    expect(context.setProvider).toHaveBeenCalledWith("openrouter");
+    expect(messageText(result)).toContain("Model changed to: deepseek/deepseek-chat-v3.1 (switched to openrouter)");
+  });
+
+  it("swallows OpenRouter API errors gracefully when fetching models", async () => {
+    globalThis.fetch = vi.fn(async (input: any) => {
+      if (String(input).includes("openrouter.ai")) {
+        return { ok: false, status: 500 } as any;
+      }
+      throw new Error("unreachable");
+    }) as any;
+
+    const context = createContext({ openrouterApiKey: "sk-or-v1-test" });
+    const result = await modelCommand.execute("", context);
+
+    expect(messageText(result)).toContain("No providers reachable");
   });
 });

--- a/source/__tests__/config-keybindings.test.ts
+++ b/source/__tests__/config-keybindings.test.ts
@@ -17,12 +17,17 @@ describe("keybindings", () => {
   });
 
   it("loads defaults and overrides from global and project files", async () => {
+    const { homedir } = await import("node:os");
+    const { join } = await import("node:path");
+    const globalPath = join(homedir(), ".agav", "keybindings.json");
+    const projectPath = join(process.cwd(), ".agav", "keybindings.json");
+
     readFile.mockImplementation(async (path: any) => {
-      if (String(path).includes("/keybindings.json") && String(path).includes(".agav")) {
-        return JSON.stringify({ submit: ["return"], exit: "ctrl+x" });
+      if (String(path) === globalPath) {
+        return JSON.stringify({ exit: "ctrl+x" });
       }
-      if (String(path).includes(".agav/keybindings.json")) {
-        return JSON.stringify({ submit: ["shift+enter"], cancel: "esc" });
+      if (String(path) === projectPath) {
+        return JSON.stringify({ submit: ["return"], cancel: "esc" });
       }
       throw new Error("missing");
     });

--- a/source/__tests__/config.test.ts
+++ b/source/__tests__/config.test.ts
@@ -85,6 +85,26 @@ describe("config", () => {
     expect(updated.template.provider.enum).not.toContain("legacy-provider");
   });
 
+  it("does not rewrite the project config when its template is current", async () => {
+    let projectContents: string | undefined;
+    readFile.mockImplementation(async (path: any) => {
+      if (/[\\/]\.agav[\\/]config\.json$/.test(String(path)) && projectContents !== undefined) {
+        return projectContents;
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+    writeFile.mockImplementation(async (_path: any, contents: any) => {
+      projectContents = String(contents);
+    });
+
+    const mod = await import("../config/config.js");
+    await mod.loadConfig();
+    expect(writeFile).toHaveBeenCalledTimes(1);
+
+    await mod.loadConfig();
+    expect(writeFile).toHaveBeenCalledTimes(1);
+  });
+
   it("loads project-level secrets when env vars are absent", async () => {
     readFile.mockImplementation(async (path: any) => {
       const s = String(path);

--- a/source/__tests__/config.test.ts
+++ b/source/__tests__/config.test.ts
@@ -56,6 +56,35 @@ describe("config", () => {
     expect(result.permissionMode).toBe("ask");
   });
 
+  it("refreshes the project config template without changing user settings", async () => {
+    const userConfig = {
+      provider: "ollama",
+      model: "custom-model",
+      customSetting: { keep: true },
+      template: { provider: { enum: ["legacy-provider"] } },
+    };
+
+    readFile.mockImplementation(async (path: any) => {
+      if (/[\\/]\.agav[\\/]config\.json$/.test(String(path))) {
+        return JSON.stringify(userConfig);
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+
+    const mod = await import("../config/config.js");
+    await mod.loadConfig();
+
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    const updated = JSON.parse(String(writeFile.mock.calls[0]?.[1]));
+    expect(updated).toMatchObject({
+      provider: "ollama",
+      model: "custom-model",
+      customSetting: { keep: true },
+    });
+    expect(updated.template.provider.enum).toContain("openrouter");
+    expect(updated.template.provider.enum).not.toContain("legacy-provider");
+  });
+
   it("loads project-level secrets when env vars are absent", async () => {
     readFile.mockImplementation(async (path: any) => {
       const s = String(path);

--- a/source/__tests__/config.test.ts
+++ b/source/__tests__/config.test.ts
@@ -23,6 +23,7 @@ describe("config", () => {
     writeFile.mockReset();
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
     delete process.env.GEMINI_API_KEY;
     delete process.env.OLLAMA_ENDPOINT;
     delete process.env.OLLAMA_HOST;
@@ -62,6 +63,7 @@ describe("config", () => {
         return JSON.stringify({
           anthropicApiKey: "enc:anthropic-project",
           openaiApiKey: "enc:openai-project",
+          openrouterApiKey: "enc:openrouter-project",
           geminiApiKey: "enc:gemini-project",
           ollamaApiKey: "enc:ollama-project",
         });
@@ -70,6 +72,7 @@ describe("config", () => {
         return JSON.stringify({
           anthropicApiKey: "enc:anthropic-global",
           openaiApiKey: "enc:openai-global",
+          openrouterApiKey: "enc:openrouter-global",
           geminiApiKey: "enc:gemini-global",
           ollamaApiKey: "enc:ollama-global",
         });
@@ -82,6 +85,7 @@ describe("config", () => {
 
     expect(loaded.anthropicApiKey).toBe("anthropic-project");
     expect(loaded.openaiApiKey).toBe("openai-project");
+    expect(loaded.openrouterApiKey).toBe("openrouter-project");
     expect(loaded.geminiApiKey).toBe("gemini-project");
     expect(loaded.ollamaApiKey).toBe("ollama-project");
   });
@@ -125,6 +129,7 @@ describe("config", () => {
   it("applies env overrides and encrypts secrets on save", async () => {
     process.env.ANTHROPIC_API_KEY = "enc:anthropic-env";
     process.env.OPENAI_API_KEY = "enc:openai-env";
+    process.env.OPENROUTER_API_KEY = "enc:openrouter-env";
     process.env.GEMINI_API_KEY = "enc:gemini-env";
     process.env.OLLAMA_ENDPOINT = "http://localhost:11434";
     process.env.OLLAMA_HOST = "127.0.0.1";
@@ -136,7 +141,13 @@ describe("config", () => {
     readFile.mockImplementation(async (path: any) => {
       const s = String(path);
       if (s.includes("/config.json") && !s.includes(".agav/config.json")) {
-        return JSON.stringify({ anthropicApiKey: "enc:anthropic-file", openaiApiKey: "enc:openai-file", geminiApiKey: "enc:gemini-file", ollamaApiKey: "enc:ollama-file" });
+        return JSON.stringify({
+          anthropicApiKey: "enc:anthropic-file",
+          openaiApiKey: "enc:openai-file",
+          openrouterApiKey: "enc:openrouter-file",
+          geminiApiKey: "enc:gemini-file",
+          ollamaApiKey: "enc:ollama-file",
+        });
       }
       if (s.endsWith("/.agav/config.json") || s.includes("/.agav/config.json")) {
         return JSON.stringify({});
@@ -149,6 +160,7 @@ describe("config", () => {
 
     expect(loaded.anthropicApiKey).toBe("anthropic-env");
     expect(loaded.openaiApiKey).toBe("openai-env");
+    expect(loaded.openrouterApiKey).toBe("openrouter-env");
     expect(loaded.geminiApiKey).toBe("gemini-env");
     expect(loaded.ollamaApiKey).toBe("ollama-env");
     expect(loaded.ollamaEndpoint).toBe("http://localhost:11434");
@@ -167,6 +179,7 @@ describe("config", () => {
       permissionMode: "ask",
       anthropicApiKey: "a",
       openaiApiKey: "o",
+      openrouterApiKey: "r",
       geminiApiKey: "g",
       ollamaApiKey: "l",
     });
@@ -174,6 +187,7 @@ describe("config", () => {
     const body = String(writeFile.mock.calls.at(-1)?.[1]);
     expect(body).toContain("enc:a");
     expect(body).toContain("enc:o");
+    expect(body).toContain("enc:r");
     expect(body).toContain("enc:g");
     expect(body).toContain("enc:l");
   });

--- a/source/__tests__/providers.openai.test.ts
+++ b/source/__tests__/providers.openai.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StreamEvent } from "../providers/types.js";
+
+const createChatCompletion = vi.fn();
+const createResponse = vi.fn();
+let capturedClientOptions: any = null;
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      constructor(options: any) {
+        capturedClientOptions = options;
+      }
+      chat = {
+        completions: {
+          create: createChatCompletion,
+        },
+      };
+      responses = {
+        create: createResponse,
+      };
+    },
+  };
+});
+
+const { OpenAIProvider } = await import("../providers/openai.js");
+
+function mockChatStream(chunks: any[]) {
+  createChatCompletion.mockImplementation(async () => (async function* () {
+    for (const chunk of chunks) yield chunk;
+  })());
+}
+
+function mockResponsesStream(events: any[]) {
+  createResponse.mockImplementation(async () => (async function* () {
+    for (const event of events) yield event;
+  })());
+}
+
+async function collectEvents(provider: InstanceType<typeof OpenAIProvider>, params: any = {}): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of provider.stream({
+    model: "gpt-4o",
+    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    systemPrompt: "sys",
+    ...params,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedClientOptions = null;
+});
+
+describe("OpenAIProvider configuration options", () => {
+  it("defaults to openai name and standard options", () => {
+    const provider = new OpenAIProvider("test-key");
+    expect(provider.name).toBe("openai");
+    expect(capturedClientOptions).toEqual({
+      apiKey: "test-key",
+      baseURL: undefined,
+      defaultHeaders: undefined,
+    });
+  });
+
+  it("supports custom name, baseURL, and defaultHeaders", () => {
+    const provider = new OpenAIProvider("test-key", "chat", {
+      name: "custom-openai",
+      baseURL: "https://custom.openai.endpoint/v1",
+      defaultHeaders: { "X-Custom-Header": "custom-value" },
+    });
+    expect(provider.name).toBe("custom-openai");
+    expect(capturedClientOptions).toEqual({
+      apiKey: "test-key",
+      baseURL: "https://custom.openai.endpoint/v1",
+      defaultHeaders: { "X-Custom-Header": "custom-value" },
+    });
+  });
+});
+
+describe("OpenAIProvider chat streaming", () => {
+  it("uses max_completion_tokens for standard OpenAI provider", async () => {
+    mockChatStream([
+      { choices: [{ delta: { content: "ok" }, finish_reason: "stop" }] },
+    ]);
+
+    const provider = new OpenAIProvider("test-key", "chat");
+    await collectEvents(provider, { model: "gpt-4o", maxTokens: 4096 });
+
+    expect(createChatCompletion).toHaveBeenCalledTimes(1);
+    const callArgs = createChatCompletion.mock.calls[0]?.[0];
+    expect(callArgs.max_completion_tokens).toBe(4096);
+    expect(callArgs.max_tokens).toBeUndefined();
+  });
+
+  it("emits thinking_delta when reasoning is in delta", async () => {
+    mockChatStream([
+      { choices: [{ delta: { reasoning: "Thinking deeply..." } }] },
+      { choices: [{ delta: { content: "Final answer" }, finish_reason: "stop" }] },
+    ]);
+
+    const provider = new OpenAIProvider("test-key", "chat");
+    const events = await collectEvents(provider);
+
+    expect(events).toContainEqual({ type: "thinking_delta", text: "Thinking deeply..." });
+    expect(events).toContainEqual({ type: "text_delta", text: "Final answer" });
+  });
+
+  it("does not emit thinking_delta when reasoning is empty or not a string", async () => {
+    mockChatStream([
+      { choices: [{ delta: { reasoning: "" } }] },
+      { choices: [{ delta: { content: "Answer" }, finish_reason: "stop" }] },
+    ]);
+
+    const provider = new OpenAIProvider("test-key", "chat");
+    const events = await collectEvents(provider);
+
+    expect(events.filter((e) => e.type === "thinking_delta")).toHaveLength(0);
+  });
+});
+
+describe("OpenAIProvider responses streaming", () => {
+  it("emits thinking_delta on reasoning summary delta", async () => {
+    mockResponsesStream([
+      { type: "response.reasoning_summary_text.delta", delta: "Step 1 thinking" },
+      { type: "response.output_text.delta", delta: "Result" },
+      { type: "response.completed", response: { status: "completed", usage: { input_tokens: 10, output_tokens: 5 } } },
+    ]);
+
+    const provider = new OpenAIProvider("test-key", "responses");
+    const events = await collectEvents(provider);
+
+    expect(events).toContainEqual({ type: "thinking_delta", text: "Step 1 thinking" });
+    expect(events).toContainEqual({ type: "text_delta", text: "Result" });
+    expect(events).toContainEqual({ type: "usage", inputTokens: 10, outputTokens: 5, cacheReadTokens: 0 });
+    expect(events).toContainEqual({ type: "message_end", stopReason: "completed" });
+  });
+});

--- a/source/__tests__/providers.openrouter.test.ts
+++ b/source/__tests__/providers.openrouter.test.ts
@@ -102,7 +102,7 @@ describe("OpenRouterProvider getContextWindow", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("returns undefined for unknown models and caches the miss", async () => {
+  it("returns undefined for unknown models and caches the miss until the TTL expires", async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       json: async () => ({
@@ -117,10 +117,19 @@ describe("OpenRouterProvider getContextWindow", () => {
     expect(missingContext).toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    // Second call does not re-fetch
+    // Second call does not re-fetch until the negative cache expires.
     const missingAgain = await provider.getContextWindow("unknown/model");
     expect(missingAgain).toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    try {
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      await provider.getContextWindow("unknown/model");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns undefined when fetch fails or returns non-ok status", async () => {
@@ -168,6 +177,19 @@ describe("OpenRouterProvider streaming chat completions", () => {
     const callArgs = createChatCompletion.mock.calls[0]?.[0];
     expect(callArgs.max_tokens).toBe(16384);
     expect(callArgs.max_completion_tokens).toBeUndefined();
+  });
+
+  it("uses prompt steering instead of reasoning_effort for mixed model families", async () => {
+    mockChatStream([
+      { choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] },
+    ]);
+
+    const provider = new OpenRouterProvider("test-key");
+    await collectEvents(provider, { model: "deepseek/deepseek-chat-v3.1", effort: "high" });
+
+    const callArgs = createChatCompletion.mock.calls[0]?.[0];
+    expect(callArgs.reasoning_effort).toBeUndefined();
+    expect(callArgs.messages[0]?.content).toContain("Think carefully");
   });
 
   it("emits thinking_delta events when delta.reasoning is provided", async () => {

--- a/source/__tests__/providers.openrouter.test.ts
+++ b/source/__tests__/providers.openrouter.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StreamEvent } from "../providers/types.js";
+
+const createChatCompletion = vi.fn();
+const createResponse = vi.fn();
+let capturedClientOptions: any = null;
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      constructor(options: any) {
+        capturedClientOptions = options;
+      }
+      chat = {
+        completions: {
+          create: createChatCompletion,
+        },
+      };
+      responses = {
+        create: createResponse,
+      };
+    },
+  };
+});
+
+const { OpenRouterProvider } = await import("../providers/openrouter.js");
+
+const originalFetch = globalThis.fetch;
+
+function mockChatStream(chunks: any[]) {
+  createChatCompletion.mockImplementation(async () => (async function* () {
+    for (const chunk of chunks) yield chunk;
+  })());
+}
+
+async function collectEvents(provider: InstanceType<typeof OpenRouterProvider>, params: any = {}): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of provider.stream({
+    model: "openrouter/auto",
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    systemPrompt: "sys",
+    ...params,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedClientOptions = null;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("OpenRouterProvider client configuration", () => {
+  it("configures OpenAI client with OpenRouter baseURL, name, and default headers", () => {
+    const provider = new OpenRouterProvider("test-openrouter-key");
+    expect(provider.name).toBe("openrouter");
+    expect(capturedClientOptions).toEqual({
+      apiKey: "test-openrouter-key",
+      baseURL: "https://openrouter.ai/api/v1",
+      defaultHeaders: {
+        "HTTP-Referer": "https://github.com/prapaa-ai/agav",
+        "X-OpenRouter-Title": "Agav",
+      },
+    });
+  });
+});
+
+describe("OpenRouterProvider getContextWindow", () => {
+  it("fetches context window from OpenRouter models endpoint and caches results", async () => {
+    const fetchMock = vi.fn(async (input: any, init: any) => {
+      if (String(input) === "https://openrouter.ai/api/v1/models") {
+        expect(init?.headers).toEqual({ Authorization: "Bearer test-key" });
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: "anthropic/claude-sonnet-4.5", context_length: 200000 },
+              { id: "google/gemini-flash-1.5", context_length: 1000000 },
+            ],
+          }),
+        } as any;
+      }
+      return { ok: false, status: 404 } as any;
+    });
+    globalThis.fetch = fetchMock;
+
+    const provider = new OpenRouterProvider("test-key");
+
+    // First call fetches models
+    const sonnetContext = await provider.getContextWindow("anthropic/claude-sonnet-4.5");
+    expect(sonnetContext).toBe(200000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second call for another model uses cached result
+    const geminiContext = await provider.getContextWindow("google/gemini-flash-1.5");
+    expect(geminiContext).toBe(1000000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined for unknown models and caches the miss", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic/claude-sonnet-4.5", context_length: 200000 }],
+      }),
+    })) as any;
+    globalThis.fetch = fetchMock;
+
+    const provider = new OpenRouterProvider("test-key");
+
+    const missingContext = await provider.getContextWindow("unknown/model");
+    expect(missingContext).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second call does not re-fetch
+    const missingAgain = await provider.getContextWindow("unknown/model");
+    expect(missingAgain).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined when fetch fails or returns non-ok status", async () => {
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 500 })) as any;
+
+    const provider = new OpenRouterProvider("test-key");
+    const result = await provider.getContextWindow("anthropic/claude-sonnet-4.5");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when fetch throws network error", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("Network error");
+    }) as any;
+
+    const provider = new OpenRouterProvider("test-key");
+    const result = await provider.getContextWindow("anthropic/claude-sonnet-4.5");
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("OpenRouterProvider streaming chat completions", () => {
+  it("uses max_tokens instead of max_completion_tokens in chat request", async () => {
+    mockChatStream([
+      { choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] },
+    ]);
+
+    const provider = new OpenRouterProvider("test-key");
+    await collectEvents(provider, { model: "openrouter/auto", maxTokens: 8192 });
+
+    expect(createChatCompletion).toHaveBeenCalledTimes(1);
+    const callArgs = createChatCompletion.mock.calls[0]?.[0];
+    expect(callArgs.max_tokens).toBe(8192);
+    expect(callArgs.max_completion_tokens).toBeUndefined();
+  });
+
+  it("defaults max_tokens to 16384 when not specified", async () => {
+    mockChatStream([
+      { choices: [{ delta: { content: "hi" }, finish_reason: "stop" }] },
+    ]);
+
+    const provider = new OpenRouterProvider("test-key");
+    await collectEvents(provider, { model: "openrouter/auto" });
+
+    const callArgs = createChatCompletion.mock.calls[0]?.[0];
+    expect(callArgs.max_tokens).toBe(16384);
+    expect(callArgs.max_completion_tokens).toBeUndefined();
+  });
+
+  it("emits thinking_delta events when delta.reasoning is provided", async () => {
+    mockChatStream([
+      { choices: [{ delta: { reasoning: "Analyzing the prompt..." } }] },
+      { choices: [{ delta: { reasoning: " Formulating plan." } }] },
+      { choices: [{ delta: { content: "Here is the answer." }, finish_reason: "stop" }] },
+    ]);
+
+    const provider = new OpenRouterProvider("test-key");
+    const events = await collectEvents(provider);
+
+    const thinkingDeltas = events.filter((e) => e.type === "thinking_delta");
+    expect(thinkingDeltas).toEqual([
+      { type: "thinking_delta", text: "Analyzing the prompt..." },
+      { type: "thinking_delta", text: " Formulating plan." },
+    ]);
+
+    const textDeltas = events.filter((e) => e.type === "text_delta");
+    expect(textDeltas).toEqual([
+      { type: "text_delta", text: "Here is the answer." },
+    ]);
+  });
+
+  it("emits tool call events and usage metadata correctly", async () => {
+    mockChatStream([
+      {
+        usage: { prompt_tokens: 50, completion_tokens: 25, prompt_tokens_details: { cached_tokens: 10 } },
+        choices: [],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, id: "call_abc", function: { name: "read_file", arguments: '{"path":' } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, function: { arguments: '"test.txt"}' } },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+    ]);
+
+    const provider = new OpenRouterProvider("test-key");
+    const events = await collectEvents(provider);
+
+    expect(events).toEqual([
+      { type: "message_start" },
+      { type: "usage", inputTokens: 50, outputTokens: 25, cacheReadTokens: 10 },
+      { type: "tool_call_start", toolCallId: "call_abc", toolName: "read_file" },
+      { type: "tool_call_delta", toolCallId: "call_abc", argsJson: '{"path":' },
+      { type: "tool_call_delta", toolCallId: "call_abc", argsJson: '"test.txt"}' },
+      { type: "tool_call_end", toolCallId: "call_abc" },
+      { type: "message_end", stopReason: "tool_calls" },
+    ]);
+  });
+});

--- a/source/__tests__/providers.registry.test.ts
+++ b/source/__tests__/providers.registry.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { createProvider } from "../providers/registry.js";
+import { OpenRouterProvider } from "../providers/openrouter.js";
+import { OpenAIProvider } from "../providers/openai.js";
+import { AnthropicProvider } from "../providers/anthropic.js";
+import { GeminiProvider } from "../providers/gemini.js";
+import { OllamaProvider } from "../providers/ollama.js";
+import { VertexAIProvider } from "../providers/vertex-ai.js";
+import { RetryProvider } from "../providers/retry.js";
+import type { AgavConfig } from "../config/config.js";
+
+const baseConfig: AgavConfig = {
+  provider: "openrouter",
+  model: "openrouter/auto",
+  effort: "high",
+  maxTokens: 1024,
+  maxIterations: 10,
+  errorRetries: 3,
+  permissionMode: "ask",
+};
+
+describe("createProvider registry", () => {
+  it("creates OpenRouterProvider wrapped in RetryProvider for openrouter", () => {
+    const config: AgavConfig = {
+      ...baseConfig,
+      provider: "openrouter",
+      openrouterApiKey: "sk-or-v1-test",
+    };
+
+    const provider = createProvider(config);
+    expect(provider).toBeInstanceOf(RetryProvider);
+    expect(provider.name).toBe("openrouter");
+    expect(provider.getContextWindow).toBeTypeOf("function");
+  });
+
+  it("throws when OpenRouter credentials are missing", () => {
+    const config: AgavConfig = {
+      ...baseConfig,
+      provider: "openrouter",
+      openrouterApiKey: undefined,
+    };
+
+    expect(() => createProvider(config)).toThrow(/OpenRouter API key not found/);
+  });
+
+  it("creates OpenAIProvider for openai", () => {
+    const config: AgavConfig = {
+      ...baseConfig,
+      provider: "openai",
+      openaiApiKey: "sk-test",
+    };
+
+    const provider = createProvider(config);
+    expect(provider).toBeInstanceOf(RetryProvider);
+    expect(provider.name).toBe("openai");
+  });
+
+  it("creates AnthropicProvider for anthropic", () => {
+    const config: AgavConfig = {
+      ...baseConfig,
+      provider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+    };
+
+    const provider = createProvider(config);
+    expect(provider).toBeInstanceOf(RetryProvider);
+    expect(provider.name).toBe("anthropic");
+  });
+
+  it("creates GeminiProvider for gemini", () => {
+    const config: AgavConfig = {
+      ...baseConfig,
+      provider: "gemini",
+      geminiApiKey: "gemini-test",
+    };
+
+    const provider = createProvider(config);
+    expect(provider).toBeInstanceOf(RetryProvider);
+    expect(provider.name).toBe("gemini");
+  });
+
+  it("creates OllamaProvider for ollama", () => {
+    const config: AgavConfig = {
+      ...baseConfig,
+      provider: "ollama",
+    };
+
+    const provider = createProvider(config);
+    expect(provider).toBeInstanceOf(RetryProvider);
+    expect(provider.name).toBe("ollama");
+  });
+
+  it("creates VertexAIProvider for vertex-ai", () => {
+    const config: AgavConfig = {
+      ...baseConfig,
+      provider: "vertex-ai",
+      vertexAICredentialsPath: "/tmp/fake-sa.json",
+    };
+
+    const provider = createProvider(config);
+    expect(provider).toBeInstanceOf(RetryProvider);
+    expect(provider.name).toBe("vertex-ai");
+  });
+
+  it("throws on unsupported provider", () => {
+    const config: any = {
+      ...baseConfig,
+      provider: "unsupported-provider",
+    };
+
+    expect(() => createProvider(config)).toThrow();
+  });
+});

--- a/source/__tests__/providers.retry.test.ts
+++ b/source/__tests__/providers.retry.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { RetryProvider } from "../providers/retry.js";
+import type { LLMProvider, StreamEvent, StreamParams } from "../providers/types.js";
+
+function createMockProvider(overrides: Partial<LLMProvider> = {}): LLMProvider {
+  return {
+    name: "mock-provider",
+    stream: vi.fn(async function* () {
+      yield { type: "text_delta" as const, text: "hello" };
+    }),
+    ...overrides,
+  };
+}
+
+describe("RetryProvider capability forwarding", () => {
+  it("forwards getContextWindow when implemented by inner provider", async () => {
+    const inner = createMockProvider({
+      name: "openrouter",
+      getContextWindow: vi.fn().mockResolvedValue(128000),
+    });
+
+    const retry = new RetryProvider(inner);
+
+    expect(retry.getContextWindow).toBeTypeOf("function");
+    const result = await retry.getContextWindow!("anthropic/claude-sonnet-4.5");
+    expect(result).toBe(128000);
+    expect(inner.getContextWindow).toHaveBeenCalledWith("anthropic/claude-sonnet-4.5");
+  });
+
+  it("leaves getContextWindow undefined when inner provider does not implement it", () => {
+    const inner = createMockProvider({ name: "anthropic" });
+    delete inner.getContextWindow;
+
+    const retry = new RetryProvider(inner);
+
+    expect(retry.getContextWindow).toBeUndefined();
+  });
+
+  it("forwards the provider name", () => {
+    const inner = createMockProvider({ name: "openrouter" });
+    const retry = new RetryProvider(inner);
+    expect(retry.name).toBe("openrouter");
+  });
+});
+
+describe("RetryProvider stream and error retries", () => {
+  const dummyParams: StreamParams = {
+    model: "test-model",
+    messages: [{ role: "user", content: [{ type: "text", text: "test" }] }],
+  };
+
+  it("streams normally when no errors occur", async () => {
+    const inner = createMockProvider({
+      stream: vi.fn(async function* (): AsyncGenerator<StreamEvent> {
+        yield { type: "message_start" };
+        yield { type: "text_delta", text: "result" };
+        yield { type: "message_end", stopReason: "stop" };
+      }),
+    });
+
+    const retry = new RetryProvider(inner);
+    const events: StreamEvent[] = [];
+    for await (const ev of retry.stream(dummyParams)) {
+      events.push(ev);
+    }
+
+    expect(events).toEqual([
+      { type: "message_start" },
+      { type: "text_delta", text: "result" },
+      { type: "message_end", stopReason: "stop" },
+    ]);
+  });
+
+  it("retries on retryable errors and succeeds when next attempt passes", async () => {
+    let attempts = 0;
+    const inner = createMockProvider({
+      stream: vi.fn(async function* (): AsyncGenerator<StreamEvent> {
+        attempts++;
+        if (attempts === 1) {
+          const err: any = new Error("Rate limited");
+          err.status = 429;
+          throw err;
+        }
+        yield { type: "text_delta", text: "recovered" };
+      }),
+    });
+
+    const retry = new RetryProvider(inner, 2);
+    const events: StreamEvent[] = [];
+    for await (const ev of retry.stream(dummyParams)) {
+      events.push(ev);
+    }
+
+    expect(attempts).toBe(2);
+    expect(events.some((e) => e.type === "error")).toBe(true);
+    expect(events.some((e) => e.type === "text_delta" && e.text === "recovered")).toBe(true);
+  });
+
+  it("throws non-retryable error immediately", async () => {
+    let attempts = 0;
+    const inner = createMockProvider({
+      stream: vi.fn(async function* (): AsyncGenerator<StreamEvent> {
+        attempts++;
+        const err: any = new Error("Invalid request");
+        err.status = 400;
+        throw err;
+      }),
+    });
+
+    const retry = new RetryProvider(inner, 3);
+    await expect(async () => {
+      for await (const _ of retry.stream(dummyParams)) {
+        // drain
+      }
+    }).rejects.toThrow("Invalid request");
+
+    expect(attempts).toBe(1);
+  });
+});

--- a/source/__tests__/smoke.test.ts
+++ b/source/__tests__/smoke.test.ts
@@ -47,6 +47,7 @@ describe("CLI boot", () => {
     const result = await runCli(["-P", "hello"], {
       ANTHROPIC_API_KEY: "",
       OPENAI_API_KEY: "",
+      OPENROUTER_API_KEY: "",
       GEMINI_API_KEY: "",
       VERTEX_AI_CREDENTIALS_PATH: "",
     });

--- a/source/__tests__/startup.test.ts
+++ b/source/__tests__/startup.test.ts
@@ -30,6 +30,10 @@ describe("startup provider and model resolution", () => {
       provider: "openai",
       model: "gpt-5.4-mini",
     });
+    expect(resolveStartupSelection(base, { cliProvider: "openrouter" })).toMatchObject({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
   });
 
   it("restores both provider and model from a resumed session", () => {
@@ -76,6 +80,10 @@ describe("startup provider and model resolution", () => {
       provider: "openai",
       model: "gpt-5.4-mini",
     });
+    expect(selectConfiguredProvider({ ...base, openrouterApiKey: "key" })).toMatchObject({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
   });
 
   it("keeps an explicit --model when falling back to another provider", () => {
@@ -91,7 +99,7 @@ describe("startup provider and model resolution", () => {
 
   it("names a runnable command for every provider when nothing is configured", () => {
     const message = noProviderCredentialsError();
-    for (const variable of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "VERTEX_AI_CREDENTIALS_PATH"]) {
+    for (const variable of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY", "VERTEX_AI_CREDENTIALS_PATH"]) {
       // The shell-specific prefix is covered by utils.shell-hints; here it only
       // matters that each variable is shown as a command, not just named.
       expect(message).toMatch(new RegExp(`(export|set|\\$env:)\\s?${variable}`));
@@ -104,5 +112,9 @@ describe("startup provider and model resolution", () => {
       .toContain("ANTHROPIC_API_KEY");
     expect(providerConfigurationError({ ...base, provider: "openai", openaiApiKey: undefined }))
       .toContain("OPENAI_API_KEY");
+    expect(providerConfigurationError({ ...base, provider: "openrouter", openrouterApiKey: undefined }))
+      .toContain("OPENROUTER_API_KEY");
+    expect(providerConfigurationError({ ...base, provider: "openrouter", openrouterApiKey: "sk-or-test" }))
+      .toBeNull();
   });
 });

--- a/source/agent/hooks.ts
+++ b/source/agent/hooks.ts
@@ -7,8 +7,12 @@ export async function runHook(hook: string, vars: Record<string, string>): Promi
     command = command.replaceAll(`$${key}`, value);
   }
 
+  const isWindows = process.platform === "win32";
+  const shell = isWindows ? "cmd.exe" : "/bin/sh";
+  const shellArgs = isWindows ? ["/c", command] : ["-c", command];
+
   return new Promise((resolve) => {
-    execFile("/bin/sh", ["-c", command], { timeout: 5000 }, (err, stdout) => {
+    execFile(shell, shellArgs, { timeout: 5000 }, (err, stdout) => {
       if (err) {
         resolve(null);
       } else {

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -67,10 +67,10 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   const [config, setConfig] = useState(initialConfig);
   const activeProvider = useMemo<LLMProvider | null>(() => {
     try { return createProvider(config); } catch { return null; }
-  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.vertexAICredentialsPath, config.vertexAILocation, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
+  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.openrouterApiKey, config.geminiApiKey, config.vertexAICredentialsPath, config.vertexAILocation, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
   const activeSideProvider = useMemo<LLMProvider | null>(() => {
     try { return createProvider(config); } catch { return null; }
-  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.geminiApiKey, config.vertexAICredentialsPath, config.vertexAILocation, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
+  }, [config.provider, config.anthropicApiKey, config.openaiApiKey, config.openrouterApiKey, config.geminiApiKey, config.vertexAICredentialsPath, config.vertexAILocation, config.ollamaEndpoint, config.ollamaHost, config.ollamaPort, config.ollamaApiKey, config.errorRetries]);
   const [showToolDetail, setShowToolDetail] = useState(false);
   const [showPlanDetail, setShowPlanDetail] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);

--- a/source/commands/model-routing.ts
+++ b/source/commands/model-routing.ts
@@ -4,6 +4,7 @@ import type { SlashCommand, CommandResult, CommandContext } from "./types.js"
 const FAST_MODELS: Record<string, string> = {
   anthropic: "claude-haiku-4-5-20251001",
   openai: "gpt-4o-mini",
+  openrouter: "~google/gemini-flash-latest",
   gemini: "gemini-3.5-flash-lite",
   "vertex-ai": "vertex/gemini-3.5-flash-lite",
 }
@@ -12,6 +13,7 @@ const FAST_MODELS: Record<string, string> = {
 const DEEP_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-20250514",
   openai: "gpt-4o",
+  openrouter: "~anthropic/claude-sonnet-latest",
   gemini: "gemini-3.5-pro",
   "vertex-ai": "vertex/gemini-3.5-pro",
 }

--- a/source/commands/model.ts
+++ b/source/commands/model.ts
@@ -44,6 +44,22 @@ async function fetchOpenAIModels(apiKey: string): Promise<FetchedModel[]> {
   }
 }
 
+async function fetchOpenRouterModels(apiKey: string): Promise<FetchedModel[]> {
+  try {
+    const res = await fetch("https://openrouter.ai/api/v1/models", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { data?: { id: string }[] };
+    return (data.data ?? [])
+      .map((m) => ({ id: m.id, provider: "openrouter" }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+  } catch {
+    return [];
+  }
+}
+
 async function fetchOllamaModels(baseUrl: string): Promise<FetchedModel[]> {
   try {
     const res = await fetch(`${baseUrl}/api/tags`, {
@@ -106,6 +122,7 @@ async function fetchAllModels(config: AgavConfig): Promise<FetchAllResult> {
 
   if (config.anthropicApiKey) fetches.push(fetchAnthropicModels(config.anthropicApiKey));
   if (config.openaiApiKey) fetches.push(fetchOpenAIModels(config.openaiApiKey));
+  if (config.openrouterApiKey) fetches.push(fetchOpenRouterModels(config.openrouterApiKey));
   if (config.geminiApiKey) fetches.push(fetchGeminiModels(config.geminiApiKey));
   if (config.vertexAICredentialsPath) {
     fetches.push(fetchVertexModels(config.vertexAICredentialsPath, config.vertexAILocation, warnings));

--- a/source/commands/model.ts
+++ b/source/commands/model.ts
@@ -141,6 +141,14 @@ function warningSuffix(warnings: string[]): string {
   return warnings.length > 0 ? `\n\n${warnings.join("\n")}` : "";
 }
 
+/** Whether a routed model slug belongs to the provider already in use. */
+function matchesProviderPrefix(model: string, provider: string): boolean {
+  const prefix = model.split("/", 1)[0]?.toLowerCase();
+  if (provider === "anthropic" || provider === "openai") return prefix === provider;
+  if (provider === "gemini" || provider === "vertex-ai") return prefix === "google";
+  return false;
+}
+
 function pickModel(
   models: FetchedModel[],
   currentModel: string,
@@ -309,7 +317,8 @@ export const modelCommand: SlashCommand = {
       }
 
       context.setModel(model);
-      if (match && match.provider !== context.config.provider) {
+      if (match && match.provider !== context.config.provider
+        && !matchesProviderPrefix(model, context.config.provider)) {
         context.setProvider(match.provider as import("../config/config.js").AgavConfig["provider"]);
         return { type: "message", text: `Model changed to: ${model} (switched to ${match.provider})` };
       }
@@ -340,7 +349,10 @@ export const modelCommand: SlashCommand = {
     }
 
     context.setModel(picked.id);
-    context.setProvider(picked.provider as AgavConfig["provider"]);
-    return { type: "message", text: `Model changed to: ${picked.id} (${picked.provider})${warningSuffix(warnings)}` };
+    if (picked.provider !== currentProvider && !matchesProviderPrefix(picked.id, currentProvider)) {
+      context.setProvider(picked.provider as AgavConfig["provider"]);
+      return { type: "message", text: `Model changed to: ${picked.id} (switched to ${picked.provider})${warningSuffix(warnings)}` };
+    }
+    return { type: "message", text: `Model changed to: ${picked.id}${warningSuffix(warnings)}` };
   },
 };

--- a/source/components/agents-inspect.tsx
+++ b/source/components/agents-inspect.tsx
@@ -27,6 +27,7 @@ export function InspectView({ agent, statusLabel, readiness, runtimeConfig, sess
   const providerMatchesModel = (model: string, provider: string): boolean => {
     if (provider === "anthropic" && model.startsWith("claude-")) return true;
     if (provider === "openai" && (model.startsWith("gpt-") || model.startsWith("o1-") || model.startsWith("o3-") || model.startsWith("o4-"))) return true;
+    if (provider === "openrouter") return true;
     if (provider === "gemini" && model.startsWith("gemini-")) return true;
     if (provider === "ollama") return true;
     return false;

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -235,8 +235,9 @@ async function ensureProjectConfigTemplate(): Promise<void> {
   try {
     const raw = await readFile(projectPath, "utf-8");
     const parsed = JSON.parse(raw) as Record<string, unknown>;
-    // Refresh shipped metadata on every start so new configuration keys are
-    // documented after an upgrade, while preserving all user-owned settings.
+    // Refresh shipped metadata after upgrades while preserving user settings,
+    // but avoid rewriting committed config files when nothing changed.
+    if (JSON.stringify(parsed.template) === JSON.stringify(PROJECT_CONFIG_TEMPLATE)) return;
     parsed.template = PROJECT_CONFIG_TEMPLATE;
     await writeFile(projectPath, JSON.stringify(parsed, null, 2) + "\n");
   } catch (error) {

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -33,10 +33,11 @@ export interface AgavHooks {
 }
 
 export interface AgavConfig {
-  provider: "anthropic" | "openai" | "ollama" | "gemini" | "vertex-ai";
+  provider: "anthropic" | "openai" | "openrouter" | "ollama" | "gemini" | "vertex-ai";
   model: string;
   anthropicApiKey?: string;
   openaiApiKey?: string;
+  openrouterApiKey?: string;
   openaiApi?: "chat" | "responses";
   geminiApiKey?: string;
   vertexAICredentialsPath?: string;
@@ -77,7 +78,7 @@ export function expandHome(path: string): string {
 const PROJECT_CONFIG_TEMPLATE = {
   provider: {
     description: "LLM provider used for new sessions.",
-    enum: ["openai", "ollama", "anthropic", "gemini", "vertex-ai"],
+    enum: ["openai", "openrouter", "ollama", "anthropic", "gemini", "vertex-ai"],
     type: "string",
     eg: "openai",
   },
@@ -137,6 +138,11 @@ const PROJECT_CONFIG_TEMPLATE = {
     description: "OpenAI API key. Prefer the OPENAI_API_KEY environment variable for secrets.",
     type: "string",
     eg: "set-via-OPENAI_API_KEY",
+  },
+  openrouterApiKey: {
+    description: "OpenRouter API key. Prefer the OPENROUTER_API_KEY environment variable for secrets.",
+    type: "string",
+    eg: "set-via-OPENROUTER_API_KEY",
   },
   geminiApiKey: {
     description: "Google Gemini API key. Prefer the GEMINI_API_KEY environment variable for secrets.",
@@ -294,6 +300,12 @@ export async function loadConfig(): Promise<AgavConfig> {
     globalConfig.openaiApiKey ??
     DEFAULT_CONFIG.openaiApiKey ?? "",
   ) || undefined;
+  merged.openrouterApiKey = decrypt(
+    process.env["OPENROUTER_API_KEY"] ??
+    projectConfig.openrouterApiKey ??
+    globalConfig.openrouterApiKey ??
+    DEFAULT_CONFIG.openrouterApiKey ?? "",
+  ) || undefined;
   merged.geminiApiKey = decrypt(
     process.env["GEMINI_API_KEY"] ??
     projectConfig.geminiApiKey ??
@@ -339,10 +351,11 @@ export async function loadConfig(): Promise<AgavConfig> {
 /** Persist config to the global config file, encrypting any API keys present. */
 export async function saveConfig(config: AgavConfig): Promise<void> {
   await ensureDir(AGAV_DIR);
-  const { anthropicApiKey, openaiApiKey, geminiApiKey, ollamaApiKey, ...safe } = config;
+  const { anthropicApiKey, openaiApiKey, openrouterApiKey, geminiApiKey, ollamaApiKey, ...safe } = config;
   const out: Record<string, unknown> = { ...safe };
   if (anthropicApiKey) out.anthropicApiKey = encrypt(anthropicApiKey);
   if (openaiApiKey) out.openaiApiKey = encrypt(openaiApiKey);
+  if (openrouterApiKey) out.openrouterApiKey = encrypt(openrouterApiKey);
   if (geminiApiKey) out.geminiApiKey = encrypt(geminiApiKey);
   if (ollamaApiKey) out.ollamaApiKey = encrypt(ollamaApiKey);
   await writeFile(CONFIG_PATH, JSON.stringify(out, null, 2) + "\n");

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -235,7 +235,8 @@ async function ensureProjectConfigTemplate(): Promise<void> {
   try {
     const raw = await readFile(projectPath, "utf-8");
     const parsed = JSON.parse(raw) as Record<string, unknown>;
-    if (parsed.template !== undefined) return;
+    // Refresh shipped metadata on every start so new configuration keys are
+    // documented after an upgrade, while preserving all user-owned settings.
     parsed.template = PROJECT_CONFIG_TEMPLATE;
     await writeFile(projectPath, JSON.stringify(parsed, null, 2) + "\n");
   } catch (error) {

--- a/source/config/startup.ts
+++ b/source/config/startup.ts
@@ -7,6 +7,7 @@ export type ProviderName = AgavConfig["provider"];
 export const PROVIDERS: readonly ProviderName[] = [
   "anthropic",
   "openai",
+  "openrouter",
   "gemini",
   "vertex-ai",
   "ollama",
@@ -15,6 +16,7 @@ export const PROVIDERS: readonly ProviderName[] = [
 const DEFAULT_MODELS: Record<ProviderName, string> = {
   anthropic: "claude-sonnet-4-20250514",
   openai: "gpt-5.4-mini",
+  openrouter: "openrouter/auto",
   gemini: "gemini-3.5-flash-lite",
   "vertex-ai": "vertex/gemini-3.5-flash",
   ollama: "",
@@ -79,6 +81,7 @@ export function hasProviderConfiguration(config: AgavConfig, provider: ProviderN
   switch (provider) {
     case "anthropic": return Boolean(config.anthropicApiKey);
     case "openai": return Boolean(config.openaiApiKey);
+    case "openrouter": return Boolean(config.openrouterApiKey);
     case "gemini": return Boolean(config.geminiApiKey);
     case "vertex-ai": return Boolean(config.vertexAICredentialsPath);
     case "ollama": return true;
@@ -121,6 +124,7 @@ export function providerSetupHints(): string {
     "  Set one of:",
     `    ${setEnvHint("ANTHROPIC_API_KEY", "sk-ant-...")}`,
     `    ${setEnvHint("OPENAI_API_KEY", "sk-...")}`,
+    `    ${setEnvHint("OPENROUTER_API_KEY", "sk-or-v1-...")}`,
     `    ${setEnvHint("GEMINI_API_KEY", "...")}`,
     `    ${setEnvHint("VERTEX_AI_CREDENTIALS_PATH", examplePath("path", "to", "service-account.json"))}`,
     "  Or start Ollama: agav --provider ollama",
@@ -140,6 +144,9 @@ export function providerConfigurationError(config: AgavConfig): string | null {
     case "openai":
       return config.openaiApiKey ? null
         : `OpenAI API key not found. Run ${setEnvHint("OPENAI_API_KEY", "sk-...")} or add it to ${agavHomePath("config.json")}`;
+    case "openrouter":
+      return config.openrouterApiKey ? null
+        : `OpenRouter API key not found. Run ${setEnvHint("OPENROUTER_API_KEY", "sk-or-v1-...")} or add it to ${agavHomePath("config.json")}`;
     case "gemini":
       return config.geminiApiKey ? null
         : `Gemini API key not found. Run ${setEnvHint("GEMINI_API_KEY", "...")} or add it to ${agavHomePath("config.json")}`;

--- a/source/main.tsx
+++ b/source/main.tsx
@@ -358,7 +358,7 @@ export async function main() {
     $ cat file | agav -P "explain this"
 
   Options
-    --provider, -p       LLM provider: anthropic, openai, gemini, vertex-ai, or ollama (default: anthropic)
+    --provider, -p       LLM provider: anthropic, openai, openrouter, gemini, vertex-ai, or ollama (default: anthropic)
     --model, -m          Model name (default: claude-sonnet-4-20250514 / gpt-4o / llama3.2)
     --effort             Reasoning effort: low, medium, high, or max (default: high)
     --ollama-host        Ollama host (default: localhost)
@@ -453,7 +453,7 @@ export async function main() {
   if (typeof flags.provider === "string") {
     const p = flags.provider;
     if (!isProviderName(p)) {
-      console.error(`Unknown provider: ${p}. Use "anthropic", "openai", "gemini", "vertex-ai", or "ollama".`);
+      console.error(`Unknown provider: ${p}. Use "anthropic", "openai", "openrouter", "gemini", "vertex-ai", or "ollama".`);
       process.exit(1);
     }
     cliProvider = p;

--- a/source/providers/effort.ts
+++ b/source/providers/effort.ts
@@ -32,6 +32,12 @@ export function mapOpenAIEffort(effort: EffortLevel): OpenAIEffortLevel {
 export function supportsNativeEffort(provider: string, model: string): boolean {
   const normalized = model.toLowerCase();
 
+  if (provider === "openrouter") {
+    // OpenRouter spans model families with incompatible effort parameters.
+    // Fall back to prompt steering rather than sending reasoning_effort blindly.
+    return false;
+  }
+
   if (provider === "openai") {
     return /^(?:o[134](?:-|$)|gpt-5(?:[.-]|$))/.test(normalized)
       || normalized.includes("codex");

--- a/source/providers/openai.ts
+++ b/source/providers/openai.ts
@@ -142,6 +142,11 @@ export class OpenAIProvider implements LLMProvider {
     }
   }
 
+  // Subclasses whose APIs predate max_completion_tokens can override this.
+  protected getMaxTokensParam(maxTokens?: number): Record<string, number> {
+    return { max_completion_tokens: maxTokens ?? 16384 };
+  }
+
   private async *streamChat(params: StreamParams): AsyncIterable<StreamEvent> {
     const hasFunctionTools = Boolean(params.tools?.length);
     const normalizedModel = params.model.toLowerCase();
@@ -160,9 +165,7 @@ export class OpenAIProvider implements LLMProvider {
     const createStream = (effort: typeof nativeEffort, prompt: string | undefined) =>
       this.client.chat.completions.create({
         model: params.model,
-        ...(this.name === "openrouter"
-          ? { max_tokens: params.maxTokens ?? 16384 }
-          : { max_completion_tokens: params.maxTokens ?? 16384 }),
+        ...this.getMaxTokensParam(params.maxTokens),
         messages: this.toChatMessages(params.messages, prompt),
         ...(effort ? { reasoning_effort: effort } : {}),
         tools: params.tools?.length ? params.tools.map((t) => this.toChatTool(t)) : undefined,

--- a/source/providers/openai.ts
+++ b/source/providers/openai.ts
@@ -21,14 +21,25 @@ type ResponseStreamEvent = OpenAI.Responses.ResponseStreamEvent;
 
 export type OpenAIApiMode = "responses" | "chat";
 
+export interface OpenAIProviderOptions {
+  name?: string;
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
+}
+
 export class OpenAIProvider implements LLMProvider {
-  readonly name = "openai";
+  readonly name: string;
   private client: OpenAI;
   private apiMode: OpenAIApiMode;
   private toolEffortUnsupportedModels = new Set<string>();
 
-  constructor(apiKey: string, apiMode: OpenAIApiMode = "responses") {
-    this.client = new OpenAI({ apiKey });
+  constructor(apiKey: string, apiMode: OpenAIApiMode = "responses", options: OpenAIProviderOptions = {}) {
+    this.name = options.name ?? "openai";
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: options.baseURL,
+      defaultHeaders: options.defaultHeaders,
+    });
     this.apiMode = apiMode;
   }
 
@@ -149,7 +160,9 @@ export class OpenAIProvider implements LLMProvider {
     const createStream = (effort: typeof nativeEffort, prompt: string | undefined) =>
       this.client.chat.completions.create({
         model: params.model,
-        max_completion_tokens: params.maxTokens ?? 16384,
+        ...(this.name === "openrouter"
+          ? { max_tokens: params.maxTokens ?? 16384 }
+          : { max_completion_tokens: params.maxTokens ?? 16384 }),
         messages: this.toChatMessages(params.messages, prompt),
         ...(effort ? { reasoning_effort: effort } : {}),
         tools: params.tools?.length ? params.tools.map((t) => this.toChatTool(t)) : undefined,
@@ -198,6 +211,11 @@ export class OpenAIProvider implements LLMProvider {
 
       if (delta?.content) {
         yield { type: "text_delta", text: delta.content };
+      }
+
+      const reasoning = (delta as any)?.reasoning;
+      if (typeof reasoning === "string" && reasoning) {
+        yield { type: "thinking_delta", text: reasoning };
       }
 
       if (delta?.tool_calls) {

--- a/source/providers/openrouter.ts
+++ b/source/providers/openrouter.ts
@@ -1,6 +1,7 @@
 import { OpenAIProvider } from "./openai.js";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const CONTEXT_CACHE_TTL_MS = 5 * 60 * 1000;
 
 interface OpenRouterModel {
   id: string;
@@ -10,7 +11,7 @@ interface OpenRouterModel {
 /** OpenRouter exposes an OpenAI-compatible Chat Completions API. */
 export class OpenRouterProvider extends OpenAIProvider {
   private readonly apiKey: string;
-  private readonly contextWindows = new Map<string, number | undefined>();
+  private readonly contextWindows = new Map<string, { value: number | undefined; expiresAt: number }>();
 
   constructor(apiKey: string) {
     super(apiKey, "chat", {
@@ -29,7 +30,9 @@ export class OpenRouterProvider extends OpenAIProvider {
   }
 
   async getContextWindow(model: string): Promise<number | undefined> {
-    if (this.contextWindows.has(model)) return this.contextWindows.get(model);
+    const cached = this.contextWindows.get(model);
+    if (cached && cached.expiresAt > Date.now()) return cached.value;
+    this.contextWindows.delete(model);
 
     try {
       const response = await fetch(`${OPENROUTER_BASE_URL}/models`, {
@@ -39,11 +42,15 @@ export class OpenRouterProvider extends OpenAIProvider {
       if (!response.ok) return undefined;
 
       const body = await response.json() as { data?: OpenRouterModel[] };
+      const expiresAt = Date.now() + CONTEXT_CACHE_TTL_MS;
       for (const item of body.data ?? []) {
-        this.contextWindows.set(item.id, item.context_length);
+        this.contextWindows.set(item.id, { value: item.context_length, expiresAt });
       }
-      if (!this.contextWindows.has(model)) this.contextWindows.set(model, undefined);
-      return this.contextWindows.get(model);
+      if (!this.contextWindows.has(model)) {
+        // Retry absent models after the TTL in case OpenRouter's catalog changes.
+        this.contextWindows.set(model, { value: undefined, expiresAt });
+      }
+      return this.contextWindows.get(model)?.value;
     } catch {
       return undefined;
     }

--- a/source/providers/openrouter.ts
+++ b/source/providers/openrouter.ts
@@ -1,0 +1,47 @@
+import { OpenAIProvider } from "./openai.js";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+interface OpenRouterModel {
+  id: string;
+  context_length?: number;
+}
+
+/** OpenRouter exposes an OpenAI-compatible Chat Completions API. */
+export class OpenRouterProvider extends OpenAIProvider {
+  private readonly apiKey: string;
+  private readonly contextWindows = new Map<string, number | undefined>();
+
+  constructor(apiKey: string) {
+    super(apiKey, "chat", {
+      name: "openrouter",
+      baseURL: OPENROUTER_BASE_URL,
+      defaultHeaders: {
+        "HTTP-Referer": "https://github.com/prapaa-ai/agav",
+        "X-OpenRouter-Title": "Agav",
+      },
+    });
+    this.apiKey = apiKey;
+  }
+
+  async getContextWindow(model: string): Promise<number | undefined> {
+    if (this.contextWindows.has(model)) return this.contextWindows.get(model);
+
+    try {
+      const response = await fetch(`${OPENROUTER_BASE_URL}/models`, {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!response.ok) return undefined;
+
+      const body = await response.json() as { data?: OpenRouterModel[] };
+      for (const item of body.data ?? []) {
+        this.contextWindows.set(item.id, item.context_length);
+      }
+      if (!this.contextWindows.has(model)) this.contextWindows.set(model, undefined);
+      return this.contextWindows.get(model);
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/source/providers/openrouter.ts
+++ b/source/providers/openrouter.ts
@@ -24,6 +24,10 @@ export class OpenRouterProvider extends OpenAIProvider {
     this.apiKey = apiKey;
   }
 
+  protected override getMaxTokensParam(maxTokens?: number): Record<string, number> {
+    return { max_tokens: maxTokens ?? 16384 };
+  }
+
   async getContextWindow(model: string): Promise<number | undefined> {
     if (this.contextWindows.has(model)) return this.contextWindows.get(model);
 

--- a/source/providers/registry.ts
+++ b/source/providers/registry.ts
@@ -2,6 +2,7 @@ import type { LLMProvider } from "./types.js";
 import type { AgavConfig } from "../config/config.js";
 import { AnthropicProvider } from "./anthropic.js";
 import { OpenAIProvider } from "./openai.js";
+import { OpenRouterProvider } from "./openrouter.js";
 import { OllamaProvider } from "./ollama.js";
 import { GeminiProvider } from "./gemini.js";
 import { VertexAIProvider } from "./vertex-ai.js";
@@ -34,6 +35,11 @@ export function createProvider(config: AgavConfig): LLMProvider {
     case "openai": {
       const key = required(config.openaiApiKey, "OpenAI API key");
       provider = new OpenAIProvider(key, config.openaiApi ?? "responses");
+      break;
+    }
+    case "openrouter": {
+      const key = required(config.openrouterApiKey, "OpenRouter API key");
+      provider = new OpenRouterProvider(key);
       break;
     }
     case "ollama": {

--- a/source/providers/retry.ts
+++ b/source/providers/retry.ts
@@ -49,11 +49,20 @@ export class RetryProvider implements LLMProvider {
   readonly name: string;
   private inner: LLMProvider;
   private maxRetries: number;
+  /**
+   * Optional capabilities must be forwarded explicitly. The agent loop probes
+   * `provider.getContextWindow` on this wrapper, so dropping the method here
+   * would silently disable context-window discovery for wrapped providers.
+   */
+  readonly getContextWindow?: LLMProvider["getContextWindow"];
 
   constructor(inner: LLMProvider, maxRetries = DEFAULT_MAX_RETRIES) {
     this.inner = inner;
     this.name = inner.name;
     this.maxRetries = maxRetries;
+    if (inner.getContextWindow) {
+      this.getContextWindow = inner.getContextWindow.bind(inner);
+    }
   }
 
   async *stream(params: StreamParams): AsyncIterable<StreamEvent> {

--- a/source/utils/auto-update.ts
+++ b/source/utils/auto-update.ts
@@ -283,7 +283,7 @@ export function detectManagedLayout(binaryPath: string): {
 async function replaceSymlink(linkPath: string, target: string): Promise<void> {
   const tmpLink = `${linkPath}.tmp.${process.pid}`;
   await rm(tmpLink, { force: true });
-  await symlink(target, tmpLink);
+  await symlink(target, tmpLink, process.platform === "win32" ? "junction" : "dir");
   try {
     await rename(tmpLink, linkPath);
   } catch {


### PR DESCRIPTION
## Summary
- Adds OpenRouter provider support alongside the existing Anthropic/OpenAI/Gemini/Vertex/Ollama providers.
- Refreshes the shipped project config template on startup so new config keys are documented without overwriting user settings.
- Improves provider/model selection and provider-specific UX for OpenRouter, including /fast, /deep, and /model.

## Changes
- Added OpenRouterProvider, using OpenRouter’s OpenAI-compatible Chat Completions API.
- Added OpenRouter config support:
- provider: "openrouter"
- openrouterApiKey
- OPENROUTER_API_KEY
- Extended startup/provider validation to recognize OpenRouter and surface a helpful missing-key error.
- Updated model routing defaults:
- /fast → ~google/gemini-flash-latest
- /deep → ~anthropic/claude-sonnet-latest
- Updated /model discovery to fetch models from OpenRouter.
- Forwarded getContextWindow through RetryProvider so wrapped providers still expose context metadata.
- Added OpenRouter-specific OpenAI provider options:
- custom baseURL
- default headers
- max_tokens for OpenRouter chat completions
- streaming thinking_delta / reasoning events
- Refreshed .agav/config.json template on load while preserving existing user config values.
- Updated README and CLI help text to document OpenRouter.
- Added/updated tests for config refresh, provider registry, retry forwarding, OpenAI streaming, and OpenRouter model support.

## Related Issues
- #100 

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] Chore

## Testing
- [x] npx tsc --noEmit passes
- [x] Manually tested in terminal
- [ ] Tested with --provider openai
- [ ] Tested with --provider anthropic
- [ ] Tested with --provider ollama
- [x] Tested with --provider openrouter
- [ ] Tested pipe mode (-P)

## Screenshots / Terminal Output
- Not applicable