### PR TITLE
fix: #99 /steer not working

### DIFF
--- a/source/__tests__/agent.steer-injection.test.ts
+++ b/source/__tests__/agent.steer-injection.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi } from "vitest";
+import { runAgentLoop, type AgentEvent } from "../agent/loop.js";
+import { ConversationState } from "../agent/conversation.js";
+import { ToolRegistry } from "../tools/registry.js";
+import { drainSteers, queueSteer } from "../commands/steer.js";
+import { STEER_DIRECTIVE_PREFIX } from "../agent/internal-prompts.js";
+import type { LLMProvider, Message, StreamEvent, StreamParams } from "../providers/types.js";
+import type { ToolDefinition } from "../tools/types.js";
+
+/**
+ * Provider whose first stream emits a tool call and whose later streams block
+ * on a gate before finishing, so the test can queue a /steer directive at a
+ * deterministic moment while the turn is still running.
+ */
+class GatedProvider implements LLMProvider {
+  name = "mock";
+  calls: StreamParams[] = [];
+  constructor(private readonly gate: Promise<void>) {}
+
+  async *stream(params: StreamParams): AsyncGenerator<StreamEvent> {
+    this.calls.push(params);
+    if (this.calls.length === 1) {
+      yield { type: "tool_call_start" as const, toolCallId: "tc_1", toolName: "gate_tool" };
+      yield { type: "tool_call_delta" as const, toolCallId: "tc_1", argsJson: "{}" };
+      yield { type: "usage" as const, inputTokens: 10, outputTokens: 5 };
+    } else {
+      yield { type: "text_delta" as const, text: "acknowledged" };
+      yield { type: "usage" as const, inputTokens: 10, outputTokens: 5 };
+      await this.gate;
+    }
+  }
+}
+
+async function collect(loop: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of loop) events.push(event);
+  return events;
+}
+
+/** Text of every user-turn text block, flattened in order. */
+function userTexts(messages: Message[]): string[] {
+  const texts: string[] = [];
+  for (const msg of messages) {
+    if (msg.role !== "user") continue;
+    for (const block of msg.content) {
+      if (block.type === "text" && block.text) texts.push(block.text);
+    }
+  }
+  return texts;
+}
+
+describe("mid-turn steer delivery", () => {
+  it("delivers a steer queued mid-turn to the same running agent loop", async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => { releaseGate = resolve; });
+
+    const gateTool: ToolDefinition = {
+      schema: {
+        name: "gate_tool",
+        description: "Blocks until released",
+        destructive: false,
+        inputSchema: { type: "object", properties: {} },
+      },
+      execute: vi.fn(async () => {
+        await gate;
+        return { output: "released", isError: false };
+      }),
+    };
+
+    const provider = new GatedProvider(gate);
+    const registry = new ToolRegistry();
+    registry.register(gateTool);
+
+    const conversation = new ConversationState();
+    conversation.addUserMessage("start the long task");
+
+    const events: AgentEvent[] = [];
+    const finished = (async () => {
+      for await (const event of runAgentLoop({
+        provider,
+        conversation,
+        toolRegistry: registry,
+        model: "mock",
+        permissionMode: "auto-accept",
+        maxIterations: 3,
+        drainSteers,
+      })) {
+        events.push(event);
+      }
+    })();
+
+    // Wait until the gated tool is executing, then steer exactly like the
+    // slash command does while the turn is in flight.
+    while (vi.mocked(gateTool.execute).mock.calls.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    queueSteer("focus on the parser");
+    releaseGate();
+    await finished;
+
+    // A second provider round happened and saw the directive.
+    expect(provider.calls.length).toBe(2);
+    const texts = userTexts(provider.calls[1]!.messages);
+    expect(texts.some((t) => t.includes(STEER_DIRECTIVE_PREFIX) && t.includes("focus on the parser"))).toBe(true);
+
+    // Protocol safety: the steer never lands between the assistant tool_use
+    // and its matching tool_result — it comes right after the tool results.
+    const messages = provider.calls[1]!.messages;
+    const toolUseIndex = messages.findIndex(
+      (msg) => msg.role === "assistant" && msg.content.some((b) => b.type === "tool_use"),
+    );
+    expect(toolUseIndex).toBeGreaterThanOrEqual(0);
+    expect(messages[toolUseIndex + 1]!.role).toBe("user");
+    expect(messages[toolUseIndex + 1]!.content.some((b) => b.type === "tool_result")).toBe(true);
+    expect(messages[toolUseIndex + 2]!.role).toBe("user");
+    expect(messages[toolUseIndex + 2]!.content[0]).toMatchObject({ type: "text" });
+    expect((messages[toolUseIndex + 2]!.content[0] as { text?: string }).text).toContain(STEER_DIRECTIVE_PREFIX);
+
+    // The UI is told the steer was delivered, and the queue is left empty.
+    const applied = events.find((e) => e.type === "steer_applied") as Extract<AgentEvent, { type: "steer_applied" }> | undefined;
+    expect(applied?.directives).toEqual(["focus on the parser"]);
+    expect(drainSteers()).toEqual([]);
+  });
+
+  it("flushes a steer queued during the final response instead of dropping it", async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => { releaseGate = resolve; });
+
+    const fastTool: ToolDefinition = {
+      schema: {
+        name: "fast_tool",
+        description: "Returns immediately",
+        destructive: false,
+        inputSchema: { type: "object", properties: {} },
+      },
+      execute: vi.fn(async () => ({ output: "ok", isError: false })),
+    };
+
+    const provider = new GatedProvider(gate);
+    const registry = new ToolRegistry();
+    registry.register(fastTool);
+
+    const conversation = new ConversationState();
+    conversation.addUserMessage("do it");
+
+    // The loop blocks inside the second (final, tool-free) stream; steering
+    // there means the directive arrives after the last tool round, when the
+    // loop is about to exit without another safe point.
+    const events: AgentEvent[] = [];
+    const finished = (async () => {
+      for await (const event of runAgentLoop({
+        provider,
+        conversation,
+        toolRegistry: registry,
+        model: "mock",
+        permissionMode: "auto-accept",
+        maxIterations: 3,
+        drainSteers,
+      })) {
+        events.push(event);
+      }
+    })();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    queueSteer("wrap up early");
+    releaseGate();
+    await finished;
+
+    const applied = events.find((e) => e.type === "steer_applied") as Extract<AgentEvent, { type: "steer_applied" }> | undefined;
+    expect(applied?.directives).toEqual(["wrap up early"]);
+
+    const tail = conversation.getMessages().at(-1)!;
+    expect(tail.role).toBe("user");
+    expect(tail.internal).toBe(true);
+    expect(userTexts([tail])[0]).toContain("wrap up early");
+
+    expect(events.some((e) => e.type === "turn_complete")).toBe(true);
+    expect(drainSteers()).toEqual([]);
+  });
+});
+
+describe("injectUserMessage placement", () => {
+  it("never inserts between an unanswered tool_use and its tool_result", async () => {
+    const { ConversationState } = await import("../agent/conversation.js");
+    const convo = new ConversationState();
+
+    convo.addUserMessage("run the thing");
+    convo.addAssistantMessage([
+      { type: "text", text: "working" },
+      { type: "tool_use", toolCallId: "t1", toolName: "shell", toolInput: {} },
+    ]);
+
+    convo.injectUserMessage("mid-turn note");
+
+    const messages = convo.getMessages();
+    // Slides back to before the pending assistant turn rather than wedging
+    // into the cycle: [user, note, assistant(tool_use…)] keeps every
+    // tool_use immediately answered once its result lands.
+    expect(messages).toHaveLength(3);
+    expect(messages[1]!.role).toBe("user");
+    expect(messages[1]!.internal).toBe(true);
+    expect((messages[1]!.content[0] as { text?: string }).text).toBe("mid-turn note");
+    expect(messages[2]!.role).toBe("assistant");
+    expect(messages[2]!.content.some((b) => b.type === "tool_use")).toBe(true);
+  });
+
+  it("inserts before a trailing pending assistant turn when earlier cycles are complete", async () => {
+    const { ConversationState } = await import("../agent/conversation.js");
+    const convo = new ConversationState();
+
+    convo.addUserMessage("go");
+    convo.addAssistantMessage([{ type: "tool_use", toolCallId: "t1", toolName: "shell", toolInput: {} }]);
+    convo.addToolResults([{ type: "tool_result", toolCallId: "t1", toolResult: "ok" }]);
+    convo.addAssistantMessage([{ type: "tool_use", toolCallId: "t2", toolName: "shell", toolInput: {} }]);
+
+    convo.injectUserMessage("mid-turn note");
+
+    const messages = convo.getMessages();
+    // Lands between the answered cycle and the pending one — legal for providers,
+    // whereas landing after t2's tool_use would be rejected.
+    expect(messages).toHaveLength(5);
+    expect((messages[3]!.content[0] as { text?: string }).text).toBe("mid-turn note");
+    expect(messages[4]!.role).toBe("assistant");
+  });
+
+  it("appends to an empty or plain-text history", async () => {
+    const { ConversationState } = await import("../agent/conversation.js");
+    const empty = new ConversationState();
+    empty.injectUserMessage("first note");
+    expect(empty.getMessages()).toHaveLength(1);
+    expect(empty.getMessages()[0]!.role).toBe("user");
+
+    const plain = new ConversationState();
+    plain.addUserMessage("hi");
+    plain.addAssistantMessage([{ type: "text", text: "hello" }]);
+    plain.injectUserMessage("note");
+    expect(plain.getMessages()).toHaveLength(3);
+    expect(plain.getMessages()[2]!.role).toBe("user");
+  });
+
+  it("ignores blank directives", async () => {
+    const { ConversationState } = await import("../agent/conversation.js");
+    const convo = new ConversationState();
+    convo.addUserMessage("hi");
+    convo.injectUserMessage("   ");
+    expect(convo.getMessages()).toHaveLength(1);
+  });
+});
+
+describe("steer queue plumbing", () => {
+  it("drains queued directives in order and empties the queue", () => {
+    queueSteer("one");
+    queueSteer("two");
+    expect(drainSteers()).toEqual(["one", "two"]);
+    expect(drainSteers()).toEqual([]);
+  });
+
+  it("loops without drainSteers (subagents/skills) never consume queued directives", async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => { releaseGate = resolve; });
+
+    const gateTool: ToolDefinition = {
+      schema: {
+        name: "gate_tool",
+        description: "Blocks until released",
+        destructive: false,
+        inputSchema: { type: "object", properties: {} },
+      },
+      execute: vi.fn(async () => {
+        await gate;
+        return { output: "released", isError: false };
+      }),
+    };
+
+    const provider = new GatedProvider(gate);
+    const registry = new ToolRegistry();
+    registry.register(gateTool);
+
+    const conversation = new ConversationState();
+    conversation.addUserMessage("subagent task");
+
+    const events: AgentEvent[] = [];
+    const finished = (async () => {
+      for await (const event of runAgentLoop({
+        provider,
+        conversation,
+        toolRegistry: registry,
+        model: "mock",
+        permissionMode: "auto-accept",
+        maxIterations: 3,
+        // No drainSteers — this is how subagent/skill/agent loops run.
+      })) {
+        events.push(event);
+      }
+    })();
+
+    while (vi.mocked(gateTool.execute).mock.calls.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    // A directive meant for the main agent is queued while the subagent runs.
+    queueSteer("for the main agent only");
+    releaseGate();
+    await finished;
+
+    // The subagent loop neither injected the directive nor reported delivery…
+    expect(events.some((e) => e.type === "steer_applied")).toBe(false);
+    const texts = userTexts(conversation.getMessages());
+    expect(texts.every((t) => !t.includes("for the main agent only"))).toBe(true);
+
+    // …and the directive survives for the main loop to pick up.
+    expect(drainSteers()).toEqual(["for the main agent only"]);
+  });
+});

