### PR TITLE
docs: add Terminal-Bench 2.1 results to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p>
   <img alt="Version" src="https://img.shields.io/github/package-json/v/prapaa-ai/agav?style=for-the-badge&amp;label=version&amp;color=111">
   <img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-111?style=for-the-badge">
+  <a href="https://github.com/harbor-framework/terminal-bench-2-1/pull/209"><img alt="Terminal-Bench 2.1" src="https://img.shields.io/badge/Terminal--Bench_2.1-85.4%25_%7C_top_of_the_board-111?style=for-the-badge"></a>
 </p>
 
 </div>
@@ -17,13 +18,14 @@
 
 ## What it does
 
-Agav reads, searches and edits the repository you run it in, and runs the commands you'd otherwise run yourself.
+Agav reads, searches and edits the repository you run it in, and runs the commands you'd otherwise run yourself. On [Terminal-Bench 2.1](https://www.tbench.ai/leaderboard/terminal-bench/2.1) — all 89 tasks, five trials each, judge-audited trajectories — Agav scored [**85.4%**](https://github.com/harbor-framework/terminal-bench-2-1/pull/209), ahead of every entry on the current public board (submission in review).
 
 - **Six providers** — Anthropic, OpenAI, OpenRouter, Gemini, Vertex AI and Ollama, switchable mid-session with `/model`.
 - **Sandboxed commands** — shell tools run under Seatbelt on macOS and Bubblewrap on Linux where either is available.
 - **Non-interactive mode** — `agav run` and `agav --print` make the same agent scriptable from CI, with per-tool permissions and optional JSON Schema output.
 - **Sessions that survive** — resume, branch, name, search and export past conversations; `/compact` reclaims context without starting over. Plans are saved per-session and picked back up on resume.
-- **Extensible** — MCP servers, plugins, skills and subagents.
+- **Extensible** — MCP servers, plugins, a skill marketplace and installable agents; delegate scoped work to fresh-context subagents.
+- **Lights-off operation** — schedule tasks (`/schedule`), loop prompts (`/loop`) and watch files (`/watch`); specs go in, verified work comes out.
 - **Repository-aware editing** — LSP-backed queries, notebook support, test running, and `/undo` for the last file change.
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p>
   <img alt="Version" src="https://img.shields.io/github/package-json/v/prapaa-ai/agav?style=for-the-badge&amp;label=version&amp;color=111">
   <img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-111?style=for-the-badge">
-  <a href="https://github.com/harbor-framework/terminal-bench-2-1/pull/209"><img alt="Terminal-Bench 2.1" src="https://img.shields.io/badge/Terminal--Bench_2.1-85.4%25_%7C_top_of_the_board-111?style=for-the-badge"></a>
+  <a href="https://github.com/harbor-framework/terminal-bench-2-1/pull/225"><img alt="Terminal-Bench 2.1" src="https://img.shields.io/badge/Terminal--Bench_2.1-84.7%25_%7C_top_of_the_board-111?style=for-the-badge"></a>
 </p>
 
 </div>
@@ -18,7 +18,7 @@
 
 ## What it does
 
-Agav reads, searches and edits the repository you run it in, and runs the commands you'd otherwise run yourself. On [Terminal-Bench 2.1](https://www.tbench.ai/leaderboard/terminal-bench/2.1) — all 89 tasks, five trials each, judge-audited trajectories — Agav scored [**85.4%**](https://github.com/harbor-framework/terminal-bench-2-1/pull/209), ahead of every entry on the current public board (submission in review).
+Agav reads, searches and edits the repository you run it in, and runs the commands you'd otherwise run yourself. On [Terminal-Bench 2.1](https://www.tbench.ai/leaderboard/terminal-bench/2.1) — all 89 tasks, five trials each, judge-audited trajectories — Agav scored [**84.7%**](https://github.com/harbor-framework/terminal-bench-2-1/pull/225) (377 of 445 trials, ± 0.84%), ahead of every entry on the current public board (submission in review).
 
 - **Six providers** — Anthropic, OpenAI, OpenRouter, Gemini, Vertex AI and Ollama, switchable mid-session with `/model`.
 - **Sandboxed commands** — shell tools run under Seatbelt on macOS and Bubblewrap on Linux where either is available.


### PR DESCRIPTION
## Summary

Adds the Terminal-Bench 2.1 results to the README:

- New shield badge linking to the leaderboard submission (84.7%, top of the board).
- Updated "What it does" intro with the verified score: **84.7%** (377 of 445 trials, ± 0.84%) across all 89 tasks × five trials, judge-audited trajectories.
- Expanded the **Extensible** bullet (skill marketplace, installable agents, subagents) and added a new **Lights-off operation** bullet covering `/schedule`, `/loop` and `/watch`.

### Accuracy figure

The badge and text cite [harbor-framework/terminal-bench-2-1#225](https://github.com/harbor-framework/terminal-bench-2-1/pull/225) — the live, recomputed submission (**84.72% ± 0.84%**, promoted from closed PR [#209](https://github.com/harbor-framework/terminal-bench-2-1/pull/209)).

Docs-only change — no code touched.

Base: `beta` (current integration branch).