### PR TITLE
ci: fix workflow failures on fork PRs

### DIFF
--- a/.github/workflows/agav-pr-label.yml
+++ b/.github/workflows/agav-pr-label.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   label:
     name: Auto-Label PR
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/agav-review.yml
+++ b/.github/workflows/agav-review.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   review:
     name: AI Code Review
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
           fetch-depth: 0
       - name: Compute changed paths
         id: diff
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4.4.0
         with:
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - name: ShellCheck
         run: |
           shellcheck -s sh \
@@ -221,7 +221,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - name: Suites under Windows PowerShell 5.1
         # This is the host install.cmd actually launches, and the only place the
         # registry half of the PATH handling runs for real. The suite captures
@@ -257,7 +257,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN || github.token }}
         with:
           types: |
             feat
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
           fetch-depth: 0
       - name: Scan for leaked secrets
         run: |
@@ -301,7 +301,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
           fetch-depth: 0
       - name: Check for oversized files
         run: |
@@ -327,7 +327,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - name: Scan for dangerous code patterns
         run: |
           echo "Scanning for dangerous patterns in source..."
@@ -364,7 +364,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
@@ -382,7 +382,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - name: Verify lockfile exists
         run: |
           if [ ! -f pnpm-lock.yaml ]; then
@@ -407,7 +407,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - run: |
           semgrep scan \
             --config "p/javascript" \
@@ -425,7 +425,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - name: Check sensitive files are not tracked
         run: |
           FAIL=0
@@ -447,7 +447,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.TOKEN || github.token }}
       - name: Check the version badge is derived, not hardcoded
         run: |
           # A literal shields.io/badge/version-x.y.z badge has to be rewritten


### PR DESCRIPTION
## Problem

All CI checks fail on PRs opened from forks (e.g. [#114](https://github.com/prapaa-ai/agav/pull/114)) because GitHub does not expose repository secrets to fork PR workflows. This causes:

- **pr-checks.yml**: Every job fails with `Input required and not supplied: token` — `actions/checkout` receives an empty `secrets.TOKEN`
- **agav-pr-label.yml**: Fails with `[@octokit/auth-app] appId option is required` — GitHub App credentials are unavailable
- **agav-review.yml**: Same GitHub App token failure as above

## Fix

### `pr-checks.yml` — Token fallback (16 usages)
```
secrets.TOKEN  →  secrets.TOKEN || github.token
```
When `secrets.TOKEN` is unavailable (fork PRs), all checkout steps and the PR title lint action fall back to the automatic `github.token`. This token has read-only permissions — sufficient for checkout, linting, scanning, and all security checks. Internal PRs continue using the custom PAT as before.

### `agav-pr-label.yml` / `agav-review.yml` — Skip on forks
```yaml
if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
```
These jobs require GitHub App credentials (`AGAV_APP_ID`, `AGAV_APP_PRIVATE_KEY`) and `GEMINI_API_KEY` which are never available to forks. They are skipped entirely for fork PRs — showing as "skipped" (not "failed") in checks, which the `required` gate already treats as passing.

## Why two different strategies?

| Workflow | Can run on forks? | Strategy |
|---|---|---|
| **pr-checks.yml** | ✅ Yes — only needs repo checkout | Fall back to `github.token` |
| **agav-pr-label.yml** | ❌ No — needs App + Gemini secrets | Skip entirely |
| **agav-review.yml** | ❌ No — needs App + Gemini secrets | Skip entirely |