--- a/source/__tests__/commands.steer.test.ts
+++ b/source/__tests__/commands.steer.test.ts
@@ -49,4 +49,24 @@ describe("commands/steer", () => {
       text: "Invalid number. Use 1-1.",
     });
   });
+
+  it("queues added directives for delivery and reports mid-turn status via isLoading", async () => {
+    const { drainSteers } = await import("../commands/steer.js");
+
+    const runningResult = await steerCommand.execute("mid-turn directive", { isLoading: true } as any);
+    expect(runningResult).toEqual({
+      type: "message",
+      text: 'Steer added: "mid-turn directive"\nWill be delivered to the running agent before it continues.',
+    });
+
+    const idleResult = await steerCommand.execute("idle directive", {} as any);
+    expect(idleResult).toEqual({
+      type: "message",
+      text: 'Steer added: "idle directive"\n2 active steer(s). Use /steer list to see all.',
+    });
+
+    // Both directives are queued in arrival order for the running loop.
+    expect(drainSteers()).toEqual(["mid-turn directive", "idle directive"]);
+    expect(drainSteers()).toEqual([]);
+  });
 });

--- a/source/agent/conversation.ts
+++ b/source/agent/conversation.ts
@@ -76,6 +76,49 @@ export class ConversationState {
     last.content.push({ type: "text", text });
   }
 
+  /**
+   * Insert a mid-turn user message (e.g. a /steer directive) into the running
+   * conversation. Placement is protocol-constrained: providers such as
+   * Anthropic reject any user message that lands between an assistant tool_use
+   * and its matching tool_result, so the message is inserted after the last
+   * complete tool cycle. When no tool results are pending — including an empty
+   * history, which would otherwise start with two user turns in a row — it is
+   * appended to the end instead.
+   */
+  injectUserMessage(text: string): void {
+    if (!text.trim()) return;
+
+    const answeredToolIds = new Set<string>();
+    for (const msg of this.messages) {
+      if (msg.role !== "user") continue;
+      for (const block of msg.content) {
+        if (block.type === "tool_result" && block.toolCallId) {
+          answeredToolIds.add(block.toolCallId);
+        }
+      }
+    }
+
+    // Walk back past trailing assistant tool_use blocks whose answers have not
+    // been added yet; insertion must land after their tool_results do.
+    let insertAt = this.messages.length;
+    while (insertAt > 0) {
+      const msg = this.messages[insertAt - 1]!;
+      if (msg.role !== "assistant") break;
+      const hasPendingToolUse = msg.content.some(
+        (block) => block.type === "tool_use" && block.toolCallId && !answeredToolIds.has(block.toolCallId),
+      );
+      if (!hasPendingToolUse) break;
+      insertAt--;
+    }
+
+    const injected: Message = {
+      role: "user",
+      content: [{ type: "text", text }],
+      internal: true,
+    };
+    this.messages.splice(insertAt, 0, injected);
+  }
+
   addAssistantMessage(content: ContentBlock[]): void {
     this.messages.push({ role: "assistant", content });
   }

--- a/source/agent/internal-prompts.ts
+++ b/source/agent/internal-prompts.ts
@@ -22,6 +22,12 @@ export const MAX_STEPS_PROMPT =
   "You have reached the maximum number of steps. Summarize what you have accomplished, " +
   "list any remaining work, and stop. Do not call any more tools.";
 
+// Prepended to /steer directives injected into the conversation mid-turn, so
+// the model can tell them apart from ordinary user turns and knows they apply
+// to the work already in progress.
+export const STEER_DIRECTIVE_PREFIX =
+  "[STEER — mid-turn directive from the user. Apply this to the work in progress.]\n";
+
 // Extracted as a constant so LEGACY_PREFIXES (below) can match this dynamic
 // prompt by its fixed opening — the full string varies per attempt number.
 export const TESTS_FAILED_PREFIX = "Tests failed (attempt ";

--- a/source/agent/loop.ts
+++ b/source/agent/loop.ts
@@ -10,6 +10,7 @@ import {
   MAX_STEPS_PROMPT,
   NEEDS_VERIFY_PROMPT,
   VERIFY_FAILED_PROMPT,
+  STEER_DIRECTIVE_PREFIX,
   testsFailedPrompt,
 } from "./internal-prompts.js";
 
@@ -24,6 +25,7 @@ export type AgentEvent =
   | { type: "tool_result"; toolName: string; toolCallId?: string; output: string; isError: boolean; diffLines?: import("../utils/diff.js").DiffLine[] }
   | { type: "assistant_message_complete"; text: string }
   | { type: "turn_complete" }
+  | { type: "steer_applied"; directives: string[] }
   | { type: "usage"; inputTokens: number; outputTokens: number; cacheReadTokens?: number; cacheWriteTokens?: number }
   | { type: "error"; error: Error };
 
@@ -58,6 +60,13 @@ interface LoopParams {
   maxIterations?: number;
   allowedTools?: string[];
   hooks?: import("../config/config.js").AgavHooks;
+  /**
+   * Drains /steer directives queued mid-turn. Only the main conversation's
+   * loop supplies this: subagents, skills, and agents run their own loops and
+   * must never consume directives addressed to the primary agent. When unset,
+   * the loop simply never receives mid-turn steers.
+   */
+  drainSteers?: () => string[];
 }
 
 // Tools that never need confirmation because they cannot modify the working
@@ -127,6 +136,10 @@ export async function* runAgentLoop(
   // user changes their mind, they can say so in a new message and the submit()
   // call starts a fresh loop with an empty set.
   const deniedCalls = new Set<string>();
+  // Mid-turn /steer directives — see LoopParams.drainSteers. Undefined for
+  // subagent/skill/agent loops, which never receive them.
+  const drainSteers = params.drainSteers;
+  const collectSteers = () => (drainSteers ? drainSteers() : []);
 
   let pendingSummarizeUsage: Record<string, number> | null = null;
 
@@ -318,7 +331,18 @@ export async function* runAgentLoop(
         conversation.addInternalUserMessage(needsVerify ? NEEDS_VERIFY_PROMPT : VERIFY_FAILED_PROMPT);
         continue;
       }
+      // A directive queued after the final tool round would otherwise sit in the
+      // queue forever — this is the loop's last exit before max-iterations.
+      // Deliver it as a fresh user turn so it still reaches the model (and the
+      // next submit() call starts a new loop on top of it).
+      const lateSteers = collectSteers();
+      for (const steer of lateSteers) {
+        conversation.injectUserMessage(STEER_DIRECTIVE_PREFIX + steer);
+      }
       yield { type: "assistant_message_complete", text: textAccum };
+      if (lateSteers.length > 0) {
+        yield { type: "steer_applied", directives: lateSteers };
+      }
       yield { type: "turn_complete" };
       return;
     }
@@ -468,6 +492,19 @@ export async function* runAgentLoop(
 
     conversation.addToolResults(toolResults);
 
+    // Deliver /steer directives typed while this turn was running. This is the
+    // safe point: tool results have just been appended, so a user message here
+    // never splits an assistant tool_use from its tool_result (which providers
+    // reject). Draining before the next provider call means the model sees the
+    // directive within the same turn.
+    const steers = collectSteers();
+    for (const steer of steers) {
+      conversation.injectUserMessage(STEER_DIRECTIVE_PREFIX + steer);
+    }
+    if (steers.length > 0) {
+      yield { type: "steer_applied", directives: steers };
+    }
+
     if (hasTestFailure) {
       testRepairAttempts++;
       if (testRepairAttempts <= MAX_REPAIR_ATTEMPTS) {
@@ -478,9 +515,17 @@ export async function* runAgentLoop(
     }
   }
 
+  // Deliver any /steer directives queued during the final iteration, then stop.
+  const finalSteers = collectSteers();
+  for (const steer of finalSteers) {
+    conversation.injectUserMessage(STEER_DIRECTIVE_PREFIX + steer);
+  }
   yield {
     type: "assistant_message_complete",
     text: "[Agent reached maximum iterations]",
   };
+  if (finalSteers.length > 0) {
+    yield { type: "steer_applied", directives: finalSteers };
+  }
   yield { type: "turn_complete" };
 }

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -89,6 +89,8 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   }, [exitInk]);
   const commandRegistryRef = useRef(new CommandRegistry());
   const keyResolverRef = useRef(new KeybindingResolver(keybindings, GLOBAL_ACTIONS));
+  /** Lets handleSubmit re-sync InputPrompt's caret after rewriting its buffer. */
+  const inputPromptCursorResetRef = useRef<(() => void) | null>(null);
 
   const {
     messages,
@@ -453,11 +455,16 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
 
       if (!trimmed && attachments.length === 0) return;
 
-      // Block non-btw submissions while agent is working
-      if (isLoading) return;
+      const commandName = trimmed.slice(1).split(/\s+/)[0]?.toLowerCase() ?? "";
+      const midTurnSafe = new Set(["steer", "help", "loop"]);
+      const isSlashCommand = trimmed.startsWith("/")
+        && attachments.length === 0
+        && (!isLoading || midTurnSafe.has(commandName));
+      if (!isSlashCommand && isLoading) return;
 
-      if (trimmed.startsWith("/") && attachments.length === 0) {
+      if (isSlashCommand) {
         setInput("");
+        inputPromptCursorResetRef.current?.();
         setShowToolDetail(false);
         setPsResponse(undefined);
         setSystemMessages([]);
@@ -490,6 +497,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
           renameSession,
           currentSessionId: sessionId,
           exit,
+          isLoading,
           getDebugState: () => ({
             tokenUsage,
             loadedPlugins,
@@ -547,7 +555,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
       setPsResponse(undefined);
       setSystemMessages([]);
     },
-    [config, conversation, clearMessages, refreshPlan, exit, submit, attachments, tokenUsage, loadedPlugins, mcpServers, mcpResourceCount, mcpPromptCount, runPsQuery, refreshDisplay, loadSession, activateSession, renameSession, sessionId],
+    [config, conversation, clearMessages, refreshPlan, exit, submit, attachments, isLoading, tokenUsage, loadedPlugins, mcpServers, mcpResourceCount, mcpPromptCount, runPsQuery, refreshDisplay, loadSession, activateSession, renameSession, sessionId],
   );
 
   const displayError = error;
@@ -721,6 +729,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
           onRemoveAttachment={() => setAttachments((prev) => prev.slice(0, -1))}
           onClearAttachments={() => setAttachments([])}
           onRegisterInsert={(fn) => { insertLabelRef.current = fn; }}
+          onCursorReset={(fn) => { inputPromptCursorResetRef.current = fn; }}
           disabled={pickerActive}
           commands={[
             { name: "ps", description: "Side query while agent is working" },

--- a/source/commands/steer.ts
+++ b/source/commands/steer.ts
@@ -1,6 +1,26 @@
-import type { SlashCommand, CommandResult } from "./types.js";
+import type { SlashCommand, CommandResult, CommandContext } from "./types.js";
 
 let activeSteers: string[] = [];
+
+/**
+ * Directives added while an agent turn was already running. The agent loop
+ * drains these at its next safe point — right after tool results are appended,
+ * where a user message is protocol-legal — so a /steer typed mid-turn reaches
+ * the model within the same turn instead of waiting for the next one.
+ */
+let steerQueue: string[] = [];
+
+export function queueSteer(directive: string): void {
+  steerQueue.push(directive);
+}
+
+/** Return queued mid-turn directives in arrival order and empty the queue. */
+export function drainSteers(): string[] {
+  if (steerQueue.length === 0) return [];
+  const drained = steerQueue;
+  steerQueue = [];
+  return drained;
+}
 
 export function getActiveSteers(): string[] {
   return activeSteers;
@@ -8,6 +28,7 @@ export function getActiveSteers(): string[] {
 
 export function clearSteers(): void {
   activeSteers = [];
+  steerQueue = [];
 }
 
 export function formatSteersForPrompt(): string {
@@ -22,8 +43,8 @@ export function formatSteersForPrompt(): string {
 export const steerCommand: SlashCommand = {
   name: "steer",
   description: "Add context or direction to guide the agent",
-  usage: "Usage: /steer <directive>\n\n  /steer be concise       Add a steering directive\n  /steer list             Show active steers\n  /steer remove <N>       Remove a specific steer\n  /steer clear            Remove all steers\n\nSteers are injected into the system prompt for all subsequent turns.",
-  async execute(args: string): Promise<CommandResult> {
+  usage: "Usage: /steer <directive>\n\n  /steer be concise       Add a steering directive\n  /steer list             Show active steers\n  /steer remove <N>       Remove a specific steer\n  /steer clear            Remove all steers\n\nWorks while the agent is running — the directive is delivered to it before\nits next step. Steers also persist and are injected into every subsequent turn.",
+  async execute(args: string, contextArg?: CommandContext): Promise<CommandResult> {
     const trimmed = args.trim();
 
     if (!trimmed || trimmed === "list") {
@@ -53,6 +74,15 @@ export const steerCommand: SlashCommand = {
     }
 
     activeSteers.push(trimmed);
+    queueSteer(trimmed);
+
+    const context = contextArg as CommandContext | undefined;
+    if (context?.isLoading) {
+      return {
+        type: "message",
+        text: `Steer added: "${trimmed}"\nWill be delivered to the running agent before it continues.`,
+      };
+    }
     return {
       type: "message",
       text: `Steer added: "${trimmed}"\n${activeSteers.length} active steer(s). Use /steer list to see all.`,

--- a/source/commands/types.ts
+++ b/source/commands/types.ts
@@ -41,6 +41,8 @@ export interface CommandContext {
   renameSession: (name: string) => void
   currentSessionId?: string
   exit: () => void
+  /** Whether an agent turn is currently in flight. */
+  isLoading?: boolean
   getDebugState: () => DebugState
   submit: (text: string) => void
   handleSubmit: (text: string, invocationReason?: InvocationReason) => void

--- a/source/components/input-prompt.tsx
+++ b/source/components/input-prompt.tsx
@@ -19,6 +19,8 @@ interface Props {
   onRemoveAttachment?: () => void;
   onClearAttachments?: () => void;
   onRegisterInsert?: (fn: (label: string) => void) => void;
+  /** Registers a callback that re-syncs the caret with the current buffer. */
+  onCursorReset?: (fn: () => void) => void;
   disabled?: boolean;
   commands?: CommandInfo[];
   keybindings: Keybindings;
@@ -75,7 +77,7 @@ function isWithinRoot(root: string, candidate: string): boolean {
 }
 
 /** Renders the interactive prompt with history, completion, and paste handling. */
-export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemoveAttachment, onClearAttachments, onRegisterInsert, disabled, commands = [], keybindings, enhancedKeyboard = false, resumeUserMessages }: Props) {
+export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemoveAttachment, onClearAttachments, onRegisterInsert, onCursorReset, disabled, commands = [], keybindings, enhancedKeyboard = false, resumeUserMessages }: Props) {
   const { isRawModeSupported } = useStdin();
   const [cursorPos, setCursorPos] = useState(0);
   const historyRef = useRef<string[]>([]);
@@ -116,6 +118,27 @@ export default function InputPrompt({ value, onChange, onSubmit, onPaste, onRemo
       });
     }
   }, [onRegisterInsert, onChange]);
+
+  // Re-sync the caret with the buffer whenever the parent rewrites the value
+  // programmatically (e.g. clearing it after a slash command). Without this the
+  // stored cursor position can point past the end of the new text, so the next
+  // keystroke inserts at a stale offset and typed characters appear out of
+  // order — the "cursor jumps to position 0" symptom.
+  //
+  // The request is handled on the render where the rewritten value actually
+  // arrives: calling setCursorPos synchronously would read the old buffer,
+  // because the parent's state update has not propagated to props yet.
+  const syncCursorOnNextValueRef = useRef(false);
+
+  useEffect(() => {
+    if (onCursorReset) onCursorReset(() => { syncCursorOnNextValueRef.current = true; });
+  }, [onCursorReset]);
+
+  useEffect(() => {
+    if (!syncCursorOnNextValueRef.current) return;
+    syncCursorOnNextValueRef.current = false;
+    setCursorPos(value.length);
+  }, [value]);
 
   const activeFileToken = getActiveFileToken(value, cursorPos);
   const showSuggestions = !activeFileToken && value.startsWith("/") && !value.includes(" ") && value.length >= 1;

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -35,6 +35,7 @@ import { loadSkills, getCachedSkills } from "../skills/loader.js";
 import { createSkillTool } from "../skills/tool.js";
 import { createSkillSlashCommand } from "../skills/commands.js";
 import { maybeRunBackgroundImprovement } from "../skills/improvement.js";
+import { drainSteers } from "../commands/steer.js";
 
 let messageId = 0;
 /** Generate incremental display ids so transient UI rows have stable React keys. */
@@ -505,7 +506,7 @@ export function useAgent(
         setError("No LLM provider configured. Check your API key.");
         return false;
       }
-      if (isLoading || submitPendingRef.current) return false;
+      if (submitPendingRef.current) return false;
 
       const trimmed = input.trim();
       if (!trimmed) return false;
@@ -754,6 +755,9 @@ export function useAgent(
             permissionMode: sessionPermissionModeRef.current ?? config.permissionMode,
             allowedTools: config.allowedTools,
             hooks: config.hooks,
+            // Only the main conversation's loop drains mid-turn /steer
+            // directives — subagent/skill/agent loops must not consume them.
+            drainSteers,
           });
 
           for await (const event of loop) {
@@ -966,6 +970,19 @@ export function useAgent(
                   setPlanContinueMsg(`Do Step ${next.id} only: ${next.title}. Mark it in_progress, do the work, mark it done, then end your response silently — no commentary about stopping or pausing.`);
                 }).catch(() => {});
                 break;
+
+              case "steer_applied": {
+                const count = event.directives.length;
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    id: nextId(),
+                    role: "system",
+                    content: `\x1b[2mDelivered ${count} steer${count === 1 ? "" : "s"} to the running agent.\x1b[0m`,
+                  },
+                ]);
+                break;
+              }
 
               case "error": {
                 const errorMsg = event.error.message || "Unknown error";


### PR DESCRIPTION
## Summary

- /steer claimed it delivers directives "to the running agent before it continues" but had no way to reach a turn already in flight — directives were only read once per turn when building the system prompt.
- Adds a mid-turn queue/drain mechanism so a /steer typed while the agent is working is injected into the live conversation at the next protocol-safe point, and updates the UI to allow /steer (and /help, /loop) to be submitted while a turn is running.

## Changes

- commands/steer.ts: added steerQueue + queueSteer()/drainSteers(), separate from the persistent activeSteers list used for system-prompt injection. /steer now returns different confirmation copy depending on context.isLoading.
- agent/loop.ts: runAgentLoop accepts an optional drainSteers callback, wired up only for the main conversation loop (never for subagents/skills/standalone agent runs). Directives are drained and injected at safe points: right after tool results are appended (same-turn delivery), on the final tool-free response, and at max-iterations.
- agent/conversation.ts: new injectUserMessage() — walks back past any trailing unanswered tool_use blocks to find a legal insertion point (never between a tool_use and its tool_result), appends instead when history is empty. Injected messages are prefixed (agent/internal-prompts.ts: STEER_DIRECTIVE_PREFIX) and marked internal: true so the model sees them but the transcript doesn't.
- agent/loop.ts: new AgentEvent variant steer_applied to report which directives were delivered.
- app.tsx / hooks/use-agent.ts: handleSubmit now lets a small allow-list of commands (steer, help, loop) run while isLoading is true instead of blocking all input; submit() no longer double-guards on isLoading since routing now happens in app.tsx.
- components/input-prompt.tsx: added onCursorReset so the caret re-syncs after handleSubmit clears the input buffer for a mid-turn command (fixes keystrokes landing at a stale cursor position).
- commands/types.ts: added isLoading?: boolean to CommandContext.

## Related Issues

Fixes #99

## Type

- [x] Bug fix

## Testing

- [x] npx tsc --noEmit passes
- [x] Manually tested in terminal
- [x] Tested with --provider openai
- [x] Tested with --provider openrouter
- [x] Tested with --provider vertex-ai
- [ ] Tested with --provider ollama
- [ ] Tested with --provider anthropic
- [ ] Tested pipe mode (-P)

New tests in source/__tests__/agent.steer-injection.test.ts:
- a steer queued while a tool is executing is delivered within the same turn, landing after the tool cycle (never between tool_use and tool_result)
- a steer queued during the final (tool-free) response is flushed instead of dropped
- ConversationState.injectUserMessage placement rules (mid-cycle, between cycles, empty history, blank directive)
- subagent/skill loops (no drainSteers) never consume directives meant for the main agent

Extended commands.steer.test.ts for queueing + isLoading messaging. Full suite passes (373/373).

## Screenshots / Terminal Output

<img width="616" height="369" alt="Screenshot from 2026-08-26 22-24-58" src="https://github.com/user-attachments/assets/1f99d30f-42db-4ea7-aa2b-532af67e30b9" />


