### PR TITLE
feat: implement attachment registry and management system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agav-cli",
-  "version": "0.2.1-beta.1",
+  "version": "0.2.1-beta.2",
   "description": "Terminal-native AI coding assistant for real repositories",
   "type": "module",
   "bin": {

--- a/source/__tests__/clickable-line.test.ts
+++ b/source/__tests__/clickable-line.test.ts
@@ -1,0 +1,168 @@
+import { EventEmitter } from "node:events";
+import { createElement as h } from "react";
+import { describe, it, expect, vi } from "vitest";
+import render from "../ink/render.js";
+import { Box } from "../ink/index.js";
+import ClickableLine from "../components/clickable-line.js";
+
+const ROWS = 10;
+const COLS = 40;
+
+type FakeStdout = NodeJS.WriteStream & { chunks: string[] };
+
+const makeStdout = (): FakeStdout => {
+  const emitter = new EventEmitter() as unknown as FakeStdout;
+  emitter.chunks = [];
+  emitter.isTTY = true;
+  emitter.columns = COLS;
+  emitter.rows = ROWS;
+  emitter.write = ((data: string) => {
+    emitter.chunks.push(data);
+    return true;
+  }) as FakeStdout["write"];
+  return emitter;
+};
+
+const makeStdin = (): NodeJS.ReadStream => {
+  const emitter = new EventEmitter() as unknown as NodeJS.ReadStream;
+  emitter.isTTY = true;
+  emitter.setRawMode = (() => emitter) as NodeJS.ReadStream["setRawMode"];
+  emitter.resume = (() => emitter) as NodeJS.ReadStream["resume"];
+  emitter.pause = (() => emitter) as NodeJS.ReadStream["pause"];
+  emitter.read = (() => null) as NodeJS.ReadStream["read"];
+  return emitter;
+};
+
+const settle = async (instance: { waitUntilRenderFlush: () => Promise<void> }) => {
+  for (let i = 0; i < 4; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    // eslint-disable-next-line no-await-in-loop
+    await instance.waitUntilRenderFlush();
+  }
+};
+
+// SGR mouse: `CSI < button ; col ; row` then `M` to press, `m` to release.
+// Columns and rows are 1-based on the wire. A click is a press and a release
+// on the same cell.
+const clickAt = async (
+  instance: { waitUntilRenderFlush: () => Promise<void> },
+  stdin: NodeJS.ReadStream,
+  column: number,
+  row: number,
+) => {
+  const at = `0;${column + 1};${row + 1}`;
+  stdin.emit("data", Buffer.from(`\x1b[<${at}M`));
+  stdin.emit("data", Buffer.from(`\x1b[<${at}m`));
+  await settle(instance);
+};
+
+// Strips SGR color/style codes as well as the terminal-mode escapes Ink's
+// renderer emits around a frame (mouse tracking, cursor show/hide, etc.).
+const stripAnsi = (s: string) => s.replace(/\x1b\[\??[0-9;]*[a-zA-Z]/g, "");
+
+describe("ClickableLine", () => {
+  it("renders plain runs with no extra characters beyond the text", async () => {
+    const stdout = makeStdout();
+    const stdin = makeStdin();
+    const instance = render(h(ClickableLine, { runs: [{ text: "hello world" }] }), {
+      stdout,
+      stdin,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    });
+    await settle(instance);
+
+    const lastFrame = stripAnsi(stdout.chunks.join(""));
+    expect(lastFrame).toContain("hello world");
+    // The row line itself should be exactly the text, not padded/altered.
+    const lines = lastFrame.split("\n").map((l) => l.replace(/\r$/, ""));
+    const helloLine = lines.find((l) => l.includes("hello world"));
+    expect(helloLine?.trimEnd()).toBe("hello world");
+
+    instance.unmount();
+  });
+
+  it("invokes onOpen with the run's targetId when a clickable run is clicked", async () => {
+    const stdout = makeStdout();
+    const stdin = makeStdin();
+    const onOpen = vi.fn();
+    const runs = [
+      { text: "before " },
+      { text: "TARGET", targetId: "t1", color: "cyan", underline: true },
+      { text: " after" },
+    ];
+    const instance = render(h(ClickableLine, { runs, onOpen }), {
+      stdout,
+      stdin,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    });
+    await settle(instance);
+
+    // "before " is 7 chars (columns 0-6), "TARGET" spans columns 7-12.
+    await clickAt(instance, stdin, 9, 0);
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledWith("t1");
+
+    instance.unmount();
+  });
+
+  it("does not invoke onOpen when clicking a plain (non-target) run", async () => {
+    const stdout = makeStdout();
+    const stdin = makeStdin();
+    const onOpen = vi.fn();
+    const runs = [
+      { text: "before " },
+      { text: "TARGET", targetId: "t1", color: "cyan", underline: true },
+      { text: " after" },
+    ];
+    const instance = render(h(ClickableLine, { runs, onOpen }), {
+      stdout,
+      stdin,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    });
+    await settle(instance);
+
+    // Column 2 lands inside "before ".
+    await clickAt(instance, stdin, 2, 0);
+
+    expect(onOpen).not.toHaveBeenCalled();
+
+    instance.unmount();
+  });
+
+  it("resolves clicks on both halves of a link wrapped across two rows to the same target", async () => {
+    const stdout = makeStdout();
+    const stdin = makeStdin();
+    const onOpen = vi.fn();
+    const tree = h(
+      Box,
+      { flexDirection: "column" },
+      h(ClickableLine, { runs: [{ text: "TARGET", targetId: "t1" }], onOpen }),
+      h(ClickableLine, { runs: [{ text: "MORE", targetId: "t1" }], onOpen }),
+    );
+    const instance = render(tree, {
+      stdout,
+      stdin,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    });
+    await settle(instance);
+
+    // Row 0: "TARGET" at columns 0-5.
+    await clickAt(instance, stdin, 2, 0);
+    // Row 1: "MORE" at columns 0-3.
+    await clickAt(instance, stdin, 1, 1);
+
+    expect(onOpen).toHaveBeenCalledTimes(2);
+    expect(onOpen).toHaveBeenNthCalledWith(1, "t1");
+    expect(onOpen).toHaveBeenNthCalledWith(2, "t1");
+
+    instance.unmount();
+  });
+});

--- a/source/__tests__/commands.open.test.ts
+++ b/source/__tests__/commands.open.test.ts
@@ -9,6 +9,7 @@ vi.mock("../utils/open-target.js", () => ({
 
 vi.mock("../utils/open-external.js", () => ({
   spoolImageToTempFile: vi.fn(),
+  cleanupSpooledImages: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { openTarget } from "../utils/open-target.js";

--- a/source/__tests__/commands.open.test.ts
+++ b/source/__tests__/commands.open.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../utils/open-target.js", () => ({
+  openTarget: vi.fn(),
+}));
+
+vi.mock("../utils/open-external.js", () => ({
+  spoolImageToTempFile: vi.fn(),
+}));
+
+import { openTarget } from "../utils/open-target.js";
+import { spoolImageToTempFile } from "../utils/open-external.js";
+import { openCommand } from "../commands/open.js";
+import type { CommandContext } from "../commands/types.js";
+import {
+  resetAttachmentCounter,
+  createTextAttachment,
+  createImageAttachmentFromData,
+  createFileAttachment,
+} from "../utils/attachments.js";
+import { clearAttachmentRegistry, getAttachment } from "../utils/attachment-registry.js";
+
+const openTargetMock = vi.mocked(openTarget);
+const spoolImageMock = vi.mocked(spoolImageToTempFile);
+
+const createContext = (): CommandContext => ({
+  conversation: {} as any,
+  config: {} as any,
+  setModel: vi.fn(),
+  setProvider: vi.fn(),
+  setEffort: vi.fn(),
+  clearMessages: vi.fn(),
+  refreshPlan: vi.fn(),
+  showStatus: vi.fn(),
+  saveSession: vi.fn(),
+  refreshDisplay: vi.fn(),
+  loadSession: vi.fn(),
+  activateSession: vi.fn(),
+  renameSession: vi.fn(),
+  exit: vi.fn(),
+  getDebugState: vi.fn(),
+  submit: vi.fn(),
+  handleSubmit: vi.fn(),
+  toolRegistry: {} as any,
+  addTokenUsage: vi.fn(),
+  setRunningSkill: vi.fn(),
+  setPickerActive: vi.fn(),
+  suspendTerminal: vi.fn(() => vi.fn()),
+  showAgentsTUI: vi.fn(),
+  showSkillsTUI: vi.fn(),
+});
+
+describe("commands/open", () => {
+  beforeEach(() => {
+    resetAttachmentCounter();
+    clearAttachmentRegistry();
+    vi.clearAllMocks();
+  });
+
+  it("reports no attachments yet when the registry is empty and args are blank", async () => {
+    const context = createContext();
+    const result = await openCommand.execute("", context);
+
+    expect(result.type).toBe("message");
+    expect((result as any).text.toLowerCase()).toContain("no attachments");
+  });
+
+  it("lists every registered attachment by #id [kind] summary, and mentions /open <n>", async () => {
+    const paste = createTextAttachment("hello world");
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    const file = createFileAttachment("/abs/src/app.ts", "src/app.ts");
+
+    const context = createContext();
+    const result = await openCommand.execute("", context);
+    const text = (result as any).text as string;
+
+    expect(text).toContain(`#${paste.id} [paste] ${paste.summary}`);
+    expect(text).toContain(`#${image.id} [image] ${image.summary}`);
+    expect(text).toContain(`#${file.id} [file] ${file.summary}`);
+    expect(text).toContain("/open <n>");
+  });
+
+  it("reports a non-numeric argument as invalid", async () => {
+    const context = createContext();
+    const result = await openCommand.execute("abc", context);
+
+    expect((result as any).text).toContain(`"abc"`);
+    expect((result as any).text.toLowerCase()).toContain("not a valid attachment number");
+  });
+
+  it("reports a nonexistent attachment id as not found", async () => {
+    const context = createContext();
+    const result = await openCommand.execute("9999", context);
+
+    expect((result as any).text).toContain("#9999");
+    expect((result as any).text.toLowerCase()).toMatch(/not found|no longer available/);
+  });
+
+  it("shows a paste attachment's summary and full text when short", async () => {
+    const paste = createTextAttachment("hello world");
+    const context = createContext();
+
+    const result = await openCommand.execute(String(paste.id), context);
+    const text = (result as any).text as string;
+
+    expect(text).toContain(paste.summary);
+    expect(text).toContain("hello world");
+  });
+
+  it("truncates a long paste attachment's text with a note", async () => {
+    const longText = "x".repeat(600);
+    const paste = createTextAttachment(longText);
+    const context = createContext();
+
+    const result = await openCommand.execute(String(paste.id), context);
+    const text = (result as any).text as string;
+
+    expect(text).toContain("x".repeat(500));
+    expect(text).not.toContain("x".repeat(501));
+    expect(text.toLowerCase()).toContain("truncated");
+    expect(text).toContain("600 chars total");
+  });
+
+  it("forwards openTarget's outcome message for a file attachment", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agav-open-cmd-"));
+    try {
+      const absPath = join(dir, "app.ts");
+      await writeFile(absPath, "export {};\n");
+      const file = createFileAttachment(absPath, "app.ts");
+
+      openTargetMock.mockResolvedValue({ ok: true, message: "Opened app.ts in VS Code." });
+
+      const context = createContext();
+      const result = await openCommand.execute(String(file.id), context);
+
+      expect(openTargetMock).toHaveBeenCalledWith({ kind: "file", absPath });
+      expect((result as any).text).toBe("Opened app.ts in VS Code.");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards openTarget's outcome for an image attachment that already has a spoolPath", async () => {
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    const registered = getAttachment(image.id)!;
+    (registered.source as any).spoolPath = "/tmp/agav-images/image-fake.png";
+
+    openTargetMock.mockResolvedValue({ ok: true, message: "Opened /tmp/agav-images/image-fake.png." });
+
+    const context = createContext();
+    const result = await openCommand.execute(String(image.id), context);
+
+    expect(spoolImageMock).not.toHaveBeenCalled();
+    expect(openTargetMock).toHaveBeenCalledWith({ kind: "file", absPath: "/tmp/agav-images/image-fake.png" });
+    expect((result as any).text).toBe("Opened /tmp/agav-images/image-fake.png.");
+  });
+
+  it("spools an image attachment with only base64 data, then forwards openTarget's outcome", async () => {
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+
+    spoolImageMock.mockResolvedValue("/tmp/agav-images/image-spooled.png");
+    openTargetMock.mockResolvedValue({ ok: true, message: "Opened /tmp/agav-images/image-spooled.png." });
+
+    const context = createContext();
+    const result = await openCommand.execute(String(image.id), context);
+
+    expect(spoolImageMock).toHaveBeenCalledWith("YWJj", "image/png");
+    expect(openTargetMock).toHaveBeenCalledWith({ kind: "file", absPath: "/tmp/agav-images/image-spooled.png" });
+    expect((result as any).text).toBe("Opened /tmp/agav-images/image-spooled.png.");
+  });
+});

--- a/source/__tests__/ink-global-selection.test.ts
+++ b/source/__tests__/ink-global-selection.test.ts
@@ -74,4 +74,42 @@ describe("global text selection", () => {
 		expect(writeClipboard).toHaveBeenCalledWith(stdout, "hello");
 		instance.unmount();
 	});
+
+	it("uses a release-only mouse report to copy a drag", async () => {
+		const stdout = makeStdout();
+		const stdin = makeStdin();
+		const instance = render(createElement(Text, null, "hello"), {
+			stdout,
+			stdin,
+			patchConsole: false,
+			exitOnCtrlC: false,
+		});
+		await instance.waitUntilRenderFlush();
+
+		stdin.emit("data", "\x1b[<0;1;1M");
+		stdin.emit("data", "\x1b[<0;6;1m");
+
+		expect(writeClipboard).toHaveBeenCalledWith(stdout, "hello");
+		instance.unmount();
+	});
+
+	it("copies an active selection when CMD reports Ctrl+Shift+C as Ctrl+C", async () => {
+		const stdout = makeStdout();
+		const stdin = makeStdin();
+		const instance = render(createElement(Text, null, "hello"), {
+			stdout,
+			stdin,
+			patchConsole: false,
+			exitOnCtrlC: true,
+		});
+		await instance.waitUntilRenderFlush();
+
+		stdin.emit("data", "\x1b[<0;1;1M");
+		stdin.emit("data", "\x1b[<0;6;1m");
+		writeClipboard.mockClear();
+		stdin.emit("data", "\x03");
+
+		expect(writeClipboard).toHaveBeenCalledWith(stdout, "hello");
+		instance.unmount();
+	});
 });

--- a/source/__tests__/ink-global-selection.test.ts
+++ b/source/__tests__/ink-global-selection.test.ts
@@ -1,0 +1,77 @@
+import {EventEmitter} from "node:events";
+import {createElement} from "react";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+const {writeClipboard} = vi.hoisted(() => ({writeClipboard: vi.fn()}));
+vi.mock("../ink/termio/clipboard.js", () => ({writeClipboard}));
+
+import render from "../ink/render.js";
+import Text from "../ink/components/Text.js";
+
+type FakeStdout = NodeJS.WriteStream & {chunks: string[]};
+
+const makeStdout = (): FakeStdout => {
+	const stdout = new EventEmitter() as unknown as FakeStdout;
+	stdout.chunks = [];
+	stdout.isTTY = true;
+	stdout.columns = 80;
+	stdout.rows = 24;
+	stdout.write = ((data: string) => {
+		stdout.chunks.push(data);
+		return true;
+	}) as FakeStdout["write"];
+	return stdout;
+};
+
+const makeStdin = (): NodeJS.ReadStream => {
+	const stdin = new EventEmitter() as unknown as NodeJS.ReadStream;
+	stdin.isTTY = true;
+	stdin.setRawMode = (() => stdin) as NodeJS.ReadStream["setRawMode"];
+	stdin.resume = (() => stdin) as NodeJS.ReadStream["resume"];
+	stdin.pause = (() => stdin) as NodeJS.ReadStream["pause"];
+	stdin.setEncoding = (() => stdin) as unknown as NodeJS.ReadStream["setEncoding"];
+	stdin.read = (() => null) as NodeJS.ReadStream["read"];
+	return stdin;
+};
+
+describe("global text selection", () => {
+	beforeEach(() => writeClipboard.mockClear());
+
+	it("copies a normal left-button drag when it is released", async () => {
+		const stdout = makeStdout();
+		const stdin = makeStdin();
+		const instance = render(createElement(Text, null, "hello"), {
+			stdout,
+			stdin,
+			patchConsole: false,
+			exitOnCtrlC: false,
+		});
+		await instance.waitUntilRenderFlush();
+
+		stdin.emit("data", "\x1b[<0;1;1M");
+		stdin.emit("data", "\x1b[<32;6;1M");
+		stdin.emit("data", "\x1b[<0;6;1m");
+
+		expect(writeClipboard).toHaveBeenCalledWith(stdout, "hello");
+		instance.unmount();
+	});
+
+	it("copies the active selection with Kitty Ctrl+Shift+C", async () => {
+		const stdout = makeStdout();
+		const stdin = makeStdin();
+		const instance = render(createElement(Text, null, "hello"), {
+			stdout,
+			stdin,
+			patchConsole: false,
+			exitOnCtrlC: false,
+		});
+		await instance.waitUntilRenderFlush();
+
+		stdin.emit("data", "\x1b[<0;1;1M");
+		stdin.emit("data", "\x1b[<32;6;1M");
+		stdin.emit("data", "\x1b[99;6u");
+
+		expect(writeClipboard).toHaveBeenCalledWith(stdout, "hello");
+		instance.unmount();
+	});
+});

--- a/source/__tests__/ink-selection.test.ts
+++ b/source/__tests__/ink-selection.test.ts
@@ -7,6 +7,7 @@ import {
 	extendSelection,
 } from "../ink/selection.js";
 import {osc52Copy} from "../ink/termio/clipboard.js";
+import {ENABLE_MOUSE_TRACKING} from "../ink/termio/dec.js";
 
 describe("normalizeSelection", () => {
 	it("orders two points on different rows into reading order", () => {
@@ -93,5 +94,14 @@ describe("getSelectedText", () => {
 describe("osc52Copy", () => {
 	it("produces the correct base64 and escape wrapper for 'hello'", () => {
 		expect(osc52Copy("hello")).toBe("\x1b]52;c;aGVsbG8=\x07");
+	});
+});
+
+describe("mouse tracking for in-app selection", () => {
+	it("enables drag tracking but not unused any-motion tracking", () => {
+		expect(ENABLE_MOUSE_TRACKING).toContain("\x1b[?1000h");
+		expect(ENABLE_MOUSE_TRACKING).toContain("\x1b[?1002h");
+		expect(ENABLE_MOUSE_TRACKING).toContain("\x1b[?1006h");
+		expect(ENABLE_MOUSE_TRACKING).not.toContain("\x1b[?1003h");
 	});
 });

--- a/source/__tests__/input-prompt-click.test.ts
+++ b/source/__tests__/input-prompt-click.test.ts
@@ -186,8 +186,8 @@ describe("clicking in the input prompt", () => {
 // into two strings that match nothing, orphaning the attachment silently.
 
 describe("clicking on an attachment placeholder", () => {
-  const PASTE = "<<(hello worl...) Pasted #1: 2k chars and 40 lines>>";
-  const IMAGE = "<<Image #2: 800x600>>";
+  const PASTE = "<<Pasted #1 · 2k chars, 40 lines>>";
+  const IMAGE = "<<Image #2 · 800x600>>";
 
   it("snaps to the near edge of a pasted-text placeholder", async () => {
     const { instance, stdin } = await mount(`${PASTE} tail`);
@@ -273,7 +273,7 @@ describe("clicking a prompt on a frame that has scrolled", () => {
 });
 
 describe("snapOutOfAttachment", () => {
-  const PASTE = "<<(hello worl...) Pasted #1: 2k chars and 40 lines>>";
+  const PASTE = "<<Pasted #1 · 2k chars, 40 lines>>";
 
   it("leaves an offset outside every placeholder alone", () => {
     const text = `head ${PASTE} tail`;
@@ -295,7 +295,7 @@ describe("snapOutOfAttachment", () => {
   });
 
   it("picks the right placeholder when there are several", () => {
-    const image = "<<Image #2: 800x600>>";
+    const image = "<<Image #2 · 800x600>>";
     const text = `${PASTE} ${image}`;
     const imageStart = PASTE.length + 1;
     expect(snapOutOfAttachment(text, imageStart + 2)).toBe(imageStart);

--- a/source/__tests__/input-prompt-click.test.ts
+++ b/source/__tests__/input-prompt-click.test.ts
@@ -169,6 +169,18 @@ describe("clicking in the input prompt", () => {
     instance.unmount();
   });
 
+  it("snaps a click in a wide grapheme to its boundary", async () => {
+    const { instance, stdin } = await mount("a🎉b");
+
+    // The second cell of 🎉 must place the caret after the entire emoji, not
+    // between its surrogate halves.
+    await clickAt(instance, stdin, PREFIX + 2, 0);
+    await type(instance, stdin, "X");
+
+    expect(currentValue).toBe("a🎉Xb");
+    instance.unmount();
+  });
+
   it("does nothing to an empty prompt", async () => {
     const { instance, stdin } = await mount("");
 

--- a/source/__tests__/input-prompt-expand-paste.test.ts
+++ b/source/__tests__/input-prompt-expand-paste.test.ts
@@ -1,0 +1,138 @@
+import { EventEmitter } from "node:events";
+import { createElement as h, useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import render from "../ink/render.js";
+import InputPrompt from "../components/input-prompt.js";
+import { DEFAULT_KEYBINDINGS } from "../config/keybindings.js";
+import { attachmentTileForId } from "../utils/attachments.js";
+
+vi.mock("../config/prompt-history.js", () => ({
+  loadPromptHistory: async () => [],
+  savePromptHistory: async () => {},
+}));
+
+const ROWS = 20;
+const COLS = 60;
+
+const makeStdout = () => {
+  const emitter = new EventEmitter() as unknown as NodeJS.WriteStream & { chunks: string[] };
+  emitter.chunks = [];
+  emitter.isTTY = true;
+  emitter.columns = COLS;
+  emitter.rows = ROWS;
+  emitter.write = ((data: string) => {
+    emitter.chunks.push(data);
+    return true;
+  }) as NodeJS.WriteStream["write"];
+  return emitter;
+};
+
+const makeStdin = (): NodeJS.ReadStream => {
+  const emitter = new EventEmitter() as unknown as NodeJS.ReadStream;
+  emitter.isTTY = true;
+  emitter.setRawMode = (() => emitter) as NodeJS.ReadStream["setRawMode"];
+  emitter.resume = (() => emitter) as NodeJS.ReadStream["resume"];
+  emitter.pause = (() => emitter) as NodeJS.ReadStream["pause"];
+  emitter.read = (() => null) as NodeJS.ReadStream["read"];
+  return emitter;
+};
+
+const settle = async (instance: { waitUntilRenderFlush: () => Promise<void> }) => {
+  for (let i = 0; i < 4; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // eslint-disable-next-line no-await-in-loop
+    await instance.waitUntilRenderFlush();
+  }
+};
+
+let currentValue = "";
+let expandFn: ((id: number, fullText: string) => boolean) | null = null;
+let insertFn: ((label: string) => void) | null = null;
+
+const Host = ({ initial }: { initial: string }) => {
+  const [value, setValue] = useState(initial);
+  currentValue = value;
+  return h(InputPrompt, {
+    value,
+    onChange: setValue,
+    onSubmit: () => {},
+    keybindings: DEFAULT_KEYBINDINGS,
+    onRegisterInsert: (fn) => { insertFn = fn; },
+    onRegisterExpand: (fn) => { expandFn = fn; },
+  });
+};
+
+const mount = async (initial = "") => {
+  const stdout = makeStdout();
+  const stdin = makeStdin();
+  const instance = render(h(Host, { initial }), {
+    stdout, stdin, patchConsole: false, exitOnCtrlC: false,
+  });
+  await settle(instance);
+  return { instance, stdout, stdin };
+};
+
+describe("attachmentTileForId", () => {
+  it("matches only the tile for the given id", () => {
+    const text = "<<Pasted #1 · 5 chars, 1 lines>> and <<Pasted #2 · 9 chars, 1 lines>>";
+    const re1 = attachmentTileForId(1);
+    const re2 = attachmentTileForId(2);
+    expect(text.match(re1)?.[0]).toBe("<<Pasted #1 · 5 chars, 1 lines>>");
+    expect(text.match(re2)?.[0]).toBe("<<Pasted #2 · 9 chars, 1 lines>>");
+  });
+
+  it("does not match a different id, even a prefix of it", () => {
+    const text = "<<Pasted #12 · 5 chars, 1 lines>>";
+    expect(attachmentTileForId(1).test(text)).toBe(false);
+    expect(attachmentTileForId(12).test(text)).toBe(true);
+  });
+});
+
+describe("double-paste-to-expand wiring in InputPrompt", () => {
+  it("replaces an existing tile with the full text via the registered expand function", async () => {
+    const label = "<<Pasted #1 · 11 chars, 1 lines>>";
+    const { instance } = await mount(`before ${label} after`);
+
+    expect(expandFn).not.toBeNull();
+    const fullText = "hello world";
+    const replaced = expandFn!(1, fullText);
+    await settle(instance);
+
+    expect(replaced).toBe(true);
+    expect(currentValue).toBe(`before ${fullText} after`);
+    instance.unmount();
+  });
+
+  it("returns false and leaves the buffer untouched when the tile is no longer present", async () => {
+    const { instance } = await mount("no attachments here");
+
+    const replaced = expandFn!(1, "full text");
+    await settle(instance);
+
+    expect(replaced).toBe(false);
+    expect(currentValue).toBe("no attachments here");
+    instance.unmount();
+  });
+
+  it("expands the correct tile when several are present", async () => {
+    const tile1 = "<<Pasted #1 · 3 chars, 1 lines>>";
+    const tile2 = "<<Pasted #2 · 3 chars, 1 lines>>";
+    const { instance } = await mount(`${tile1} and ${tile2}`);
+
+    const replaced = expandFn!(2, "XYZ");
+    await settle(instance);
+
+    expect(replaced).toBe(true);
+    expect(currentValue).toBe(`${tile1} and XYZ`);
+    instance.unmount();
+  });
+
+  it("still allows inserting a fresh label afterward via onRegisterInsert", async () => {
+    const { instance } = await mount("");
+    insertFn!("<<Pasted #1 · 5 chars, 1 lines>>");
+    await settle(instance);
+    expect(currentValue).toContain("<<Pasted #1 · 5 chars, 1 lines>>");
+    instance.unmount();
+  });
+});

--- a/source/__tests__/markdown-table.test.ts
+++ b/source/__tests__/markdown-table.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import stringWidth from "string-width";
+import chalk from "chalk";
 
-const { wrapStyled, fitColumns, renderMarkdown } = await import("../components/markdown-text.js");
+const { wrapStyled, fitColumns, renderMarkdown, sliceStyled } = await import("../components/markdown-text.js");
 
 const ESC = String.fromCharCode(27);
 const bold = (s: string) => `${ESC}[1m${s}${ESC}[22m`;
@@ -57,6 +58,125 @@ describe("wrapStyled", () => {
       // A split flag would leave a lone regional indicator.
       expect(Array.from(line).length % 2).toBe(0);
     }
+  });
+
+  it("treats an embedded newline as a hard break, not a zero-width character to wrap through", () => {
+    // Regression: `stringWidth("\n")` is 0, so without an explicit newline
+    // split the single-pass wrapper below happily packed several source
+    // lines — e.g. every bullet of a rendered markdown list — onto one
+    // returned "line", which downstream renders as one `<Box>` row containing
+    // a raw "\n" and breaks the terminal display (bullets run together with
+    // no visible separation).
+    const text = "line one\nline two\nline three";
+    const lines = wrapStyled(text, 60);
+    expect(lines).toEqual(["line one", "line two", "line three"]);
+    for (const line of lines) expect(line.includes("\n")).toBe(false);
+  });
+
+  it("wraps each newline-separated segment independently when a segment overflows", () => {
+    const text = "short\na very long line that needs to be wrapped across more than one row of output";
+    const lines = wrapStyled(text, 20);
+    for (const line of lines) {
+      expect(stringWidth(line)).toBeLessThanOrEqual(20);
+      expect(line.includes("\n")).toBe(false);
+    }
+    expect(lines[0]).toBe("short");
+    expect(lines.join(" ").replace(/\s+/g, " ")).toContain("a very long line that needs to be wrapped across more than one row of output".split(" ")[0]);
+  });
+
+  it("reproduces a multi-line bulleted list as one wrapped row per bullet", () => {
+    const styled = renderMarkdown("Files:\n- source/app.ts\n- source/utils/attachments.ts\n- source/commands/open.ts\n");
+    const lines = wrapStyled(styled, 60);
+    const visible = lines.map(stripAnsi);
+    expect(visible.filter((l) => l.includes("•")).length).toBe(3);
+    for (const line of lines) expect(line.includes("\n")).toBe(false);
+  });
+});
+
+describe("renderMarkdown does not pre-wrap prose (leaves wrapping to a single downstream pass)", () => {
+  // Regression: marked-terminal's own `reflowText` option wrapped prose to a
+  // fixed column count *inside* renderMarkdown's own output, inserting a
+  // literal "\n" through any inline token (a file path, a URL) long enough to
+  // straddle that column. Every caller re-wraps `renderMarkdown`'s result a
+  // second time anyway (`wrapStyled` for clickable messages, Ink's own
+  // `<Text>` wrapping everywhere else), and detection/click-matching does a
+  // literal substring search for the token that was found clickable — a
+  // token pre-split by marked-terminal's reflow could never be found as one
+  // contiguous substring again, which is why ctrl+click worked for some
+  // agent-mentioned paths (short enough to survive intact) and silently
+  // failed for others of the exact same kind (long enough to be reflow-split)
+  // — depending only on width and per-message text, with no visible sign
+  // anything had gone wrong.
+  it("keeps a long inline path/URL-like token intact rather than splitting it with an embedded newline", () => {
+    const longPath = ".agav-worktrees/vertex-ai-thinking-tokens/source/commands/export.ts";
+    const out = renderMarkdown(`See ${longPath} for details.`);
+    expect(out).toContain(longPath);
+    expect(out.includes("\n")).toBe(false);
+  });
+
+  it("keeps a long inline token intact regardless of terminal width", () => {
+    const longPath = "source/utils/some-really-quite-long-module-name-here.ts";
+    for (const width of [40, 60, 80, 120]) {
+      const original = process.stdout.columns;
+      process.stdout.columns = width;
+      try {
+        const out = renderMarkdown(`Check ${longPath} please`);
+        expect(out).toContain(longPath);
+      } finally {
+        process.stdout.columns = original;
+      }
+    }
+  });
+});
+
+describe("sliceStyled", () => {
+  // chalk paints nothing at all when it cannot detect a colour terminal,
+  // which it never can under vitest. Force a level so the escapes the
+  // styled-string tests below look for are actually emitted.
+  beforeAll(() => {
+    chalk.level = 3;
+  });
+
+  it("slices a plain unstyled string", () => {
+    expect(sliceStyled("hello world", 0, 5)).toBe("hello");
+  });
+
+  it("clamps out-of-range indices", () => {
+    expect(sliceStyled("hello", 2, 100)).toBe("llo");
+    expect(sliceStyled("hello", -5, 3)).toBe("hel");
+  });
+
+  it("returns an empty string when end <= start", () => {
+    expect(sliceStyled("hello", 3, 3)).toBe("");
+    expect(sliceStyled("hello", 4, 2)).toBe("");
+  });
+
+  it("loses no visible characters when concatenating slices", () => {
+    const styled = chalk.bold("hello ") + "plain " + chalk.underline.cyan("link");
+    const visible = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+    const total = visible(styled).length;
+    const a = sliceStyled(styled, 0, 6);
+    const b = sliceStyled(styled, 6, 13);
+    const c = sliceStyled(styled, 13, total);
+    expect(visible(a) + visible(b) + visible(c)).toBe(visible(styled));
+  });
+
+  it("keeps a middle slice's own styling recoverable", () => {
+    const styled = chalk.bold("hello ") + "plain " + chalk.underline.cyan("link");
+    const visible = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+    const total = visible(styled).length;
+    const linkStart = visible(styled).indexOf("link");
+    const c = sliceStyled(styled, linkStart, total);
+    expect(c).toMatch(/\x1b\[/);
+    expect(visible(c)).toBe("link");
+  });
+
+  it("never slices inside an escape sequence", () => {
+    const styled = chalk.bold("hello ") + "plain " + chalk.underline.cyan("link");
+    expect(() => sliceStyled(styled, 0, 1)).not.toThrow();
+    const first = sliceStyled(styled, 0, 1);
+    const visible = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+    expect(visible(first)).toBe("h");
   });
 });
 

--- a/source/__tests__/message-list-user-click.test.ts
+++ b/source/__tests__/message-list-user-click.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from "node:events";
+import { createElement as h } from "react";
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import render from "../ink/render.js";
+import MessageList from "../components/message-list.js";
+import type { DisplayMessage } from "../components/message-list.js";
+import type { OpenRef } from "../utils/open-ref.js";
+import { clearDetectionCache } from "../utils/detect-targets.js";
+
+// Regression coverage for: ctrl+click did not work on a file path the *user*
+// typed into a message, only on paths the agent mentioned — because the user
+// bubble was painted as a single opaque `<Text>` band with no per-run click
+// targets at all, unlike the assistant bubble which already went through
+// `ClickableMarkdown`.
+
+const ROWS = 20;
+const COLS = 60;
+
+type FakeStdout = NodeJS.WriteStream & { chunks: string[] };
+
+const makeStdout = (): FakeStdout => {
+  const emitter = new EventEmitter() as unknown as FakeStdout;
+  emitter.chunks = [];
+  emitter.isTTY = true;
+  emitter.columns = COLS;
+  emitter.rows = ROWS;
+  emitter.write = ((data: string) => {
+    emitter.chunks.push(data);
+    return true;
+  }) as FakeStdout["write"];
+  return emitter;
+};
+
+const makeStdin = (): NodeJS.ReadStream => {
+  const emitter = new EventEmitter() as unknown as NodeJS.ReadStream;
+  emitter.isTTY = true;
+  emitter.setRawMode = (() => emitter) as NodeJS.ReadStream["setRawMode"];
+  emitter.resume = (() => emitter) as NodeJS.ReadStream["resume"];
+  emitter.pause = (() => emitter) as NodeJS.ReadStream["pause"];
+  emitter.read = (() => null) as NodeJS.ReadStream["read"];
+  return emitter;
+};
+
+const settle = async (instance: { waitUntilRenderFlush: () => Promise<void> }) => {
+  for (let i = 0; i < 4; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // eslint-disable-next-line no-await-in-loop
+    await instance.waitUntilRenderFlush();
+  }
+};
+
+const clickAt = async (
+  instance: { waitUntilRenderFlush: () => Promise<void> },
+  stdin: NodeJS.ReadStream,
+  column: number,
+  row: number,
+) => {
+  const at = `0;${column + 1};${row + 1}`;
+  stdin.emit("data", Buffer.from(`\x1b[<${at}M`));
+  stdin.emit("data", Buffer.from(`\x1b[<${at}m`));
+  await settle(instance);
+};
+
+describe("clicking a file path inside a user-typed message", () => {
+  let root: string;
+
+  afterEach(async () => {
+    clearDetectionCache();
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  it("resolves to the same path the user typed, opened via onOpenRef", async () => {
+    root = await mkdtemp(join(tmpdir(), "agav-user-click-"));
+    const origCwd = process.cwd();
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "app.ts"), "export {}\n");
+    process.chdir(root);
+
+    try {
+      const stdout = makeStdout();
+      const stdin = makeStdin();
+      let opened: OpenRef | null = null;
+
+      const messages: DisplayMessage[] = [
+        { id: "u1", role: "user", content: "please open src/app.ts for me" },
+      ];
+
+      const instance = render(
+        h(MessageList, {
+          messages,
+          toolDetailKey: "ctrl+o",
+          columns: COLS,
+          onOpenRef: (ref: OpenRef) => { opened = ref; },
+        }),
+        { stdout, stdin, patchConsole: false, exitOnCtrlC: false },
+      );
+      await settle(instance);
+      // Detection is async (it stats the filesystem); give it one more
+      // render cycle to land before scanning for the clickable run.
+      await settle(instance);
+
+      // "❯ please open " is 14 visible columns before "src/app.ts" begins,
+      // on the row the message text prints to (row 0 is the band's top
+      // padding line).
+      const prefixLen = "❯ please open ".length;
+      let found = false;
+      for (let row = 0; row < 4 && !found; row++) {
+        // eslint-disable-next-line no-await-in-loop
+        await clickAt(instance, stdin, prefixLen + 2, row);
+        if (opened) found = true;
+      }
+
+      expect(opened).not.toBeNull();
+      expect((opened as unknown as OpenRef)?.kind).toBe("path");
+      if (opened && (opened as OpenRef).kind === "path") {
+        expect((opened as Extract<OpenRef, { kind: "path" }>).absPath).toBe(join(root, "src", "app.ts"));
+      }
+
+      instance.unmount();
+    } finally {
+      process.chdir(origCwd);
+    }
+  }, 15000);
+
+  it("renders no clickable run (falls back to plain text) when no onOpenRef handler is provided", async () => {
+    root = await mkdtemp(join(tmpdir(), "agav-user-click-noop-"));
+    const origCwd = process.cwd();
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "app.ts"), "export {}\n");
+    process.chdir(root);
+
+    try {
+      const stdout = makeStdout();
+      const stdin = makeStdin();
+
+      const messages: DisplayMessage[] = [
+        { id: "u1", role: "user", content: "please open src/app.ts for me" },
+      ];
+
+      const instance = render(
+        h(MessageList, { messages, toolDetailKey: "ctrl+o", columns: COLS }),
+        { stdout, stdin, patchConsole: false, exitOnCtrlC: false },
+      );
+      await settle(instance);
+
+      // Nothing to assert on click resolution since there's no handler; the
+      // real assertion is that mounting/rendering without a handler does not
+      // throw and still paints the message text.
+      const painted = stdout.chunks.some((chunk) => chunk.includes("please open"));
+      expect(painted).toBe(true);
+
+      instance.unmount();
+    } finally {
+      process.chdir(origCwd);
+    }
+  });
+});

--- a/source/__tests__/utils.attachment-registry.test.ts
+++ b/source/__tests__/utils.attachment-registry.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("../utils/open-external.js", () => ({
   spoolImageToTempFile: vi.fn(),
+  cleanupSpooledImage: vi.fn().mockResolvedValue(undefined),
+  cleanupSpooledImages: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { spoolImageToTempFile } from "../utils/open-external.js";
+import { spoolImageToTempFile, cleanupSpooledImage } from "../utils/open-external.js";
 import {
   getAttachment,
   clearAttachmentRegistry,
@@ -22,6 +24,7 @@ import {
 } from "../utils/attachments.js";
 
 const spoolMock = vi.mocked(spoolImageToTempFile);
+const cleanupSpoolMock = vi.mocked(cleanupSpooledImage);
 
 describe("utils/attachment-registry: listAttachments", () => {
   beforeEach(() => {
@@ -49,6 +52,14 @@ describe("utils/attachment-registry: listAttachments", () => {
     const listed = listAttachments();
     expect(listed.find((a) => a.id === first.id)).toBeUndefined();
     expect(listed).toHaveLength(200);
+  });
+
+  it("removes a spooled image when it is evicted", () => {
+    const image = createImageAttachmentFromData("YWJj", "image/png");
+    (getAttachment(image.id)!.source as any).spoolPath = "/tmp/agav-images/image-evicted.png";
+    for (let i = 0; i < 200; i++) createTextAttachment(`filler-${i}`);
+
+    expect(cleanupSpoolMock).toHaveBeenCalledWith("/tmp/agav-images/image-evicted.png");
   });
 });
 

--- a/source/__tests__/utils.attachment-registry.test.ts
+++ b/source/__tests__/utils.attachment-registry.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../utils/open-external.js", () => ({
+  spoolImageToTempFile: vi.fn(),
+}));
+
+import { spoolImageToTempFile } from "../utils/open-external.js";
+import {
+  getAttachment,
+  clearAttachmentRegistry,
+  listAttachments,
+  compactImageAttachment,
+  compactImageAttachments,
+  unregisterAttachment,
+  wasEvicted,
+} from "../utils/attachment-registry.js";
+import {
+  resetAttachmentCounter,
+  createTextAttachment,
+  createImageAttachmentFromData,
+  createFileAttachment,
+} from "../utils/attachments.js";
+
+const spoolMock = vi.mocked(spoolImageToTempFile);
+
+describe("utils/attachment-registry: listAttachments", () => {
+  beforeEach(() => {
+    resetAttachmentCounter();
+    clearAttachmentRegistry();
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty list when nothing is registered", () => {
+    expect(listAttachments()).toEqual([]);
+  });
+
+  it("returns every registered attachment, oldest first", () => {
+    const first = createTextAttachment("first");
+    const second = createImageAttachmentFromData("YWJj", "image/png", 10, 10);
+    const third = createFileAttachment("/abs/a.ts", "a.ts");
+
+    expect(listAttachments()).toEqual([first, second, third]);
+  });
+
+  it("omits an attachment once it has been evicted", () => {
+    const first = createTextAttachment("first");
+    for (let i = 0; i < 200; i++) createTextAttachment(`filler-${i}`);
+
+    const listed = listAttachments();
+    expect(listed.find((a) => a.id === first.id)).toBeUndefined();
+    expect(listed).toHaveLength(200);
+  });
+});
+
+describe("utils/attachment-registry: unregisterAttachment", () => {
+  beforeEach(() => {
+    resetAttachmentCounter();
+    clearAttachmentRegistry();
+    vi.clearAllMocks();
+  });
+
+  it("removes the attachment so it can no longer be looked up", () => {
+    const paste = createTextAttachment("hello world");
+    expect(getAttachment(paste.id)).toBe(paste);
+
+    unregisterAttachment(paste.id);
+
+    expect(getAttachment(paste.id)).toBeUndefined();
+  });
+
+  it("does not mark the id as evicted — it was forgotten, not lost to a cap", () => {
+    const paste = createTextAttachment("hello world");
+    unregisterAttachment(paste.id);
+    expect(wasEvicted(paste.id)).toBe(false);
+  });
+
+  it("removes it from listAttachments without disturbing the order of the rest", () => {
+    const first = createTextAttachment("first");
+    const second = createTextAttachment("second");
+    const third = createTextAttachment("third");
+
+    unregisterAttachment(second.id);
+
+    expect(listAttachments()).toEqual([first, third]);
+  });
+
+  it("is a no-op for an id that was never registered", () => {
+    expect(() => unregisterAttachment(999999)).not.toThrow();
+    expect(listAttachments()).toEqual([]);
+  });
+});
+
+describe("utils/attachment-registry: compactImageAttachment", () => {
+  beforeEach(() => {
+    resetAttachmentCounter();
+    clearAttachmentRegistry();
+    vi.clearAllMocks();
+  });
+
+  it("spools base64 to a temp file and drops the base64 copy, keeping spoolPath", async () => {
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    spoolMock.mockResolvedValue("/tmp/agav-images/spooled-1.png");
+
+    await compactImageAttachment(image.id);
+
+    expect(spoolMock).toHaveBeenCalledWith("YWJj", "image/png");
+    const stored = getAttachment(image.id)!;
+    expect(stored.source).toMatchObject({ type: "image", spoolPath: "/tmp/agav-images/spooled-1.png" });
+    expect((stored.source as any).base64).toBeUndefined();
+  });
+
+  it("is a no-op when the attachment already has a spoolPath", async () => {
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    const stored = getAttachment(image.id)!;
+    (stored.source as any).spoolPath = "/already/spooled.png";
+
+    await compactImageAttachment(image.id);
+
+    expect(spoolMock).not.toHaveBeenCalled();
+    expect((getAttachment(image.id)!.source as any).spoolPath).toBe("/already/spooled.png");
+  });
+
+  it("is a no-op when there is no base64 data to spool", async () => {
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    const stored = getAttachment(image.id)!;
+    (stored.source as any).base64 = undefined;
+
+    await compactImageAttachment(image.id);
+
+    expect(spoolMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for a nonexistent attachment id", async () => {
+    await expect(compactImageAttachment(123456)).resolves.toBeUndefined();
+    expect(spoolMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for a non-image attachment", async () => {
+    const paste = createTextAttachment("hello");
+    await compactImageAttachment(paste.id);
+    expect(spoolMock).not.toHaveBeenCalled();
+    expect(getAttachment(paste.id)!.source).toEqual({ type: "text", text: "hello" });
+  });
+
+  it("leaves the base64 in place if spooling fails", async () => {
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    spoolMock.mockRejectedValue(new Error("disk full"));
+
+    await expect(compactImageAttachment(image.id)).resolves.toBeUndefined();
+
+    const stored = getAttachment(image.id)!;
+    expect((stored.source as any).base64).toBe("YWJj");
+    expect((stored.source as any).spoolPath).toBeUndefined();
+  });
+});
+
+describe("utils/attachment-registry: compactImageAttachments", () => {
+  beforeEach(() => {
+    resetAttachmentCounter();
+    clearAttachmentRegistry();
+    vi.clearAllMocks();
+  });
+
+  it("compacts every id in the list concurrently", async () => {
+    const a = createImageAttachmentFromData("YWJj", "image/png", 1, 1);
+    const b = createImageAttachmentFromData("ZGVm", "image/jpeg", 2, 2);
+    const paste = createTextAttachment("not an image");
+
+    spoolMock.mockImplementation(async (base64) => `/tmp/spooled-${base64}.png`);
+
+    await compactImageAttachments([a.id, b.id, paste.id]);
+
+    expect(spoolMock).toHaveBeenCalledTimes(2);
+    expect((getAttachment(a.id)!.source as any).spoolPath).toBe("/tmp/spooled-YWJj.png");
+    expect((getAttachment(b.id)!.source as any).spoolPath).toBe("/tmp/spooled-ZGVm.png");
+    // Non-image attachment untouched.
+    expect(getAttachment(paste.id)!.source).toEqual({ type: "text", text: "not an image" });
+  });
+
+  it("resolves even for an empty id list", async () => {
+    await expect(compactImageAttachments([])).resolves.toBeUndefined();
+    expect(spoolMock).not.toHaveBeenCalled();
+  });
+});

--- a/source/__tests__/utils.attachments.test.ts
+++ b/source/__tests__/utils.attachments.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
 
-import { resetAttachmentCounter, createTextAttachment, isLargeText } from "../utils/attachments.js";
+import {
+  resetAttachmentCounter,
+  createTextAttachment,
+  createImageAttachmentFromData,
+  createFileAttachment,
+  isLargeText,
+  ATTACHMENT_TILE_RE,
+  attachmentTileScanner,
+} from "../utils/attachments.js";
+import { getAttachment, clearAttachmentRegistry, wasEvicted } from "../utils/attachment-registry.js";
 
 describe("utils/attachments", () => {
   it("creates numbered text attachments with size labels", () => {
@@ -9,9 +18,9 @@ describe("utils/attachments", () => {
     const att2 = createTextAttachment("x".repeat(1000));
 
     expect(att1.id).toBe(1);
-    expect(att1.type).toBe("text");
+    expect(att1.kind).toBe("paste");
     expect(att1.label).toContain("Pasted #1");
-    expect(att1.label).toContain("7 chars and 2 lines");
+    expect(att1.label).toContain("7 chars, 2 lines");
     expect(att2.id).toBe(2);
     expect(att2.label).toContain("1k chars");
   });
@@ -20,5 +29,74 @@ describe("utils/attachments", () => {
     expect(isLargeText("a".repeat(501))).toBe(true);
     expect(isLargeText(Array.from({ length: 11 }, () => "x").join("\n"))).toBe(true);
     expect(isLargeText("small\ntext")).toBe(false);
+  });
+
+  it("registers every attachment under the shared session-unique id source", () => {
+    resetAttachmentCounter();
+    clearAttachmentRegistry();
+    const paste = createTextAttachment("hello");
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    const file = createFileAttachment("/abs/src/app.ts", "src/app.ts");
+
+    expect(paste.id).not.toBe(image.id);
+    expect(image.id).not.toBe(file.id);
+    expect(getAttachment(paste.id)).toBe(paste);
+    expect(getAttachment(image.id)).toBe(image);
+    expect(getAttachment(file.id)).toBe(file);
+  });
+
+  it("builds labels in the `<<Kind #id · summary>>` grammar", () => {
+    resetAttachmentCounter();
+    const paste = createTextAttachment("x".repeat(20));
+    const image = createImageAttachmentFromData("YWJj", "image/png", 800, 600);
+    const file = createFileAttachment("/abs/src/app.ts", "src/app.ts");
+
+    expect(paste.label).toMatch(/^<<Pasted #\d+ · .+>>$/);
+    expect(image.label).toMatch(/^<<Image #\d+ · 800x600>>$/);
+    expect(file.label).toMatch(/^<<File #\d+ · src\/app\.ts>>$/);
+  });
+
+  it("substitutes '>' in a summary so a tile can never run past its own delimiter", () => {
+    resetAttachmentCounter();
+    const file = createFileAttachment("/abs/weird>name.ts", "weird>name.ts");
+    expect(file.label).not.toMatch(/weird>name\.ts/);
+    expect(file.label).toContain("weird?name.ts");
+    // And the tile still matches as a single, well-formed unit.
+    expect(ATTACHMENT_TILE_RE.test(file.label)).toBe(true);
+  });
+});
+
+describe("ATTACHMENT_TILE_RE / attachmentTileScanner", () => {
+  it("matches all three kinds", () => {
+    expect(ATTACHMENT_TILE_RE.test("<<Pasted #1 · 2k chars, 40 lines>>")).toBe(true);
+    expect(ATTACHMENT_TILE_RE.test("<<Image #2 · 800x600>>")).toBe(true);
+    expect(ATTACHMENT_TILE_RE.test("<<File #3 · src/app.ts>>")).toBe(true);
+  });
+
+  it("does not match a malformed tile", () => {
+    expect(ATTACHMENT_TILE_RE.test("<<Pasted 2k chars>>")).toBe(false);
+    expect(ATTACHMENT_TILE_RE.test("<<Weird #1 · foo>>")).toBe(false);
+    expect(ATTACHMENT_TILE_RE.test("<<Pasted #1: 2k chars>>")).toBe(false);
+  });
+
+  it("matches two adjacent tiles separately", () => {
+    const text = "<<Pasted #1 · a>><<Image #2 · b>>";
+    const scanner = attachmentTileScanner();
+    const matches = [...text.matchAll(scanner)];
+    expect(matches).toHaveLength(2);
+    expect(matches[0]![1]).toBe("1");
+    expect(matches[1]![1]).toBe("2");
+  });
+});
+
+describe("attachment registry eviction", () => {
+  it("evicts the oldest record once the cap is exceeded and reports it as evicted", async () => {
+    resetAttachmentCounter();
+    clearAttachmentRegistry();
+    const first = createTextAttachment("first");
+    for (let i = 0; i < 200; i++) createTextAttachment(`filler-${i}`);
+
+    expect(getAttachment(first.id)).toBeUndefined();
+    expect(wasEvicted(first.id)).toBe(true);
   });
 });

--- a/source/__tests__/utils.detect-targets.test.ts
+++ b/source/__tests__/utils.detect-targets.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { detectTargets, clearDetectionCache } from "../utils/detect-targets.js";
+
+describe("utils/detect-targets", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await realpath(await mkdtemp(join(tmpdir(), "agav-detect-")));
+  });
+
+  afterEach(async () => {
+    clearDetectionCache();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("detects a bare URL in prose", async () => {
+    const targets = await detectTargets("check out https://example.com/foo?x=1 for more", root);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ kind: "url", text: "https://example.com/foo?x=1" });
+  });
+
+  it("excludes sentence-ending trailing punctuation from a URL", async () => {
+    const targets = await detectTargets("see https://example.com/page.", root);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.kind).toBe("url");
+    expect(targets[0]!.text).toBe("https://example.com/page");
+    expect(targets[0]!.text.endsWith(".")).toBe(false);
+  });
+
+  it("reports a path target for a file that actually exists under root", async () => {
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "app.ts"), "export {};\n");
+
+    const targets = await detectTargets("edit src/app.ts to fix it", root);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.kind).toBe("path");
+    expect(targets[0]!.absPath).toBe(resolve(root, "src/app.ts"));
+  });
+
+  it("does not report a path for a file that does not exist", async () => {
+    const targets = await detectTargets("edit src/does-not-exist.ts to fix it", root);
+    expect(targets.find((t) => t.kind === "path")).toBeUndefined();
+    expect(targets).toHaveLength(0);
+  });
+
+  it("does not report a path that resolves outside root via traversal", async () => {
+    const projectRoot = join(root, "project");
+    await mkdir(projectRoot, { recursive: true });
+
+    // `/etc/passwd` exists on virtually every unix test machine; the point is
+    // that even if it resolves to a real file, it must be rejected because it
+    // is outside `projectRoot`.
+    const targets = await detectTargets("do not open ../../etc/passwd please", projectRoot);
+    expect(targets.find((t) => t.kind === "path")).toBeUndefined();
+  });
+
+  it("validates a path candidate that has a :line:col suffix, resolving/stat-ing the bare path only", async () => {
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "app.ts"), "export {};\n");
+
+    const targets = await detectTargets("see src/app.ts:12:5 for the bug", root);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ kind: "path", line: 12, col: 5, text: "src/app.ts:12:5" });
+    expect(targets[0]!.absPath).toBe(resolve(root, "src/app.ts"));
+  });
+
+  it("skips known false-positive corpora that merely look like paths", async () => {
+    const cases = [
+      "the ratio is 3.5/2.1",
+      "released v1.2.3 today",
+      "logged on 2024/01/02",
+      "built for linux/amd64",
+      "downloads at 10 MB/s",
+      "the odds are 50/50",
+      "email a@b.com for help",
+      "the file is package.json",
+    ];
+    for (const text of cases) {
+      const targets = await detectTargets(text, root);
+      expect(targets.find((t) => t.kind === "path"), text).toBeUndefined();
+    }
+  });
+
+  it("finds true-positive paths end-to-end, validated against the filesystem", async () => {
+    await mkdir(join(root, "source", "utils"), { recursive: true });
+    await writeFile(join(root, "source", "utils", "hyperlink.ts"), "export {};\n");
+
+    await mkdir(join(root, "scripts"), { recursive: true });
+    await writeFile(join(root, "scripts", "gen.mjs"), "export {};\n");
+
+    let targets = await detectTargets("see source/utils/hyperlink.ts:12 for the bug", root);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ kind: "path", line: 12 });
+    expect(targets[0]!.absPath).toBe(resolve(root, "source/utils/hyperlink.ts"));
+
+    targets = await detectTargets("run ./scripts/gen.mjs", root);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.absPath).toBe(resolve(root, "scripts/gen.mjs"));
+
+    // NB: "../x/y.json" is not exercised as a true positive here: `resolve`
+    // always uses `root` itself as the base, so any `../`-prefixed candidate
+    // necessarily resolves to root's *parent* — which `isWithinRoot` then
+    // always rejects (this is exactly what the traversal-rejection test above
+    // covers). There is no directory layout under which a `../`-prefixed
+    // candidate validates against this boundary model, so it can only ever be
+    // a rejected (false) case, not a true positive.
+
+    await mkdir(join(root, "docs"), { recursive: true });
+    await writeFile(join(root, "docs", "guide.md"), "# guide\n");
+    targets = await detectTargets("read docs/guide.md", root);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.absPath).toBe(resolve(root, "docs/guide.md"));
+  });
+
+  it("caches validated results by cacheKey, even after the filesystem changes underneath", async () => {
+    await mkdir(join(root, "src"), { recursive: true });
+    const filePath = join(root, "src", "app.ts");
+    await writeFile(filePath, "export {};\n");
+
+    const text = "edit src/app.ts please";
+    const first = await detectTargets(text, root, "cache-key-1");
+    expect(first).toHaveLength(1);
+
+    await rm(filePath);
+
+    const second = await detectTargets(text, root, "cache-key-1");
+    expect(second).toBe(first);
+    expect(second).toHaveLength(1);
+  });
+
+  // The public URL_RE requires a literal `https?://` prefix, and everything
+  // matching that prefix parses successfully via `new URL()` with protocol
+  // "http:" or "https:" — there is no realistic input reaching the public API
+  // that would exercise the `new URL()` catch branch or the non-http(s)
+  // protocol branch for a `kind: "url"` candidate. Skipped as noted in the task.
+});

--- a/source/__tests__/utils.detect-targets.test.ts
+++ b/source/__tests__/utils.detect-targets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, mkdir, writeFile, rm, realpath } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, realpath, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -56,6 +56,21 @@ describe("utils/detect-targets", () => {
     // is outside `projectRoot`.
     const targets = await detectTargets("do not open ../../etc/passwd please", projectRoot);
     expect(targets.find((t) => t.kind === "path")).toBeUndefined();
+  });
+
+  it("does not report a project-relative symlink that resolves outside root", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "agav-detect-outside-"));
+    try {
+      const secret = join(outside, "secret.txt");
+      await writeFile(secret, "not project content\n");
+      await mkdir(join(root, "public"));
+      await symlink(secret, join(root, "public", "secret.txt"));
+
+      const targets = await detectTargets("read public/secret.txt", root);
+      expect(targets.find((target) => target.kind === "path")).toBeUndefined();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
   });
 
   it("validates a path candidate that has a :line:col suffix, resolving/stat-ing the bare path only", async () => {

--- a/source/__tests__/utils.open-external.test.ts
+++ b/source/__tests__/utils.open-external.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { extensionForImage } from "../utils/open-external.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { extensionForImage, isSafeOpenTarget, openExternal } from "../utils/open-external.js";
 
 describe("extensionForImage", () => {
   it("maps media types to file extensions", () => {
@@ -15,3 +15,65 @@ describe("extensionForImage", () => {
     expect(extensionForImage("image/svg+xml")).toBe(".png");
   });
 });
+
+describe("isSafeOpenTarget", () => {
+  it("accepts URLs with any scheme", () => {
+    expect(isSafeOpenTarget("https://example.com")).toBe(true);
+    expect(isSafeOpenTarget("http://example.com/path?q=1")).toBe(true);
+    // This helper only validates shape, not an allow-list of schemes — a
+    // separate concern for callers that need to restrict which schemes are
+    // permitted (e.g. http/https only).
+    expect(isSafeOpenTarget("vscode://file/some/path")).toBe(true);
+    expect(isSafeOpenTarget("mailto:someone@example.com")).toBe(true);
+  });
+
+  it("accepts absolute paths", () => {
+    expect(isSafeOpenTarget("/tmp/foo.png")).toBe(true);
+    if (process.platform === "win32") {
+      expect(isSafeOpenTarget("C:\\Users\\foo\\bar.png")).toBe(true);
+      expect(isSafeOpenTarget("C:/Users/foo/bar.png")).toBe(true);
+    }
+  });
+
+  it("rejects relative paths", () => {
+    expect(isSafeOpenTarget("foo.png")).toBe(false);
+    expect(isSafeOpenTarget("./foo.png")).toBe(false);
+    expect(isSafeOpenTarget("../etc/passwd")).toBe(false);
+  });
+
+  it("rejects a path starting with -", () => {
+    // Not absolute anyway, so this is rejected on that basis, but assert the
+    // rejection explicitly since flag-injection is the underlying concern.
+    expect(isSafeOpenTarget("-rf /tmp")).toBe(false);
+  });
+});
+
+// The win32 explorer.exe launcher fix cannot be exercised at runtime in this
+// (Linux) CI environment — it is verified by code review against the
+// rationale documented for this change (avoiding cmd.exe /c start "" command
+// injection). See M2 milestone documentation for details.
+if (process.platform === "linux") {
+  describe("openExternal no-GUI guard (linux)", () => {
+    let savedDisplay: string | undefined;
+    let savedWayland: string | undefined;
+
+    beforeEach(() => {
+      savedDisplay = process.env["DISPLAY"];
+      savedWayland = process.env["WAYLAND_DISPLAY"];
+      delete process.env["DISPLAY"];
+      delete process.env["WAYLAND_DISPLAY"];
+    });
+
+    afterEach(() => {
+      if (savedDisplay === undefined) delete process.env["DISPLAY"];
+      else process.env["DISPLAY"] = savedDisplay;
+      if (savedWayland === undefined) delete process.env["WAYLAND_DISPLAY"];
+      else process.env["WAYLAND_DISPLAY"] = savedWayland;
+    });
+
+    it("refuses to spawn xdg-open when there is no display", async () => {
+      const result = await openExternal("https://example.com");
+      expect(result).toBe(false);
+    });
+  });
+}

--- a/source/__tests__/utils.open-target.test.ts
+++ b/source/__tests__/utils.open-target.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("../utils/open-external.js", () => ({
+  openExternal: vi.fn(),
+  extensionForImage: vi.fn(),
+  spoolImageToTempFile: vi.fn(),
+}));
+
+vi.mock("../utils/path-guard.js", () => ({
+  checkPathBoundary: vi.fn(async () => null),
+  isWithinRoot: vi.fn(() => true),
+}));
+
+import { execFile } from "node:child_process";
+import { openExternal } from "../utils/open-external.js";
+import { checkPathBoundary } from "../utils/path-guard.js";
+import { openTarget } from "../utils/open-target.js";
+
+const execFileMock = vi.mocked(execFile);
+const openExternalMock = vi.mocked(openExternal);
+const checkPathBoundaryMock = vi.mocked(checkPathBoundary);
+
+/** Default: every execFile invocation fails, as if no CLI/tool is on PATH. */
+function failAllExecFile() {
+  execFileMock.mockImplementation((...args: any[]) => {
+    const cb = args[args.length - 1];
+    if (typeof cb === "function") cb(new Error("not found"));
+    return undefined as any;
+  });
+}
+
+describe("openTarget", () => {
+  let savedEnv: Record<string, string | undefined>;
+  let savedIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    savedEnv = {
+      CI: process.env["CI"],
+      BROWSER: process.env["BROWSER"],
+      TERM_PROGRAM: process.env["TERM_PROGRAM"],
+      DISPLAY: process.env["DISPLAY"],
+      WAYLAND_DISPLAY: process.env["WAYLAND_DISPLAY"],
+      WSL_DISTRO_NAME: process.env["WSL_DISTRO_NAME"],
+      WSL_INTEROP: process.env["WSL_INTEROP"],
+      SSH_CONNECTION: process.env["SSH_CONNECTION"],
+      SSH_TTY: process.env["SSH_TTY"],
+    };
+    savedIsTTY = process.stdout.isTTY;
+
+    delete process.env["CI"];
+    delete process.env["BROWSER"];
+    delete process.env["TERM_PROGRAM"];
+    delete process.env["WSL_DISTRO_NAME"];
+    delete process.env["WSL_INTEROP"];
+    delete process.env["SSH_CONNECTION"];
+    delete process.env["SSH_TTY"];
+    // Not-CI by default: a real TTY, no $CI.
+    process.stdout.isTTY = true;
+
+    vi.clearAllMocks();
+    checkPathBoundaryMock.mockResolvedValue(null);
+    failAllExecFile();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    process.stdout.isTTY = savedIsTTY as boolean;
+  });
+
+  describe("url requests", () => {
+    it("opens a valid http(s) URL via openExternal when it succeeds", async () => {
+      openExternalMock.mockResolvedValue(true);
+
+      const result = await openTarget({ kind: "url", url: "https://example.com" });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toEqual(expect.stringContaining("https://example.com"));
+      expect(openExternalMock).toHaveBeenCalledWith("https://example.com");
+    });
+
+    it.each(["javascript:alert(1)", "vscode://foo", "file:///etc/passwd"])(
+      "rejects disallowed scheme %s before ever calling openExternal",
+      async (url) => {
+        const result = await openTarget({ kind: "url", url });
+
+        expect(result.ok).toBe(false);
+        expect(result.message.toLowerCase()).toContain("not allowed");
+        expect(openExternalMock).not.toHaveBeenCalled();
+      },
+    );
+
+    it("reports a malformed URL string as invalid", async () => {
+      const result = await openTarget({ kind: "url", url: "not a url" });
+
+      expect(result.ok).toBe(false);
+      expect(result.message.toLowerCase()).toContain("not a valid url");
+      expect(openExternalMock).not.toHaveBeenCalled();
+    });
+
+    it("prefers $BROWSER when set, and never reaches openExternal on success", async () => {
+      process.env["BROWSER"] = "my-fake-browser";
+      execFileMock.mockImplementation((...args: any[]) => {
+        const cb = args[args.length - 1];
+        if (args[0] === "my-fake-browser" && typeof cb === "function") cb(null, "", "");
+        else if (typeof cb === "function") cb(new Error("not found"));
+        return undefined as any;
+      });
+
+      const result = await openTarget({ kind: "url", url: "https://example.com" });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toContain("$BROWSER");
+      expect(openExternalMock).not.toHaveBeenCalled();
+    });
+
+    it("refuses to open in CI/non-TTY, surfacing the URL for manual copy", async () => {
+      process.env["CI"] = "1";
+
+      const result = await openTarget({ kind: "url", url: "https://example.com" });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("https://example.com");
+      expect(openExternalMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("file requests", () => {
+    it("reports a nonexistent file as no longer existing", async () => {
+      const result = await openTarget({ kind: "file", absPath: "/definitely/does/not/exist/xyz123.ts" });
+
+      expect(result.ok).toBe(false);
+      expect(result.message.toLowerCase()).toContain("no longer exists");
+    });
+
+    it("surfaces whatever checkPathBoundary returns as the error message", async () => {
+      checkPathBoundaryMock.mockResolvedValue("Access denied: /fake/.ssh/id_rsa is inside a protected credential path.");
+
+      const result = await openTarget({ kind: "file", absPath: "/fake/.ssh/id_rsa" });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("Cannot open:");
+      expect(result.message).toContain("Access denied: /fake/.ssh/id_rsa is inside a protected credential path.");
+    });
+
+    it("refuses to open in CI/non-TTY, surfacing the path for manual copy", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "agav-open-target-"));
+      try {
+        const filePath = join(dir, "note.txt");
+        await writeFile(filePath, "hello");
+        process.env["CI"] = "1";
+
+        const result = await openTarget({ kind: "file", absPath: filePath });
+
+        expect(result.ok).toBe(false);
+        expect(result.message).toContain(filePath);
+        expect(openExternalMock).not.toHaveBeenCalled();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("refuses an extension that is not in the allow-list", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "agav-open-target-"));
+      try {
+        // `.desktop` is not in INERT_EXTENSIONS.
+        const filePath = join(dir, "launcher.desktop");
+        await writeFile(filePath, "[Desktop Entry]\nExec=echo hi\n");
+        if (process.platform === "linux") process.env["DISPLAY"] = ":0";
+
+        const result = await openTarget({ kind: "file", absPath: filePath });
+
+        expect(result.ok).toBe(false);
+        expect(result.message.toLowerCase()).toContain("allow-list");
+        expect(openExternalMock).not.toHaveBeenCalled();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("opens an allow-listed file via the platform opener on the happy path", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "agav-open-target-"));
+      try {
+        const filePath = join(dir, "note.txt");
+        await writeFile(filePath, "hello");
+        if (process.platform === "linux") process.env["DISPLAY"] = ":0";
+        openExternalMock.mockResolvedValue(true);
+
+        const result = await openTarget({ kind: "file", absPath: filePath });
+
+        expect(result.ok).toBe(true);
+        expect(result.message).toContain(filePath);
+        expect(openExternalMock).toHaveBeenCalledWith(filePath);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("opens via VS Code CLI when TERM_PROGRAM=vscode and `code` is on PATH", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "agav-open-target-"));
+      try {
+        const filePath = join(dir, "note.txt");
+        await writeFile(filePath, "hello");
+        process.env["TERM_PROGRAM"] = "vscode";
+        if (process.platform === "linux") process.env["DISPLAY"] = ":0";
+
+        execFileMock.mockImplementation((...args: any[]) => {
+          const cb = args[args.length - 1];
+          const cmd = args[0];
+          const cmdArgs = args[1];
+          // `commandExists("code")` probe: `which code` (linux) or `where code` (win32).
+          if ((cmd === "which" || cmd === "where") && cmdArgs?.[0] === "code") {
+            if (typeof cb === "function") cb(null, "/usr/bin/code\n", "");
+          } else if (cmd === "code") {
+            // `code -r ...` invocation.
+            if (typeof cb === "function") cb(null, "", "");
+          } else if (typeof cb === "function") {
+            cb(new Error("not found"));
+          }
+          return undefined as any;
+        });
+
+        const result = await openTarget({ kind: "file", absPath: filePath });
+
+        expect(result.ok).toBe(true);
+        expect(result.message).toContain("VS Code");
+        expect(openExternalMock).not.toHaveBeenCalled();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/source/__tests__/utils.render-clickable.test.ts
+++ b/source/__tests__/utils.render-clickable.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import chalk from "chalk";
+
+import { buildClickableLines } from "../utils/render-clickable.js";
+import { wrapStyled } from "../components/markdown-text.js";
+import type { DetectedTarget } from "../utils/detect-targets.js";
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+function makeTarget(text: string, kind: DetectedTarget["kind"] = "path"): DetectedTarget {
+  return { kind, text, start: 0, end: text.length };
+}
+
+describe("buildClickableLines", () => {
+  beforeAll(() => {
+    // chalk paints nothing without a detected colour terminal under vitest.
+    chalk.level = 3;
+  });
+
+  it("returns wrapStyled's lines unchanged (as single plain runs) when there are no targets", () => {
+    const styled = chalk.bold("hello ") + "plain world that keeps going and going";
+    const width = 12;
+    const result = buildClickableLines(styled, width, [], () => "id", {});
+    const expected = wrapStyled(styled, width).map((line) => [{ text: line }]);
+    expect(result).toEqual(expected);
+  });
+
+  it("makes a target's literal text clickable when it's found in the rendered line", () => {
+    const styled = `See ${chalk.bold("source/app.ts")} for details`;
+    const target = makeTarget("source/app.ts");
+    const result = buildClickableLines(styled, 80, [target], () => "target-id", { color: "cyan", underline: true });
+
+    expect(result).toHaveLength(1);
+    const clickable = result[0]!.filter((r) => r.targetId !== undefined);
+    expect(clickable).toHaveLength(1);
+    expect(stripAnsi(clickable[0]!.text)).toBe("source/app.ts");
+    expect(clickable[0]!.targetId).toBe("target-id");
+  });
+
+  it("renders as plain text with no crash and no phantom link when the target text is absent", () => {
+    const styled = "nothing to see here";
+    const target = makeTarget("src/not-here.ts");
+    const result = buildClickableLines(styled, 80, [target], () => "target-id", {});
+
+    const allRuns = result.flat();
+    expect(allRuns.some((r) => r.targetId !== undefined)).toBe(false);
+    expect(allRuns.map((r) => stripAnsi(r.text)).join("")).toBe(stripAnsi(styled));
+  });
+
+  it("marks both occurrences clickable when the same target text appears twice", () => {
+    const styled = "path/a.ts appears here and path/a.ts appears again";
+    const target = makeTarget("path/a.ts");
+    const result = buildClickableLines(styled, 80, [target], () => "dup-id", {});
+
+    const clickable = result.flat().filter((r) => r.targetId === "dup-id");
+    expect(clickable).toHaveLength(2);
+    for (const run of clickable) expect(stripAnsi(run.text)).toBe("path/a.ts");
+  });
+
+  it("merges/dedupes overlapping occurrences, keeping only non-overlapping runs in order", () => {
+    // "abcdef" and "cdefgh" overlap in "abcdefgh" at indices [0,6) and [2,8).
+    // Sorted by start, the first occurrence (start 0) is kept; the second
+    // (start 2) overlaps [0,6) so per the source's `>= lastEnd` merge rule it
+    // is dropped entirely — the source does not attempt to render the
+    // non-overlapping tail of a dropped occurrence.
+    const styled = "abcdefgh";
+    const targetA = makeTarget("abcdef");
+    const targetB = makeTarget("cdefgh");
+    const result = buildClickableLines(styled, 80, [targetA, targetB], (t) => `id:${t.text}`, {});
+
+    const clickable = result.flat().filter((r) => r.targetId !== undefined);
+    expect(clickable).toHaveLength(1);
+    expect(clickable[0]!.targetId).toBe("id:abcdef");
+    expect(stripAnsi(clickable[0]!.text)).toBe("abcdef");
+
+    // Trailing "gh" (not covered by the kept occurrence) survives as plain text.
+    const plain = result.flat().filter((r) => r.targetId === undefined);
+    expect(plain.map((r) => stripAnsi(r.text)).join("")).toBe("gh");
+  });
+
+  it("applies plainRunStyle to plain runs but not to clickable runs' plain fields", () => {
+    const styled = `See ${chalk.bold("source/app.ts")} for details`;
+    const target = makeTarget("source/app.ts");
+    const result = buildClickableLines(styled, 80, [target], () => "target-id", { color: "cyan", underline: true }, { dimColor: true });
+
+    const runs = result[0]!;
+    const plainRuns = runs.filter((r) => r.targetId === undefined);
+    const clickableRuns = runs.filter((r) => r.targetId !== undefined);
+
+    expect(plainRuns.length).toBeGreaterThan(0);
+    for (const run of plainRuns) expect(run.dimColor).toBe(true);
+
+    expect(clickableRuns).toHaveLength(1);
+    expect(clickableRuns[0]!.dimColor).toBeUndefined();
+    expect(clickableRuns[0]!.color).toBe("cyan");
+    expect(clickableRuns[0]!.underline).toBe(true);
+  });
+
+  it("marks both halves of a target that straddles a wrap boundary with the same targetId", () => {
+    // Regression: only searching for a target's literal text *within each
+    // already-wrapped line* (rather than across the whole rendered text
+    // first) meant a target long enough to be hard-broken by the wrap had no
+    // single line containing its complete substring, so it never matched at
+    // all and silently rendered as plain, unclickable text — the exact
+    // "works for some agent-mentioned files but not others" inconsistency.
+    const longPath = "a-quite-long-directory-name/another-long-segment/finally-the-file.ts";
+    const styled = `See ${longPath} for details`;
+    const target = makeTarget(longPath);
+    const width = 30;
+    const result = buildClickableLines(styled, width, [target], () => "straddling-id", { color: "cyan", underline: true });
+
+    expect(result.length).toBeGreaterThan(1);
+    const clickableRuns = result.flat().filter((r) => r.targetId === "straddling-id");
+    expect(clickableRuns.length).toBeGreaterThanOrEqual(2);
+    // Every clickable fragment concatenates back to the original long path.
+    expect(clickableRuns.map((r) => stripAnsi(r.text)).join("")).toBe(longPath);
+  });
+
+  it("loses no visible characters across all lines/runs for a styled multi-run input", () => {
+    const styled = chalk.bold("hello ") + "plain text about " + chalk.underline.cyan("source/app.ts") + " and more words to force wrapping across several lines of output";
+    const width = 20;
+    const target = makeTarget("source/app.ts");
+    const result = buildClickableLines(styled, width, [target], () => "id", { color: "cyan", underline: true });
+
+    const actual = result.map((runs) => runs.map((r) => stripAnsi(r.text)).join("")).join("");
+    const expected = wrapStyled(styled, width).map(stripAnsi).join("");
+    expect(actual).toBe(expected);
+  });
+});

--- a/source/__tests__/utils.render-clickable.test.ts
+++ b/source/__tests__/utils.render-clickable.test.ts
@@ -116,6 +116,15 @@ describe("buildClickableLines", () => {
     expect(clickableRuns.map((r) => stripAnsi(r.text)).join("")).toBe(longPath);
   });
 
+  it("keeps a target after a wide grapheme aligned with its styled text", () => {
+    const target = makeTarget("source/app.ts");
+    const styled = `🎉 see ${chalk.bold(target.text)} for details`;
+    const result = buildClickableLines(styled, 80, [target], () => "target-id", {});
+
+    const clickable = result.flat().filter((run) => run.targetId === "target-id");
+    expect(clickable.map((run) => stripAnsi(run.text)).join("")).toBe(target.text);
+  });
+
   it("loses no visible characters across all lines/runs for a styled multi-run input", () => {
     const styled = chalk.bold("hello ") + "plain text about " + chalk.underline.cyan("source/app.ts") + " and more words to force wrapping across several lines of output";
     const width = 20;

--- a/source/__tests__/utils.wrap-runs.test.ts
+++ b/source/__tests__/utils.wrap-runs.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+
+import { wrapTextToRuns, targetToRefId, type LineRunSpec } from "../utils/wrap-runs.js";
+import { wrapToWidth } from "../utils/wrap-text.js";
+import type { DetectedTarget } from "../utils/detect-targets.js";
+import { encodeOpenRef } from "../utils/open-ref.js";
+
+function makeTarget(overrides: Partial<DetectedTarget> & Pick<DetectedTarget, "kind" | "text" | "start" | "end">): DetectedTarget {
+  return { ...overrides };
+}
+
+function linesText(result: LineRunSpec[][]): string[] {
+  return result.map((runs) => runs.map((r) => r.text).join(""));
+}
+
+describe("wrapTextToRuns", () => {
+  it("matches wrapToWidth exactly with no targets, each line a single plain run", () => {
+    const text = "hello world, this wraps across lines";
+    const width = 10;
+    const result = wrapTextToRuns(text, width, [], () => "x");
+    const expected = wrapToWidth(text, width);
+
+    expect(linesText(result)).toEqual(expected);
+    for (const runs of result) {
+      expect(runs).toHaveLength(1);
+      expect(runs[0]!.targetId).toBeUndefined();
+    }
+  });
+
+  it("makes a target that lands on a single wrapped line into one clickable run", () => {
+    // "world" sits entirely inside the first wrapped line at width 12.
+    const text = "hello world and more text that keeps going";
+    const width = 12;
+    const start = text.indexOf("world");
+    const end = start + "world".length;
+    const target = makeTarget({ kind: "path", text: "world", start, end });
+
+    const lines = wrapToWidth(text, width);
+    const firstLineIndex = lines.findIndex((l) => l.includes("world"));
+    expect(firstLineIndex).toBeGreaterThanOrEqual(0);
+
+    const makeTargetId = (t: DetectedTarget) => `id:${t.text}`;
+    const result = wrapTextToRuns(text, width, [target], makeTargetId);
+
+    expect(linesText(result)).toEqual(lines);
+
+    const runsOnLine = result[firstLineIndex]!;
+    const clickable = runsOnLine.filter((r) => r.targetId !== undefined);
+    expect(clickable).toHaveLength(1);
+    expect(clickable[0]!.targetId).toBe("id:world");
+
+    // Concatenating all runs on that line reproduces the plain line text.
+    expect(runsOnLine.map((r) => r.text).join("")).toBe(lines[firstLineIndex]);
+  });
+
+  it("gives both halves of a target straddling a wrap boundary the same targetId", () => {
+    // A single long unbroken token forces wrapToWidth to hard-break it mid
+    // token; the target covers the whole token, so it necessarily straddles
+    // the resulting wrap boundary.
+    const text = "start_aaaaaaaaaaaaaaaaaaaaaaend more words after it";
+    const width = 10;
+    const tokenStart = text.indexOf("start_aaaaaaaaaaaaaaaaaaaaaaend");
+    const tokenEnd = tokenStart + "start_aaaaaaaaaaaaaaaaaaaaaaend".length;
+    const target = makeTarget({ kind: "path", text: text.slice(tokenStart, tokenEnd), start: tokenStart, end: tokenEnd });
+
+    const makeTargetId = () => "straddling-id";
+    const result = wrapTextToRuns(text, width, [target], makeTargetId);
+    const lines = wrapToWidth(text, width);
+    expect(linesText(result)).toEqual(lines);
+
+    // Find every line that contains a run with our targetId.
+    const linesWithTarget = result.filter((runs) => runs.some((r) => r.targetId === "straddling-id"));
+    expect(linesWithTarget.length).toBeGreaterThanOrEqual(2);
+    for (const runs of linesWithTarget) {
+      const run = runs.find((r) => r.targetId === "straddling-id")!;
+      expect(run.targetId).toBe("straddling-id");
+    }
+  });
+
+  it("handles multiple non-overlapping targets on the same short line", () => {
+    const text = "alpha beta gamma";
+    const width = 40; // whole thing fits on one line
+    const alphaStart = text.indexOf("alpha");
+    const alphaEnd = alphaStart + "alpha".length;
+    const gammaStart = text.indexOf("gamma");
+    const gammaEnd = gammaStart + "gamma".length;
+
+    const targets: DetectedTarget[] = [
+      makeTarget({ kind: "path", text: "alpha", start: alphaStart, end: alphaEnd }),
+      makeTarget({ kind: "path", text: "gamma", start: gammaStart, end: gammaEnd }),
+    ];
+    const makeTargetId = (t: DetectedTarget) => `id:${t.text}`;
+    const result = wrapTextToRuns(text, width, targets, makeTargetId);
+
+    expect(result).toHaveLength(1);
+    const runs = result[0]!;
+    const alphaRun = runs.find((r) => r.targetId === "id:alpha");
+    const gammaRun = runs.find((r) => r.targetId === "id:gamma");
+    expect(alphaRun?.text).toBe("alpha");
+    expect(gammaRun?.text).toBe("gamma");
+
+    // Plain text " beta " preserved around/between them.
+    const plainRuns = runs.filter((r) => r.targetId === undefined);
+    expect(plainRuns.map((r) => r.text).join("")).toContain("beta");
+
+    expect(runs.map((r) => r.text).join("")).toBe(text);
+  });
+
+  it("never loses or duplicates characters across many text/width/target combinations", () => {
+    const cases: { text: string; width: number; targets: DetectedTarget[] }[] = [
+      {
+        text: "the quick brown fox jumps over the lazy dog again and again",
+        width: 9,
+        targets: [],
+      },
+      {
+        text: "see src/app.ts and also docs/readme.md for context on this",
+        width: 15,
+        targets: (() => {
+          const t = "see src/app.ts and also docs/readme.md for context on this";
+          const aStart = t.indexOf("src/app.ts");
+          const bStart = t.indexOf("docs/readme.md");
+          return [
+            makeTarget({ kind: "path", text: "src/app.ts", start: aStart, end: aStart + "src/app.ts".length }),
+            makeTarget({ kind: "path", text: "docs/readme.md", start: bStart, end: bStart + "docs/readme.md".length }),
+          ];
+        })(),
+      },
+      {
+        text: "a".repeat(50),
+        width: 7,
+        targets: [makeTarget({ kind: "path", text: "a".repeat(50), start: 0, end: 50 })],
+      },
+      {
+        text: "  leading and trailing spaces   ",
+        width: 6,
+        targets: [],
+      },
+    ];
+
+    for (const { text, width, targets } of cases) {
+      const result = wrapTextToRuns(text, width, targets, (t) => `id:${t.start}`);
+      const expectedJoined = wrapToWidth(text, width).join("");
+      const actualJoined = result.map((runs) => runs.map((r) => r.text).join("")).join("");
+      expect(actualJoined, JSON.stringify({ text, width })).toBe(expectedJoined);
+    }
+  });
+});
+
+describe("targetToRefId", () => {
+  it("builds a url OpenRef for a url target", () => {
+    const target: DetectedTarget = { kind: "url", text: "https://example.com/x", start: 0, end: 21 };
+    const encode = (ref: any) => JSON.stringify(ref);
+    const id = targetToRefId(target, encode);
+    expect(JSON.parse(id)).toEqual({ kind: "url", url: "https://example.com/x" });
+  });
+
+  it("builds a path OpenRef with absPath/line/col for a path target", () => {
+    const target: DetectedTarget = {
+      kind: "path",
+      text: "src/app.ts:12:5",
+      start: 0,
+      end: 15,
+      absPath: "/abs/src/app.ts",
+      line: 12,
+      col: 5,
+    };
+    const encode = (ref: any) => JSON.stringify(ref);
+    const id = targetToRefId(target, encode);
+    expect(JSON.parse(id)).toEqual({ kind: "path", absPath: "/abs/src/app.ts", line: 12, col: 5 });
+  });
+
+  it("round-trips through the real encodeOpenRef", () => {
+    const urlTarget: DetectedTarget = { kind: "url", text: "https://x.test", start: 0, end: 14 };
+    const encoded = targetToRefId(urlTarget, encodeOpenRef);
+    expect(JSON.parse(encoded)).toEqual({ kind: "url", url: "https://x.test" });
+  });
+});

--- a/source/__tests__/utils.wrap-text.test.ts
+++ b/source/__tests__/utils.wrap-text.test.ts
@@ -44,6 +44,18 @@ describe("wrapToWidth", () => {
     expect(wrapToWidth(colored, 7)).toEqual([colored]);
   });
 
+  it("wraps wide graphemes by terminal column without splitting them", () => {
+    const lines = wrapToWidth("界界界", 4);
+    expect(lines).toEqual(["界界", "界"]);
+    expect(fitsOnOneRow(lines, 4)).toBe(true);
+  });
+
+  it("keeps emoji grapheme clusters intact while wrapping", () => {
+    const lines = wrapToWidth("🎉🎉🎉", 4);
+    expect(lines).toEqual(["🎉🎉", "🎉"]);
+    expect(fitsOnOneRow(lines, 4)).toBe(true);
+  });
+
   it("always returns at least one line", () => {
     expect(wrapToWidth("", 40)).toEqual([""]);
   });

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { basename } from "node:path";
-import { Box, Text, ScrollBox, Spinner, useInput, useApp, measureElement } from "./ink/index.js";
+import { Box, Text, ScrollBox, Spinner, useInput, useApp, useStdout, measureElement } from "./ink/index.js";
 import type { DOMElement, ScrollBoxControls, WheelEventData } from "./ink/index.js";
 import MessageList from "./components/message-list.js";
 import type { DisplayMessage } from "./components/message-list.js";
@@ -26,9 +26,10 @@ import { saveSession } from "./config/history.js";
 import {
   type Attachment,
   createTextAttachment,
+  createImageAttachmentFromData,
 } from "./utils/attachments.js";
+import { getAttachment, clearAttachmentRegistry, compactImageAttachments, unregisterAttachment, wasEvicted } from "./utils/attachment-registry.js";
 import { getRandomHint } from "./utils/hints.js";
-import { fileLink } from "./utils/hyperlink.js";
 import { getClipboardImage, type ClipboardImage } from "./utils/clipboard-image.js";
 import { getClipboardText } from "./utils/clipboard-text.js";
 import { useClipboardImageDetector } from "./hooks/use-paste-handler.js";
@@ -38,6 +39,12 @@ import { loadScheduledTasks, cronMatches, markTaskRun } from "./config/scheduler
 import { getSandboxName } from "./utils/sandbox.js";
 import { expandFileMentions } from "./utils/file-mentions.js";
 import { terminalRelativePaths } from "./utils/display-path.js";
+import { openTarget } from "./utils/open-target.js";
+import { writeClipboard } from "./ink/termio/clipboard.js";
+import type { OpenRef } from "./utils/open-ref.js";
+import AttachmentPreview, { type PreviewContent } from "./components/attachment-preview.js";
+import { readFileContext } from "./utils/file-context.js";
+import { spoolImageToTempFile } from "./utils/open-external.js";
 
 import type { Message } from "./providers/types.js";
 
@@ -77,6 +84,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   const [showPlanDetail, setShowPlanDetail] = useState(false);
   const [showThinking, setShowThinking] = useState(initialConfig.showThinking ?? false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [preview, setPreview] = useState<PreviewContent | null>(null);
   const [focusedSubagentId, setFocusedSubagentId] = useState<string | null>(null);
   // Everything above the input prompt is one scrolling document, driven from
   // here by the scroll keybindings and by wheel events that landed on the
@@ -148,6 +156,99 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   } = useAgent(activeProvider, config, resumeMessages, resumeSessionId, resumeTokenUsage, resumeCompacted, resumeSessionName);
 
   const [systemMessages, setSystemMessages] = useState<DisplayMessage[]>([]);
+  const { stdout } = useStdout();
+
+  /** Show a single-line status update via the system-message channel. */
+  const showStatusLine = useCallback((text: string, isError = false) => {
+    setSystemMessages([{ id: `sys-${++sysMessageId}`, role: "system", content: text, isError }]);
+  }, []);
+
+  /** Preview a pasted-text attachment in the document. */
+  const previewAttachment = useCallback((attachment: Attachment) => {
+    if (attachment.kind === "paste" && attachment.source.type === "text") {
+      setPreview({ title: `Pasted #${attachment.id} · ${attachment.summary}`, text: attachment.source.text });
+      return;
+    }
+    if (attachment.kind === "file" && attachment.source.type === "file") {
+      readFileContext(attachment.source.absPath)
+        .then((result) => {
+          if (result.kind !== "text") {
+            showStatusLine(`Cannot preview: ${attachment.source.type === "file" ? attachment.source.absPath : ""} is not a text file.`, true);
+            return;
+          }
+          setPreview({ title: `File #${attachment.id} · ${attachment.summary}`, text: result.output });
+        })
+        .catch((err) => showStatusLine(`Cannot preview: ${err instanceof Error ? err.message : String(err)}`, true));
+    }
+  }, [showStatusLine]);
+
+  /** Try the OS/editor open ladder for a file; fall back to an in-document preview when neither succeeds. */
+  const openFileOrPreview = useCallback((absPath: string, title: string, line?: number, col?: number) => {
+    openTarget({ kind: "file", absPath, line, col })
+      .then((outcome) => {
+        if (outcome.ok) {
+          showStatusLine(outcome.message, false);
+          return;
+        }
+        readFileContext(absPath)
+          .then((result) => {
+            if (result.kind !== "text") {
+              showStatusLine(outcome.message, true);
+              return;
+            }
+            setPreview({ title, text: result.output });
+          })
+          .catch(() => showStatusLine(outcome.message, true));
+      })
+      .catch((err) => showStatusLine(`Cannot open: ${err instanceof Error ? err.message : String(err)}`, true));
+  }, [showStatusLine]);
+
+  /** Open or preview an attachment tile the user clicked, resolved by id from the session registry. */
+  const handleOpenAttachment = useCallback((id: number) => {
+    const attachment = getAttachment(id);
+    if (!attachment) {
+      showStatusLine(wasEvicted(id) ? `Attachment #${id} is no longer available.` : `Attachment #${id} could not be found.`, true);
+      return;
+    }
+
+    if (attachment.kind === "paste") {
+      previewAttachment(attachment);
+      return;
+    }
+
+    if (attachment.kind === "image" && attachment.source.type === "image") {
+      const spoolPromise = attachment.source.spoolPath
+        ? Promise.resolve(attachment.source.spoolPath)
+        : attachment.source.base64
+          ? spoolImageToTempFile(attachment.source.base64, attachment.source.mediaType)
+          : Promise.reject(new Error("image data is no longer available"));
+      spoolPromise
+        .then((path) => openTarget({ kind: "file", absPath: path }))
+        .then((outcome) => showStatusLine(outcome.message, !outcome.ok))
+        .catch((err) => showStatusLine(`Cannot open image: ${err instanceof Error ? err.message : String(err)}`, true));
+      return;
+    }
+
+    if (attachment.kind === "file" && attachment.source.type === "file") {
+      openFileOrPreview(attachment.source.absPath, `File #${id} · ${attachment.summary}`);
+    }
+  }, [previewAttachment, showStatusLine, openFileOrPreview]);
+
+  /** Open or preview whatever a detected URL/file-path run in the transcript resolved to. */
+  const handleOpenRef = useCallback((ref: OpenRef) => {
+    if (ref.kind === "attachment") {
+      handleOpenAttachment(ref.id);
+      return;
+    }
+    if (ref.kind === "url") {
+      openTarget({ kind: "url", url: ref.url })
+        .then((outcome) => showStatusLine(outcome.message, !outcome.ok))
+        .catch((err) => showStatusLine(`Cannot open: ${err instanceof Error ? err.message : String(err)}`, true));
+      return;
+    }
+    // ref.kind === "path"
+    openFileOrPreview(ref.absPath, ref.absPath, ref.line, ref.col);
+  }, [handleOpenAttachment, openFileOrPreview]);
 
   // Register/refresh slash commands discovered from connected MCP servers' prompts.
   useEffect(() => {
@@ -171,26 +272,45 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   }, []);
 
   const insertLabelRef = useRef<((label: string) => void) | null>(null);
+  const expandTileRef = useRef<((id: number, fullText: string) => boolean) | null>(null);
+  // The most recent paste that was compacted into a tile, so an identical
+  // paste immediately after it is recognized as "expand this" rather than
+  // "attach a second copy of the same thing" — similar to Claude Code's
+  // double-paste-to-expand.
+  const lastPasteRef = useRef<{ text: string; attachmentId: number } | null>(null);
   const [psResponse, setPsResponse] = useState<string | undefined>();
   const [psLoading, setPsLoading] = useState(false);
 
   /** Auto-detect clipboard images so copied screenshots can be attached without manual file handling. */
   const handleClipboardImage = useCallback((img: ClipboardImage) => {
-    const id = Date.now();
-    const dimStr = img.width && img.height ? `${img.width}x${img.height}` : "image";
-    const label = `<<Image: ${dimStr}>>`;
-
-    setAttachments((prev) => [...prev, {
-      id, type: "image", label,
-      contentBlock: { type: "image", imageData: img.base64, imageMediaType: img.mediaType, imageWidth: img.width, imageHeight: img.height },
-    }]);
-    insertLabelRef.current?.(label);
+    // Uses the shared monotonic counter (not `Date.now()`) so this attachment's
+    // id can never collide with one created in the same millisecond, and its
+    // tile is always resolvable back to a record.
+    const attachment = createImageAttachmentFromData(img.base64, img.mediaType, img.width || undefined, img.height || undefined);
+    setAttachments((prev) => [...prev, attachment]);
+    insertLabelRef.current?.(attachment.label);
   }, []);
 
   const handleLargePaste = useCallback((text: string) => {
+    const last = lastPasteRef.current;
+    if (last && last.text === text) {
+      // Same text pasted again — try to swap the tile it made for its full
+      // literal text. `onRegisterExpand`'s function reports back whether the
+      // tile was still there to replace; if the user had already edited or
+      // removed it, fall through and attach this paste as a fresh tile
+      // instead of silently doing nothing.
+      const expanded = expandTileRef.current?.(last.attachmentId, text) ?? false;
+      if (expanded) {
+        setAttachments((prev) => prev.filter((a) => a.id !== last.attachmentId));
+        unregisterAttachment(last.attachmentId);
+        lastPasteRef.current = null;
+        return;
+      }
+    }
     const attachment = createTextAttachment(text);
     setAttachments((prev) => [...prev, attachment]);
     insertLabelRef.current?.(attachment.label);
+    lastPasteRef.current = { text, attachmentId: attachment.id };
   }, []);
 
   const handleShortPaste = useCallback((text: string) => {
@@ -336,6 +456,18 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
   useInput((rawChar, rawKey) => {
     if (pickerActive) return;
     const { input: char, key } = normalizeKeyEvent(rawChar, rawKey);
+    // The attachment/file preview panel is read-only and owns no other state,
+    // so its keys are handled before anything else can claim them — Esc closes
+    // it outright rather than falling through to whatever else Esc means
+    // while a turn is in flight.
+    if (preview) {
+      if (key.escape) { setPreview(null); return; }
+      if (char === "c" && !key.ctrl && !key.meta) {
+        if (stdout) writeClipboard(stdout, preview.text);
+        showStatusLine("Copied preview to clipboard.");
+        return;
+      }
+    }
     const match = keyResolverRef.current.feed(char, key);
     if (match.action === "interrupt" && isLoading && !pendingConfirmation) {
       cancel();
@@ -515,6 +647,8 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
           clearMessages: () => {
             clearMessages();
             setSystemMessages([]);
+            setPreview(null);
+            clearAttachmentRegistry();
             resetDisplay();
           },
           refreshPlan,
@@ -584,8 +718,18 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
       const llmText = trimmed || "See attached content";
       const accepted = await submit(llmText, extraBlocks, undefined, undefined, invocationReason);
       if (!accepted) return;
+      // The pending list is cleared here, but the registry (keyed by id) is
+      // not — a tile stays clickable in the scrolled-back transcript for the
+      // rest of the session. Image bytes are spooled to disk and dropped from
+      // memory now that the base64 payload has already gone to the provider.
+      const imageIds = attachments.filter((a) => a.kind === "image").map((a) => a.id);
+      if (imageIds.length > 0) compactImageAttachments(imageIds).catch(() => {});
       setInput("");
       setAttachments([]);
+      // The tile a tracked paste made is gone now that the buffer is cleared;
+      // an identical paste after this turn should attach fresh, not try to
+      // expand a tile that no longer exists anywhere.
+      lastPasteRef.current = null;
       setShowToolDetail(false);
       setPsResponse(undefined);
       setSystemMessages([]);
@@ -651,7 +795,7 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
         </Box>
       )}
 
-      <MessageList messages={allMessages} toolDetailKey={formatKeybinding(keybindings, "toggleToolDetail")} columns={termCols} />
+      <MessageList messages={allMessages} toolDetailKey={formatKeybinding(keybindings, "toggleToolDetail")} columns={termCols} onOpenRef={handleOpenRef} />
 
       {systemMessages.length > 0 && (
         <Box marginBottom={1} flexDirection="column">
@@ -775,6 +919,15 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
           closeKey={formatKeybinding(keybindings, "togglePlanDetail")}
         />
       )}
+
+      {preview && (
+        <AttachmentPreview
+          content={preview}
+          closeKey="Esc"
+          copyKey="c"
+          columns={termCols}
+        />
+      )}
       </ScrollBox>
 
       {/*
@@ -828,9 +981,17 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
           onChange={setInput}
           onSubmit={handleSubmit}
           onPaste={handlePaste}
-          onRemoveAttachment={() => setAttachments((prev) => prev.slice(0, -1))}
-          onClearAttachments={() => setAttachments([])}
+          onRemoveAttachment={() => {
+            setAttachments((prev) => prev.slice(0, -1));
+            lastPasteRef.current = null;
+          }}
+          onClearAttachments={() => {
+            setAttachments([]);
+            lastPasteRef.current = null;
+          }}
           onRegisterInsert={(fn) => { insertLabelRef.current = fn; }}
+          onRegisterExpand={(fn) => { expandTileRef.current = fn; }}
+          onOpenAttachment={handleOpenAttachment}
           disabled={pickerActive}
           suppressHistory={isLoading}
           commands={[

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -714,7 +714,10 @@ export default function App({ config: initialConfig, keybindings, resumeMessages
       }
 
       // Collect attachment content blocks
-      const extraBlocks: ContentBlock[] = attachments.map((a) => a.contentBlock);
+      // The registry later compacts image records by dropping their retained
+      // payload. Give the conversation its own block objects so that cleanup
+      // cannot mutate image data retained in the submitted turn.
+      const extraBlocks: ContentBlock[] = attachments.map((attachment) => ({ ...attachment.contentBlock }));
       const llmText = trimmed || "See attached content";
       const accepted = await submit(llmText, extraBlocks, undefined, undefined, invocationReason);
       if (!accepted) return;

--- a/source/commands/open.ts
+++ b/source/commands/open.ts
@@ -1,0 +1,65 @@
+import type { SlashCommand, CommandResult, CommandContext } from "./types.js";
+import { listAttachments, getAttachment } from "../utils/attachment-registry.js";
+import { openTarget } from "../utils/open-target.js";
+
+/**
+ * The keyboard path required for every open/preview action. Mouse reporting
+ * can be disabled outright in several terminals (iTerm2, Ghostty, Konsole,
+ * PuTTY), is opt-in in Apple Terminal, and ctrl+click is swallowed by xterm —
+ * `/open` with no argument doubles as the discovery surface for what a click
+ * would have done.
+ */
+export const openCommand: SlashCommand = {
+  name: "open",
+  description: "List or open/preview an attachment from this session",
+  usage: "Usage: /open — list every attachment in the session\n/open <n> — open or preview attachment #n",
+  async execute(args: string, context: CommandContext): Promise<CommandResult> {
+    const trimmed = args.trim();
+
+    if (!trimmed) {
+      const attachments = listAttachments();
+      if (attachments.length === 0) {
+        return { type: "message", text: "No attachments in this session yet." };
+      }
+      const lines = attachments.map((a) => `  #${a.id} [${a.kind}] ${a.summary}`);
+      return { type: "message", text: `Attachments:\n${lines.join("\n")}\n\nUse /open <n> to open or preview one.` };
+    }
+
+    const id = Number(trimmed);
+    if (!Number.isInteger(id)) {
+      return { type: "message", text: `"${trimmed}" is not a valid attachment number. Use /open to list them.` };
+    }
+
+    const attachment = getAttachment(id);
+    if (!attachment) {
+      return { type: "message", text: `Attachment #${id} was not found or is no longer available.` };
+    }
+
+    if (attachment.kind === "paste" && attachment.source.type === "text") {
+      const preview = attachment.source.text.length > 500
+        ? `${attachment.source.text.slice(0, 500)}\n...(truncated — ${attachment.source.text.length} chars total)`
+        : attachment.source.text;
+      return { type: "message", text: `Pasted #${id} (${attachment.summary}):\n\n${preview}` };
+    }
+
+    if (attachment.kind === "image" && attachment.source.type === "image") {
+      const { spoolImageToTempFile } = await import("../utils/open-external.js");
+      try {
+        const path = attachment.source.spoolPath
+          ?? (attachment.source.base64 ? await spoolImageToTempFile(attachment.source.base64, attachment.source.mediaType) : null);
+        if (!path) return { type: "message", text: `Image #${id} data is no longer available.` };
+        const outcome = await openTarget({ kind: "file", absPath: path });
+        return { type: "message", text: outcome.message };
+      } catch (err) {
+        return { type: "message", text: `Cannot open image #${id}: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    }
+
+    if (attachment.kind === "file" && attachment.source.type === "file") {
+      const outcome = await openTarget({ kind: "file", absPath: attachment.source.absPath });
+      return { type: "message", text: outcome.message };
+    }
+
+    return { type: "message", text: `Attachment #${id} cannot be opened.` };
+  },
+};

--- a/source/commands/registry.ts
+++ b/source/commands/registry.ts
@@ -23,6 +23,7 @@ import { steerCommand } from "./steer.js"
 import { changelogCommand } from "./changelog.js"
 import { contextCommand } from "./context.js"
 import { agentsCommand } from "./agents.js"
+import { openCommand } from "./open.js"
 
 /** Store slash commands and dispatch raw user input to the matching handler. */
 export class CommandRegistry {
@@ -59,6 +60,7 @@ export class CommandRegistry {
     this.register(changelogCommand)
     this.register(contextCommand)
     this.register(agentsCommand)
+    this.register(openCommand)
   }
 
   /** Add a command to the registry by name. */

--- a/source/commands/reserved-names.ts
+++ b/source/commands/reserved-names.ts
@@ -10,5 +10,5 @@ export const RESERVED_COMMAND_NAMES: ReadonlySet<string> = new Set([
   "history", "export", "watch", "branch", "compact", "memory",
   "remember", "forget", "fast", "deep", "undo", "plan", "debug",
   "search", "loop", "schedule", "skills", "steer", "changelog",
-  "context", "agents",
+  "context", "agents", "open",
 ]);

--- a/source/components/attachment-preview.tsx
+++ b/source/components/attachment-preview.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Box, Text } from "../ink/index.js";
+import { wrapToWidth } from "../utils/wrap-text.js";
+
+const MAX_PREVIEW_LINES = 2000;
+
+export interface PreviewContent {
+  /** Header line shown above the body, e.g. "Pasted #1 · 2k chars, 40 lines" or a file path. */
+  title: string;
+  /** Plain text to preview — already read/decoded by the caller. */
+  text: string;
+}
+
+interface Props {
+  content: PreviewContent;
+  closeKey: string;
+  copyKey: string;
+  columns: number;
+}
+
+/**
+ * Read-only in-document preview of a pasted block or a file's text, following
+ * the same pattern as `ToolDetailPanel` / `PlanDetailPanel` — a panel inside
+ * the scrolling document, not a footer modal, since a read-only view has no
+ * reason to seize the keyboard.
+ */
+export default function AttachmentPreview({ content, closeKey, copyKey, columns }: Props) {
+  const lines = wrapToWidth(content.text, Math.max(10, columns - 4));
+  const truncated = lines.length > MAX_PREVIEW_LINES;
+  const visible = truncated ? lines.slice(0, MAX_PREVIEW_LINES) : lines;
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} marginBottom={1}>
+      <Text bold dimColor>{content.title} <Text>({closeKey} to close · {copyKey} to copy)</Text></Text>
+      {visible.map((line, i) => (
+        <Text key={i}>{line || " "}</Text>
+      ))}
+      {truncated && (
+        <Text dimColor>... {lines.length - MAX_PREVIEW_LINES} more lines</Text>
+      )}
+    </Box>
+  );
+}

--- a/source/components/clickable-line.tsx
+++ b/source/components/clickable-line.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Box, Text } from "../ink/index.js";
+import type { MouseEventData } from "../ink/index.js";
+
+/** One clickable or plain run within a single pre-wrapped visual line. */
+export interface LineRun {
+  /**
+   * Text for this run. May be pre-styled with ANSI SGR codes (as produced by
+   * `renderMarkdown`/`sliceStyled`) — but only when `color`/`underline` below
+   * are both omitted, since `<Text>` chalk-transforms its children when those
+   * props are set, and doing so on top of an already-styled run would nest
+   * escape sequences incorrectly.
+   */
+  text: string;
+  /** Present only for clickable runs. Opaque to this component — passed through verbatim to onOpen. */
+  targetId?: string;
+  /** Rendered with this color when set (used for the "clickable" affordance). */
+  color?: string;
+  /** Rendered with this background color when set — e.g. the user-message band. */
+  backgroundColor?: string;
+  /** Rendered underlined when set (used for the "clickable" affordance). */
+  underline?: boolean;
+  /** Rendered dim when set — used to keep a plain run's styling consistent with the surrounding text. */
+  dimColor?: boolean;
+  /** Rendered bold when set. */
+  bold?: boolean;
+}
+
+interface Props {
+  runs: LineRun[];
+  /** Called when a clickable run (one with `targetId` set) is clicked. */
+  onOpen?: (targetId: string) => void;
+  /**
+   * Optional additional handler for clicks that do NOT land on a clickable
+   * run (e.g. caret placement in an input) — receives the raw mouse event.
+   */
+  onMiss?: (event: MouseEventData) => void;
+}
+
+/**
+ * Renders one pre-wrapped visual line as a row of sibling `<Text>` spans,
+ * some of them clickable.
+ *
+ * A `<Text>` nested inside another `<Text>` is not individually hit-testable
+ * for mouse clicks in this Ink fork — the reconciler collapses nested `Text`
+ * into a non-interactive "virtual text" node with no layout rectangle. Every
+ * run must therefore be a sibling `<Text>` directly inside the row's
+ * `<Box flexDirection="row">`, never nested inside another `<Text>`.
+ *
+ * This component does not wrap text itself — the caller is responsible for
+ * splitting a paragraph into rows that each fit the terminal width before
+ * handing runs to `ClickableLine`.
+ */
+export default function ClickableLine({ runs, onOpen, onMiss }: Props) {
+  return (
+    <Box flexDirection="row">
+      {runs.map((run, i) => {
+        const handleClick = run.targetId
+          ? (event: MouseEventData) => {
+              event.stopPropagation?.();
+              onOpen?.(run.targetId!);
+            }
+          : onMiss;
+        return (
+          <Text
+            key={i}
+            color={run.color}
+            backgroundColor={run.backgroundColor}
+            underline={run.underline}
+            dimColor={run.dimColor}
+            bold={run.bold}
+            onClick={handleClick}
+          >
+            {run.text}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}

--- a/source/components/input-prompt.tsx
+++ b/source/components/input-prompt.tsx
@@ -5,6 +5,7 @@ import { loadPromptHistory, savePromptHistory } from "../config/prompt-history.j
 import { writeClipboard } from "../ink/termio/clipboard.js";
 import { readdir, realpath } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
+import { ATTACHMENT_TILE_RE, attachmentTileScanner, attachmentTileForId } from "../utils/attachments.js";
 
 /** Metadata for a slash command suggestion. */
 export interface CommandInfo {
@@ -20,6 +21,16 @@ interface Props {
   onRemoveAttachment?: () => void;
   onClearAttachments?: () => void;
   onRegisterInsert?: (fn: (label: string) => void) => void;
+  /**
+   * Registers a function that replaces an existing attachment tile (matched
+   * by id) in the buffer with literal text — the "paste the same thing again
+   * to expand it" gesture. Returns whether a matching tile was found and
+   * replaced; the caller falls back to creating a fresh attachment when it
+   * returns `false` (the tile was edited away, or never existed here).
+   */
+  onRegisterExpand?: (fn: (id: number, fullText: string) => boolean) => void;
+  /** Opens/previews the attachment a tile click resolved to, instead of moving the caret. */
+  onOpenAttachment?: (id: number) => void;
   disabled?: boolean;
   /**
    * When true, arrow keys do not cycle through prompt history.
@@ -84,17 +95,13 @@ export function isEscapeResidue(input: string): boolean {
 }
 
 /**
- * Matches an attachment placeholder: the `<<...>>` stand-in the prompt shows
- * for a pasted block or an image.
- *
- * Written once because two things depend on its exact shape — backspace, which
- * takes a whole one out at a stroke, and click, which refuses to put the caret
- * inside one.
+ * The attachment tile grammar, immediately before the cursor, with its
+ * trailing space. Shared with `ATTACHMENT_TILE_RE` from `utils/attachments.ts`
+ * so backspace (which removes a whole tile at a stroke) and click (which
+ * refuses to put the caret inside one) never disagree with how a tile was
+ * actually built.
  */
-const ATTACHMENT_LABEL = String.raw`<<(?:\(.*?\) )?(?:Pasted|Image)(?:\s*#\d+)?:.+?>>`;
-
-/** The same placeholder, immediately before the cursor, with its trailing space. */
-const ATTACHMENT_BEFORE_CURSOR_RE = new RegExp(`${ATTACHMENT_LABEL} ?$`);
+const ATTACHMENT_BEFORE_CURSOR_RE = new RegExp(ATTACHMENT_TILE_RE.source + " ?$");
 
 /** Every character cell the prompt prints before the text: `"❯ "` or `"  "`. */
 const PREFIX_WIDTH = 2;
@@ -111,7 +118,7 @@ const PREFIX_WIDTH = 2;
  * are positions the user can sensibly mean, so pick the closer one.
  */
 export function snapOutOfAttachment(text: string, offset: number): number {
-  const pattern = new RegExp(ATTACHMENT_LABEL, "g");
+  const pattern = attachmentTileScanner();
 
   for (let match = pattern.exec(text); match; match = pattern.exec(text)) {
     const start = match.index;
@@ -125,6 +132,29 @@ export function snapOutOfAttachment(text: string, offset: number): number {
   }
 
   return offset;
+}
+
+/**
+ * Returns the attachment id of the tile that spans `offset`, or `null` if
+ * `offset` does not land inside one. A click landing anywhere within a
+ * tile — including on its edges — resolves to it; the click handler checks
+ * this before falling back to `snapOutOfAttachment`, so opening a tile never
+ * also moves the caret.
+ */
+export function attachmentTileAt(text: string, offset: number): number | null {
+  const pattern = attachmentTileScanner();
+
+  for (let match = pattern.exec(text); match; match = pattern.exec(text)) {
+    const start = match.index;
+    const end = start + match[0].length;
+    if (offset >= start && offset < end) {
+      const id = Number(match[1]);
+      return Number.isFinite(id) ? id : null;
+    }
+    if (start > offset) break;
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -184,7 +214,7 @@ function isWithinRoot(root: string, candidate: string): boolean {
 }
 
 /** Renders the interactive prompt with history, completion, and paste handling. */
-export default function InputPrompt({ value, onChange: emitValue, onSubmit, onPaste, onRemoveAttachment, onClearAttachments, onRegisterInsert, disabled, suppressHistory = false, commands = [], keybindings, enhancedKeyboard = false, resumeUserMessages }: Props) {
+export default function InputPrompt({ value, onChange: emitValue, onSubmit, onPaste, onRemoveAttachment, onClearAttachments, onRegisterInsert, onRegisterExpand, onOpenAttachment, disabled, suppressHistory = false, commands = [], keybindings, enhancedKeyboard = false, resumeUserMessages }: Props) {
   const { isRawModeSupported } = useStdin();
   const { stdout } = useStdout();
   const [, bumpCursor] = useState(0);
@@ -374,6 +404,29 @@ export default function InputPrompt({ value, onChange: emitValue, onSubmit, onPa
       });
     }
   }, [onRegisterInsert]);
+
+  // Register expand function so the parent can turn a pasted-block tile back
+  // into its full literal text — the "paste the same thing again" gesture.
+  useEffect(() => {
+    if (onRegisterExpand) {
+      onRegisterExpand((id: number, fullText: string) => {
+        const val = liveRef.current.value;
+        const match = val.match(attachmentTileForId(id));
+        if (!match || match.index === undefined) return false;
+        const start = match.index;
+        const end = start + match[0].length;
+        const cur = liveRef.current.cursor;
+        // A caret sitting inside the tile being replaced (or anywhere after
+        // it) must shift by the length delta so it lands in the same
+        // *logical* spot in the expanded text rather than snapping to
+        // wherever the old offset now falls.
+        const delta = fullText.length - match[0].length;
+        const nextCursor = cur <= start ? cur : cur >= end ? cur + delta : end + delta;
+        applyEdit(val.slice(0, start) + fullText + val.slice(end), nextCursor);
+        return true;
+      });
+    }
+  }, [onRegisterExpand]);
 
   const activeFileToken = getActiveFileToken(text, cursorPos);
   const showSuggestions = !activeFileToken && text.startsWith("/") && !text.includes(" ") && text.length >= 1;
@@ -812,13 +865,21 @@ export default function InputPrompt({ value, onChange: emitValue, onSubmit, onPa
   };
 
   /**
-   * Click (press + release on the same node): positions the caret.
-   * Selection copy is handled by the container-level mouseUp handler.
+   * Click (press + release on the same node): opens the attachment under the
+   * click if there is one, otherwise positions the caret. Selection copy is
+   * handled by the container-level mouseUp handler.
    */
   const handleRowClick = (line: WrappedLine) => (event: MouseEventData) => {
     if (!draggingRef.current && clickCountRef.current <= 1) {
+      const rawOffset = eventToOffset(event, line);
+      const tileId = onOpenAttachment ? attachmentTileAt(text, rawOffset) : null;
+      if (tileId !== null) {
+        onOpenAttachment!(tileId);
+        event.stopPropagation?.();
+        return;
+      }
       // Plain click with no drag — position caret, clear selection.
-      const offset = snapOutOfAttachment(text, eventToOffset(event, line));
+      const offset = snapOutOfAttachment(text, rawOffset);
       clearSelection();
       moveCaret(offset);
     }

--- a/source/components/input-prompt.tsx
+++ b/source/components/input-prompt.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import stringWidth from "string-width";
 import { Box, Text, useInput, useStdin, useStdout, type DOMElement, type MouseEventData } from "../ink/index.js";
 import { KeybindingResolver, PROMPT_ACTIONS, formatKeybinding, formatUsableKeybinding, normalizeKeyEvent, type Keybindings } from "../config/keybindings.js";
 import { loadPromptHistory, savePromptHistory } from "../config/prompt-history.js";
@@ -328,8 +329,18 @@ export default function InputPrompt({ value, onChange: emitValue, onSubmit, onPa
   const eventToOffset = (event: MouseEventData, wl: { offset: number; text: string }): number => {
     const rows = linesRef.current;
     if (!rows || rows.internal_x === undefined) return wl.offset;
-    const column = event.x - rows.internal_x - PREFIX_WIDTH;
-    return wl.offset + Math.max(0, Math.min(column, wl.text.length));
+    const column = Math.max(0, event.x - rows.internal_x - PREFIX_WIDTH);
+    let offset = 0;
+    let width = 0;
+    for (const { segment, index } of segmenter.segment(wl.text)) {
+      const nextWidth = width + stringWidth(segment);
+      if (column < nextWidth) {
+        return wl.offset + (column - width < nextWidth - column ? index : index + segment.length);
+      }
+      width = nextWidth;
+      offset = index + segment.length;
+    }
+    return wl.offset + offset;
   };
 
   /**
@@ -765,18 +776,24 @@ export default function InputPrompt({ value, onChange: emitValue, onSubmit, onPa
   let globalOffset = 0;
   for (let li = 0; li < rawLines.length; li++) {
     const raw = rawLines[li]!;
-    if (raw.length <= usable) {
-      wrappedLines.push({ text: raw, offset: globalOffset, isFirst: li === 0 && wrappedLines.length === 0 });
-      globalOffset += raw.length + 1;
-    } else {
-      let pos = 0;
-      while (pos < raw.length) {
-        const chunk = raw.slice(pos, pos + usable);
-        wrappedLines.push({ text: chunk, offset: globalOffset + pos, isFirst: li === 0 && pos === 0 });
-        pos += usable;
+    let chunkStart = 0;
+    let chunkWidth = 0;
+    let hasChunk = false;
+    for (const { segment, index } of segmenter.segment(raw)) {
+      const segmentWidth = stringWidth(segment);
+      if (hasChunk && chunkWidth + segmentWidth > usable) {
+        wrappedLines.push({ text: raw.slice(chunkStart, index), offset: globalOffset + chunkStart, isFirst: li === 0 && chunkStart === 0 });
+        chunkStart = index;
+        chunkWidth = 0;
+        hasChunk = false;
       }
-      globalOffset += raw.length + 1;
+      chunkWidth += segmentWidth;
+      hasChunk = true;
     }
+    if (hasChunk || raw === "") {
+      wrappedLines.push({ text: raw.slice(chunkStart), offset: globalOffset + chunkStart, isFirst: li === 0 && chunkStart === 0 });
+    }
+    globalOffset += raw.length + 1;
   }
   if (wrappedLines.length === 0) wrappedLines.push({ text: "", offset: 0, isFirst: true });
   wrappedLinesRef.current = wrappedLines;

--- a/source/components/markdown-text.tsx
+++ b/source/components/markdown-text.tsx
@@ -96,6 +96,19 @@ function applySgr(state: string[], seq: string): string[] {
  */
 export function wrapStyled(text: string, maxWidth: number): string[] {
   if (maxWidth <= 0) return [""];
+  // A hard newline in the source must become a hard line break in the output,
+  // not a zero-width character to wrap through — `stringWidth` counts "\n" as
+  // contributing nothing to a line's visible width, so without this the
+  // single-line algorithm below would happily pack "line one\nline two" onto
+  // one wrapped "line", producing a `ClickableLine` row that itself contains
+  // an embedded newline and renders as two terminal rows squeezed into one
+  // Box, breaking multi-line markdown (bulleted lists, in particular) into a
+  // single run-on line. Each hard-split segment is wrapped independently —
+  // mirroring `ink/wrap-text.ts`'s own per-line wrapping — so a returned
+  // array entry is always exactly one visual row.
+  if (text.includes("\n")) {
+    return text.split("\n").flatMap((line) => wrapStyled(line, maxWidth));
+  }
   if (stringWidth(text) <= maxWidth) return [text];
 
   const lines: string[] = [];
@@ -146,6 +159,55 @@ export function wrapStyled(text: string, maxWidth: number): string[] {
     emit(cut, line.length);
   }
   return lines.length > 0 ? lines : [""];
+}
+
+/**
+ * Slice a possibly-ANSI-styled string by *visible* character position — the
+ * same units `stringWidth`-based logic elsewhere in this file uses — without
+ * ever cutting inside an SGR escape sequence, and reopening/closing whatever
+ * styles were active at the cut so each returned piece renders correctly on
+ * its own.
+ *
+ * Used to split one call to `renderMarkdown` (which returns one big styled
+ * string) into several sibling `<Text>` spans — e.g. plain / clickable-link /
+ * plain — without losing any styling `renderMarkdown` applied.
+ *
+ * `start`/`end` count visible grapheme clusters (not UTF-16 code units), so
+ * they line up with what a user counted on screen. Out-of-range indices clamp
+ * to the string's visible bounds. If `end <= start` after clamping, returns
+ * an empty string.
+ */
+export function sliceStyled(text: string, start: number, end: number): string {
+  const pieces = toPieces(text);
+  const total = pieces.reduce((n, p) => n + (p.kind === "text" ? 1 : 0), 0);
+
+  const clampedStart = Math.max(0, Math.min(start, total));
+  const clampedEnd = Math.max(clampedStart, Math.min(end, total));
+  if (clampedEnd <= clampedStart) return "";
+
+  let openBefore: string[] = [];
+  const collected: string[] = [];
+  let visibleIndex = 0;
+
+  for (const piece of pieces) {
+    if (piece.kind === "sgr") {
+      if (visibleIndex < clampedStart) {
+        openBefore = applySgr(openBefore, piece.value);
+      } else if (visibleIndex >= clampedStart && visibleIndex <= clampedEnd) {
+        collected.push(piece.value);
+      }
+      continue;
+    }
+    if (visibleIndex >= clampedStart && visibleIndex < clampedEnd) {
+      collected.push(piece.value);
+    }
+    visibleIndex++;
+  }
+
+  const body = collected.join("");
+  return body.length > 0 && (openBefore.length > 0 || body.includes("\x1b"))
+    ? openBefore.join("") + body + RESET
+    : body;
 }
 
 function extractCells(token: any): { headers: string[]; rows: string[][] } {
@@ -271,7 +333,21 @@ function getMarked(): Marked {
   const instance = new Marked();
   instance.use({ extensions: [makeTableExtension(width)] });
   instance.use(markedTerminal({
-    reflowText: true,
+    // marked-terminal's own text reflow wraps prose at `width` *inside* this
+    // function's output, splitting a long inline token (a file path, a URL)
+    // across two lines with a literal "\n" in the middle whenever it happens
+    // to straddle that column. Everything this module hands `renderMarkdown`'s
+    // result to re-wraps it a second time anyway — `wrapStyled` for
+    // `ClickableMarkdown`, or Ink's own `<Text>` wrapping for every other
+    // caller — and that second pass correctly hard-breaks a long token
+    // without ever inserting a real newline through it. Two independent wrap
+    // passes at slightly different widths (this one ignores the 2-space
+    // indent every caller applies) is what made target detection — a literal
+    // substring search for the token marked as clickable — fail for exactly
+    // the tokens long enough to have been split here, which is why ctrl+click
+    // worked on some agent-mentioned paths and not others of the same kind.
+    // Turning this off leaves ALL wrapping to the single downstream pass.
+    reflowText: false,
     width,
     heading: (text: string) => "\n" + chalk.bold.cyan(text) + "\n",
     strong: chalk.bold,

--- a/source/components/message-list.tsx
+++ b/source/components/message-list.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import { Box, Text } from "../ink/index.js";
 import { renderMarkdown } from "./markdown-text.js";
+import ClickableLine from "./clickable-line.js";
 import { getToolLabel, getToolSummary, isBookkeepingTool } from "../utils/tool-labels.js";
 import { getTheme } from "../config/theme.js";
-import { fileLink } from "../utils/hyperlink.js";
 import type { DiffLine } from "../utils/diff.js";
 import type { InvocationReason } from "../providers/types.js";
 import { projectRelativePath, terminalRelativePaths, toolPathValues } from "../utils/display-path.js";
 import { visualLen, wrapToWidth } from "../utils/wrap-text.js";
 import { VERSION } from "../version.js";
+import { useDetectedTargets } from "../hooks/use-detected-targets.js";
+import { buildClickableLines } from "../utils/render-clickable.js";
+import { targetToRefId, wrapTextToRuns } from "../utils/wrap-runs.js";
+import { encodeOpenRef, type OpenRef } from "../utils/open-ref.js";
 
 /** Normalized message shape used for terminal rendering. */
 export interface DisplayMessage {
@@ -28,7 +32,107 @@ interface Props {
   messages: DisplayMessage[];
   toolDetailKey: string;
   columns: number;
+  /** Opens/previews whatever a clickable run in the transcript resolved to. */
+  onOpenRef?: (ref: OpenRef) => void;
 }
+
+/**
+ * Renders markdown-rendered text as a column of `ClickableLine` rows, making
+ * every detected URL/file path in it clickable. Falls back to plain
+ * `renderMarkdown` output with no per-run splitting while detection is still
+ * pending or found nothing — indistinguishable from today's rendering.
+ */
+const ClickableMarkdown = React.memo(function ClickableMarkdown({
+  rawText, styledText, messageId, columns, indent, onOpenRef, dimColor,
+}: { rawText: string; styledText: string; messageId: string; columns: number; indent: string; onOpenRef?: (ref: OpenRef) => void; dimColor?: boolean }) {
+  const theme = getTheme();
+  const targets = useDetectedTargets(rawText, messageId, Boolean(onOpenRef));
+
+  if (targets.length === 0 || !onOpenRef) {
+    return <Text dimColor={dimColor}>{indent}{styledText}</Text>;
+  }
+
+  const width = Math.max(10, columns - visualLen(indent));
+  const lines = buildClickableLines(styledText, width, targets, (t) => targetToRefId(t, encodeOpenRef), {
+    color: theme.linkColor,
+    underline: true,
+  }, { dimColor });
+
+  const handleOpen = (targetId: string) => {
+    const ref = JSON.parse(targetId) as OpenRef;
+    onOpenRef(ref);
+  };
+
+  return (
+    <Box flexDirection="column">
+      {lines.map((runs, i) => (
+        <ClickableLine
+          key={i}
+          runs={i === 0 ? [{ text: indent }, ...runs] : [{ text: " ".repeat(visualLen(indent)) }, ...runs]}
+          onOpen={handleOpen}
+        />
+      ))}
+    </Box>
+  );
+});
+
+/**
+ * Renders a user message inside its padded background band, making every
+ * detected URL/file path in it clickable.
+ *
+ * The band is painted by writing each line followed by enough spaces to reach
+ * the right edge (`wrapToWidth` guarantees each line fits in one row), so a
+ * clickable run's padding must land on the SAME row it was measured for — the
+ * padding is appended as a final plain run on that row rather than as a
+ * separate `<Text>` sibling measured against the whole message.
+ */
+const UserMessage = React.memo(function UserMessage({ message, columns, onOpenRef }: { message: DisplayMessage; columns: number; onOpenRef?: (ref: OpenRef) => void }) {
+  const cols = columns;
+  const usable = cols - 2;
+  const targets = useDetectedTargets(message.content, message.id, Boolean(onOpenRef));
+
+  const emptyLine = " ".repeat(cols);
+  const invocationText = message.invocationReason
+    ? `AUTOMATION  /${message.invocationReason.source} · ${message.invocationReason.detail}`
+    : undefined;
+
+  const handleOpen = (targetId: string) => {
+    const ref = JSON.parse(targetId) as OpenRef;
+    onOpenRef?.(ref);
+  };
+
+  // Every line is padded out to the full width below, which only paints a
+  // clean band while each one fits on a single row — `wrapToWidth` (used both
+  // directly here and inside `wrapTextToRuns`) guarantees that.
+  const runLines = onOpenRef && targets.length > 0
+    ? wrapTextToRuns(message.content, usable, targets, (t) => targetToRefId(t, encodeOpenRef), { color: getTheme().linkColor, underline: true }, { color: "white" })
+    : wrapToWidth(message.content, usable).map((line) => [{ text: line, color: "white" }]);
+
+  return (
+    <Box flexDirection="column" marginTop={1} marginBottom={1}>
+      <Text backgroundColor="#2d2d2d">{emptyLine}</Text>
+      {invocationText ? (
+        <Text backgroundColor="#2d2d2d">
+          <Text color="yellow" bold>{"  AUTOMATION"}</Text>
+          <Text dimColor>{`  /${message.invocationReason!.source} · ${message.invocationReason!.detail}`}</Text>
+          {" ".repeat(Math.max(0, cols - visualLen(invocationText) - 2))}
+        </Text>
+      ) : null}
+      {runLines.map((runs, i) => {
+        const prefix = i === 0 ? "❯ " : "  ";
+        const lineText = runs.map((r) => r.text).join("");
+        const pad = Math.max(0, cols - prefix.length - visualLen(lineText));
+        const prefixRun = i === 0
+          ? { text: prefix, color: "green", bold: true, backgroundColor: "#2d2d2d" }
+          : { text: prefix, dimColor: true, backgroundColor: "#2d2d2d" };
+        const styledRuns = runs.map((r) => ({ ...r, backgroundColor: "#2d2d2d" }));
+        const padRun = { text: " ".repeat(pad), backgroundColor: "#2d2d2d" };
+        return <ClickableLine key={i} runs={[prefixRun, ...styledRuns, padRun]} onOpen={handleOpen} />;
+      })}
+      <Text backgroundColor="#2d2d2d">{emptyLine}</Text>
+    </Box>
+  );
+});
 
 /** Renders a compact preview of diff output. */
 const DiffView = React.memo(function DiffView({ diffLines }: { diffLines: DiffLine[] }) {
@@ -89,16 +193,19 @@ const ToolResultLine = React.memo(function ToolResultLine({ message }: { message
   const summary = message.toolName && message.toolInput ? getToolSummary(message.toolName, message.toolInput) : "";
   const displayContent = terminalRelativePaths(message.content, toolPathValues(message.toolInput));
 
-  // Image reference with hyperlink
+  // Image reference. Plain text rather than an OSC 8 hyperlink — this
+  // renderer corrupts OSC 8 (the URL leaks into visible text) and emitting it
+  // on a row we also handle clicks for causes terminals to double-open. The
+  // path itself is picked up by the same file-path detection the rest of the
+  // transcript uses, so it is still clickable.
   if (message.toolName === "image" && message.content) {
     const filePath = message.content;
-    const linked = fileLink(projectRelativePath(filePath), filePath);
     return (
       <Box flexDirection="column">
         <Text>
           <Text dimColor>{"  └─ "}</Text>
           <Text bold color="magenta">Image</Text>
-          <Text> {linked}</Text>
+          <Text> {projectRelativePath(filePath)}</Text>
         </Text>
       </Box>
     );
@@ -148,7 +255,7 @@ const ToolResultLine = React.memo(function ToolResultLine({ message }: { message
 });
 
 /** Renders the appropriate terminal bubble for a message role. */
-const MessageBubble = React.memo(function MessageBubble({ message, prevRole, toolDetailKey, columns }: { message: DisplayMessage; prevRole?: string; toolDetailKey: string; columns: number }) {
+const MessageBubble = React.memo(function MessageBubble({ message, prevRole, toolDetailKey, columns, onOpenRef }: { message: DisplayMessage; prevRole?: string; toolDetailKey: string; columns: number; onOpenRef?: (ref: OpenRef) => void }) {
   if (message.role === "banner") {
     return (
       <Box flexDirection="column" marginBottom={1}>
@@ -182,38 +289,12 @@ const MessageBubble = React.memo(function MessageBubble({ message, prevRole, too
   }
 
   if (message.role === "user") {
-    const cols = columns;
-    // Every line is padded out to the full width below, which only paints a clean
-    // band while each one fits on a single row. `wrapToWidth` guarantees that.
-    const lines = wrapToWidth(message.content, cols - 2);
-
-    const emptyLine = " ".repeat(cols);
-    const invocationText = message.invocationReason
-      ? `AUTOMATION  /${message.invocationReason.source} · ${message.invocationReason.detail}`
-      : undefined;
     return (
-      <Box flexDirection="column" marginTop={1} marginBottom={1}>
-        <Text backgroundColor="#2d2d2d">{emptyLine}</Text>
-        {invocationText ? (
-          <Text backgroundColor="#2d2d2d">
-            <Text color="yellow" bold>{"  AUTOMATION"}</Text>
-            <Text dimColor>{`  /${message.invocationReason!.source} · ${message.invocationReason!.detail}`}</Text>
-            {" ".repeat(Math.max(0, cols - visualLen(invocationText) - 2))}
-          </Text>
-        ) : null}
-        {lines.map((line, i) => {
-          const prefix = i === 0 ? "❯ " : "  ";
-          const pad = Math.max(0, cols - prefix.length - visualLen(line));
-          return (
-            <Text key={i} backgroundColor="#2d2d2d">
-              {i === 0 ? <Text color="green" bold>{prefix}</Text> : <Text dimColor>{prefix}</Text>}
-              <Text color="white">{line}</Text>
-              {" ".repeat(pad)}
-            </Text>
-          );
-        })}
-        <Text backgroundColor="#2d2d2d">{emptyLine}</Text>
-      </Box>
+      <UserMessage
+        message={message}
+        columns={columns}
+        onOpenRef={onOpenRef}
+      />
     );
   }
 
@@ -223,21 +304,45 @@ const MessageBubble = React.memo(function MessageBubble({ message, prevRole, too
 
   if (message.role === "assistant") {
     const hadTools = prevRole === "tool";
+    const displayContent = terminalRelativePaths(message.content);
     return (
       <Box flexDirection="column" marginBottom={1}>
         {hadTools ? <Text dimColor>  ({toolDetailKey} to expand tools)</Text> : null}
-        <Text>{"  "}{renderMarkdown(terminalRelativePaths(message.content))}</Text>
+        <ClickableMarkdown
+          rawText={displayContent}
+          styledText={renderMarkdown(displayContent)}
+          messageId={message.id}
+          columns={columns}
+          indent="  "
+          onOpenRef={onOpenRef}
+        />
       </Box>
     );
   }
 
   if (message.role === "system") {
     const isLong = message.content.length > 200;
+    const displayContent = terminalRelativePaths(message.content);
+    if (message.isError) {
+      return (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text color="red">
+            {"  "}{isLong ? renderMarkdown(displayContent) : displayContent}
+          </Text>
+        </Box>
+      );
+    }
     return (
       <Box flexDirection="column" marginBottom={1}>
-        <Text color={message.isError ? "red" : undefined} dimColor={!message.isError}>
-          {"  "}{isLong ? renderMarkdown(terminalRelativePaths(message.content)) : terminalRelativePaths(message.content)}
-        </Text>
+        <ClickableMarkdown
+          rawText={displayContent}
+          styledText={isLong ? renderMarkdown(displayContent) : displayContent}
+          messageId={message.id}
+          columns={columns}
+          indent="  "
+          onOpenRef={onOpenRef}
+          dimColor
+        />
       </Box>
     );
   }
@@ -253,11 +358,11 @@ const MessageBubble = React.memo(function MessageBubble({ message, prevRole, too
  * to a fixed band of the screen while everything below — a streaming reply, a
  * plan, a detail panel — slid around inside bands of their own.
  */
-const MessageList = React.memo(function MessageList({ messages, toolDetailKey, columns }: Props) {
+const MessageList = React.memo(function MessageList({ messages, toolDetailKey, columns, onOpenRef }: Props) {
   return (
     <Box flexDirection="column" flexShrink={0}>
       {messages.map((message, index) => (
-        <MessageBubble key={message.id} message={message} prevRole={index > 0 ? messages[index - 1]?.role : undefined} toolDetailKey={toolDetailKey} columns={columns} />
+        <MessageBubble key={message.id} message={message} prevRole={index > 0 ? messages[index - 1]?.role : undefined} toolDetailKey={toolDetailKey} columns={columns} onOpenRef={onOpenRef} />
       ))}
     </Box>
   );

--- a/source/config/theme.ts
+++ b/source/config/theme.ts
@@ -11,6 +11,8 @@ export interface AgavTheme {
   promptColor: string;
   userBg?: string;
   userFg?: string;
+  /** Color for a clickable run — a detected file path, URL, or attachment tile. */
+  linkColor: string;
 }
 
 const DEFAULT_THEME: AgavTheme = {
@@ -26,6 +28,7 @@ const DEFAULT_THEME: AgavTheme = {
   promptColor: "green",
   userBg: "#2d2d2d",
   userFg: "white",
+  linkColor: "cyan",
 };
 
 let currentTheme: AgavTheme = { ...DEFAULT_THEME };

--- a/source/hooks/use-agent.ts
+++ b/source/hooks/use-agent.ts
@@ -11,6 +11,8 @@ import { createToolRegistry } from "../tools/registry-factory.js";
 import type { ToolRegistry } from "../tools/registry.js";
 import { saveSession, type SessionRecord } from "../config/history.js";
 import { saveSessionState } from "../config/session-state.js";
+import { reserveAttachmentIds } from "../utils/attachments.js";
+import { clearAttachmentRegistry } from "../utils/attachment-registry.js";
 import {
   shouldAutoPlan,
   savePlan,
@@ -231,6 +233,10 @@ export function useAgent(
     if (resumeMessages && resumeMessages.length > 0 && !resumedRef.current) {
       resumedRef.current = true;
       conversationRef.current.setMessages(resumeMessages, resumeCompacted);
+      // Only transcript-facing fields contain attachment tiles. Inspecting all
+      // content blocks could reserve an arbitrary `<<... #n>>` sequence found
+      // inside attached file content.
+      reserveAttachmentIds(resumeMessages.flatMap((message) => [message.displayText, message.sourceText]).filter((text): text is string => typeof text === "string"));
       const displayMsgs = messagesToDisplay(resumeMessages);
       if (displayMsgs.length > 0) {
         setMessages(displayMsgs);
@@ -479,6 +485,11 @@ export function useAgent(
   }, [config.model, config.provider]);
 
   const loadSession = useCallback((session: SessionRecord) => {
+    // Attachment records are process-local. Forget the prior session before
+    // reserving this transcript's ids, so its persisted tiles cannot resolve
+    // to attachments created under the previous session.
+    clearAttachmentRegistry();
+    reserveAttachmentIds(session.messages.flatMap((message) => [message.displayText, message.sourceText]).filter((text): text is string => typeof text === "string"));
     conversationRef.current.setMessages(session.messages, session.compacted);
     sessionIdRef.current = session.id;
     setSessionId(session.id);

--- a/source/hooks/use-detected-targets.ts
+++ b/source/hooks/use-detected-targets.ts
@@ -18,6 +18,9 @@ export function useDetectedTargets(text: string, cacheKey: string | undefined, e
       setTargets([]);
       return;
     }
+    // Do not apply ranges from the previous text while a streaming update is
+    // being scanned; those offsets can point at unrelated content.
+    setTargets([]);
     let cancelled = false;
     detectTargets(text, process.cwd(), cacheKey).then((found) => {
       if (!cancelled) setTargets(found);

--- a/source/hooks/use-detected-targets.ts
+++ b/source/hooks/use-detected-targets.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { detectTargets, type DetectedTarget } from "../utils/detect-targets.js";
+
+/**
+ * Detect URLs and existing file paths in `text`, memoised per `cacheKey`
+ * (typically a message id) so the (async, filesystem-touching) detection
+ * runs once per message rather than on every render.
+ *
+ * Returns `[]` until detection resolves — callers render plain text in the
+ * meantime, which is indistinguishable from "nothing detected" and never
+ * shows a stale or half-applied result.
+ */
+export function useDetectedTargets(text: string, cacheKey: string | undefined, enabled: boolean): DetectedTarget[] {
+  const [targets, setTargets] = useState<DetectedTarget[]>([]);
+
+  useEffect(() => {
+    if (!enabled || !text) {
+      setTargets([]);
+      return;
+    }
+    let cancelled = false;
+    detectTargets(text, process.cwd(), cacheKey).then((found) => {
+      if (!cancelled) setTargets(found);
+    }).catch(() => {
+      if (!cancelled) setTargets([]);
+    });
+    return () => { cancelled = true; };
+  }, [text, cacheKey, enabled]);
+
+  return targets;
+}

--- a/source/ink/ink.tsx
+++ b/source/ink/ink.tsx
@@ -597,9 +597,19 @@ export default class Ink {
 
 		const flushInput = (): void => {
 			if (pendingInput.length > 0) {
-				// Any keyboard input clears the global selection.
-				this.clearGlobalSelection();
-				this.internalEventEmitter.emit("input", pendingInput);
+				// Ctrl+Shift+C is an explicit copy fallback for terminals (notably
+				// Windows Terminal) that do not automatically copy a selection.
+				// Handle it before keyboard input clears the in-app highlight.
+				if (pendingInput.includes("\x1b[99;6u")) {
+					this.copyGlobalSelection();
+					pendingInput = pendingInput.replaceAll("\x1b[99;6u", "");
+				}
+
+				if (pendingInput.length > 0) {
+					// Any other keyboard input clears the global selection.
+					this.clearGlobalSelection();
+					this.internalEventEmitter.emit("input", pendingInput);
+				}
 				pendingInput = "";
 			}
 		};
@@ -947,19 +957,23 @@ export default class Ink {
 		}
 	}
 
+	/** Copy the active frame-wide selection without changing its highlight. */
+	private copyGlobalSelection(): void {
+		if (!this.selectionRange) return;
+
+		const text = getSelectedText(this.getPlainLines(), this.selectionRange);
+		if (text.trim()) {
+			writeClipboard(this.options.stdout, text);
+		}
+	}
+
 	/** Finalise the global selection: copy to clipboard and keep highlight. */
 	private finaliseGlobalSelection(): void {
 		if (this.selectionRange) {
 			// Ensure the highlight reflects the final drag position — the last
 			// drag event may have been throttled.
 			this.repaintWithSelection();
-
-			const lines = this.getPlainLines();
-			const text = getSelectedText(lines, this.selectionRange);
-
-			if (text.trim()) {
-				writeClipboard(this.options.stdout, text);
-			}
+			this.copyGlobalSelection();
 
 			if (!this.selectionDragging && this.selectionClickCount >= 2) {
 				// Double/triple-click — copy and keep highlight briefly.

--- a/source/ink/ink.tsx
+++ b/source/ink/ink.tsx
@@ -584,10 +584,17 @@ export default class Ink {
 			clearTimeout(this.escapeTimer);
 		}
 
-		// Ctrl+C handling.
+		// CMD cannot distinguish Ctrl+Shift+C from Ctrl+C: both arrive as ETX.
+		// When a global selection is active, treat ETX as the copy shortcut rather
+		// than exiting. A plain Ctrl+C (with no selection) still exits normally.
 		if (this.exitOnCtrlC && chunk.includes("\x03")) {
-			this.unmount();
-			return;
+			if (this.selectionRange) {
+				this.copyGlobalSelection();
+				chunk = chunk.replaceAll("\x03", "");
+			} else {
+				this.unmount();
+				return;
+			}
 		}
 
 		// Drain the chunk left-to-right. Mouse reports and bracketed paste
@@ -807,6 +814,13 @@ export default class Ink {
 				if (target === this.mouseDownTarget) {
 					dispatchClick(target, base);
 				}
+			}
+
+			// Some terminals (including CMD) report only the press and release,
+			// not button-motion. Use the release location as the final endpoint so
+			// a drag still selects and copies without an intermediate drag report.
+			if (this.selectionOwned && this.selectionAnchor) {
+				this.extendGlobalSelection(ev.x, y);
 			}
 
 			// Finalise global selection: copy to clipboard on mouse-up.

--- a/source/ink/termio/dec.ts
+++ b/source/ink/termio/dec.ts
@@ -10,23 +10,16 @@ export const decset = (code: number | string): string => `\x1b[?${code}h`;
 /** Build a DECRESET (disable) sequence for the given private mode code. */
 export const decreset = (code: number | string): string => `\x1b[?${code}l`;
 
-// Mouse tracking private mode codes.
-const MOUSE_NORMAL = 1000; // X11 normal tracking (press/release).
+// Mouse tracking private mode codes. Button-motion is needed for Agav's
+// application-owned drag selection; any-motion is not, and needlessly floods
+// stdin while the pointer moves with no button held.
+const MOUSE_NORMAL = 1000; // X11 normal tracking (press/release and wheel).
 const MOUSE_BUTTON_MOTION = 1002; // Button-event (drag) tracking.
-const MOUSE_ANY_MOTION = 1003; // Any-motion tracking.
 const MOUSE_SGR = 1006; // SGR extended coordinate encoding.
 
-const MOUSE_MODES = [
-	MOUSE_NORMAL,
-	MOUSE_BUTTON_MOTION,
-	MOUSE_ANY_MOTION,
-	MOUSE_SGR,
-];
+const MOUSE_MODES = [MOUSE_NORMAL, MOUSE_BUTTON_MOTION, MOUSE_SGR];
 
-/**
- * Enable mouse tracking: normal (1000), button-motion (1002), any-motion
- * (1003), and SGR extended encoding (1006).
- */
+/** Enable normal, drag, and SGR-coordinate mouse tracking. */
 export const ENABLE_MOUSE_TRACKING = MOUSE_MODES.map(decset).join("");
 
 /** Disable the same set of mouse tracking modes. */

--- a/source/utils/attachment-registry.ts
+++ b/source/utils/attachment-registry.ts
@@ -1,0 +1,102 @@
+import type { Attachment } from "./attachments.js";
+import { spoolImageToTempFile } from "./open-external.js";
+
+/**
+ * Session-scoped store of every attachment created this session, keyed by id.
+ *
+ * Unlike the pending-attachment list in `app.tsx` (which `submit` clears once
+ * a turn is sent), this registry is never cleared on submit — a tile stays
+ * clickable in the scrolled-back transcript long after the turn that created
+ * it finished. It is cleared only when the whole session resets (`/clear`,
+ * `/new`).
+ */
+const registry = new Map<number, Attachment>();
+
+/** Insertion order, oldest first — used to evict the oldest record once the cap is hit. */
+const insertionOrder: number[] = [];
+
+/** Hard cap on how many attachment records the registry retains at once. */
+const MAX_RECORDS = 200;
+
+/** Ids evicted to make room, so a stale tile can report why it can't be opened. */
+const evicted = new Set<number>();
+
+/** Register a newly-created attachment, evicting the oldest record if the cap is exceeded. */
+export function registerAttachment(attachment: Attachment): void {
+  registry.set(attachment.id, attachment);
+  insertionOrder.push(attachment.id);
+  evicted.delete(attachment.id);
+
+  while (insertionOrder.length > MAX_RECORDS) {
+    const oldestId = insertionOrder.shift();
+    if (oldestId === undefined) break;
+    // Never evict a record still in the process of being resolved by the id
+    // we just inserted — this can't happen since attachment ids are
+    // monotonic, but guard anyway for safety.
+    if (oldestId === attachment.id) continue;
+    registry.delete(oldestId);
+    evicted.add(oldestId);
+  }
+}
+
+/** Look up an attachment by id. Returns `undefined` if it was never registered or has been evicted. */
+export function getAttachment(id: number): Attachment | undefined {
+  return registry.get(id);
+}
+
+/**
+ * Remove an attachment that never made it into a sent turn — e.g. a pasted
+ * block whose tile was expanded back into literal text before being
+ * submitted. Distinct from eviction: this id is simply forgotten, not marked
+ * `wasEvicted`, since nothing was lost — there is no tile left anywhere
+ * referring to it.
+ */
+export function unregisterAttachment(id: number): void {
+  registry.delete(id);
+  const index = insertionOrder.indexOf(id);
+  if (index !== -1) insertionOrder.splice(index, 1);
+}
+
+/** Whether `id` once existed in this session but was evicted to make room for newer attachments. */
+export function wasEvicted(id: number): boolean {
+  return evicted.has(id);
+}
+
+/** Drop every registered attachment. Used when the session itself resets. */
+export function clearAttachmentRegistry(): void {
+  registry.clear();
+  insertionOrder.length = 0;
+  evicted.clear();
+}
+
+/** All attachments currently registered, oldest first — used by `/open` to list targets. */
+export function listAttachments(): Attachment[] {
+  return insertionOrder.map((id) => registry.get(id)).filter((a): a is Attachment => a !== undefined);
+}
+
+/**
+ * Spool an image attachment's bytes to a temp file and drop the base64 copy
+ * from memory, keeping only the path needed to open or preview it later.
+ *
+ * Called once a turn is submitted — the base64 payload has already gone to
+ * the provider by then, so retaining it in the registry only costs memory
+ * for the rest of the session.
+ */
+export async function compactImageAttachment(id: number): Promise<void> {
+  const attachment = registry.get(id);
+  if (!attachment || attachment.kind !== "image" || attachment.source.type !== "image") return;
+  if (attachment.source.spoolPath || !attachment.source.base64) return;
+
+  try {
+    const spoolPath = await spoolImageToTempFile(attachment.source.base64, attachment.source.mediaType);
+    attachment.source = { ...attachment.source, base64: undefined, spoolPath };
+  } catch {
+    // Leave the base64 in place if spooling fails — still resolvable, just
+    // not compacted.
+  }
+}
+
+/** Compact every currently-pending image attachment once a turn has been submitted. */
+export async function compactImageAttachments(ids: number[]): Promise<void> {
+  await Promise.all(ids.map(compactImageAttachment));
+}

--- a/source/utils/attachment-registry.ts
+++ b/source/utils/attachment-registry.ts
@@ -1,5 +1,5 @@
 import type { Attachment } from "./attachments.js";
-import { spoolImageToTempFile } from "./open-external.js";
+import { spoolImageToTempFile, cleanupSpooledImage, cleanupSpooledImages } from "./open-external.js";
 
 /**
  * Session-scoped store of every attachment created this session, keyed by id.
@@ -23,7 +23,13 @@ const evicted = new Set<number>();
 
 /** Register a newly-created attachment, evicting the oldest record if the cap is exceeded. */
 export function registerAttachment(attachment: Attachment): void {
+  const existing = registry.get(attachment.id);
+  const existingIndex = insertionOrder.indexOf(attachment.id);
+  if (existingIndex !== -1) insertionOrder.splice(existingIndex, 1);
   registry.set(attachment.id, attachment);
+  if (existing?.source.type === "image" && existing.source.spoolPath && existing !== attachment) {
+    cleanupSpooledImage(existing.source.spoolPath).catch(() => {});
+  }
   insertionOrder.push(attachment.id);
   evicted.delete(attachment.id);
 
@@ -34,8 +40,12 @@ export function registerAttachment(attachment: Attachment): void {
     // we just inserted — this can't happen since attachment ids are
     // monotonic, but guard anyway for safety.
     if (oldestId === attachment.id) continue;
+    const evictedAttachment = registry.get(oldestId);
     registry.delete(oldestId);
     evicted.add(oldestId);
+    if (evictedAttachment?.source.type === "image" && evictedAttachment.source.spoolPath) {
+      cleanupSpooledImage(evictedAttachment.source.spoolPath).catch(() => {});
+    }
   }
 }
 
@@ -52,9 +62,13 @@ export function getAttachment(id: number): Attachment | undefined {
  * referring to it.
  */
 export function unregisterAttachment(id: number): void {
+  const attachment = registry.get(id);
   registry.delete(id);
   const index = insertionOrder.indexOf(id);
   if (index !== -1) insertionOrder.splice(index, 1);
+  if (attachment?.source.type === "image" && attachment.source.spoolPath) {
+    cleanupSpooledImage(attachment.source.spoolPath).catch(() => {});
+  }
 }
 
 /** Whether `id` once existed in this session but was evicted to make room for newer attachments. */
@@ -67,6 +81,7 @@ export function clearAttachmentRegistry(): void {
   registry.clear();
   insertionOrder.length = 0;
   evicted.clear();
+  cleanupSpooledImages().catch(() => {});
 }
 
 /** All attachments currently registered, oldest first — used by `/open` to list targets. */
@@ -89,7 +104,16 @@ export async function compactImageAttachment(id: number): Promise<void> {
 
   try {
     const spoolPath = await spoolImageToTempFile(attachment.source.base64, attachment.source.mediaType);
+    // The record may have been cleared, evicted, or replaced while the image
+    // was being written. Do not retain an orphaned temp file in that case.
+    if (registry.get(id) !== attachment) {
+      await cleanupSpooledImage(spoolPath);
+      return;
+    }
     attachment.source = { ...attachment.source, base64: undefined, spoolPath };
+    // `app.tsx` clones blocks into the submitted conversation, so this is only
+    // the registry's duplicate payload and can be released after spooling.
+    attachment.contentBlock.imageData = undefined;
   } catch {
     // Leave the base64 in place if spooling fails — still resolvable, just
     // not compacted.

--- a/source/utils/attachments.ts
+++ b/source/utils/attachments.ts
@@ -2,12 +2,28 @@ import { readFile, stat } from "node:fs/promises";
 import { resolve, extname } from "node:path";
 import { execFileSync } from "node:child_process";
 import type { ContentBlock } from "../providers/types.js";
+import { registerAttachment } from "./attachment-registry.js";
+
+export type AttachmentKind = "paste" | "image" | "file";
+
+export type AttachmentSource =
+  | { type: "text"; text: string }
+  | { type: "image"; base64?: string; mediaType: string; width?: number; height?: number; spoolPath?: string }
+  | { type: "file"; absPath: string };
 
 export interface Attachment {
+  /** Session-unique, monotonic. Never `Date.now()` — two attachments created in
+   * the same millisecond must still resolve to distinct records. */
   id: number;
-  type: "text" | "image";
-  label: string;
+  kind: AttachmentKind;
+  /** Short human-readable description shown in the tile, e.g. "2k chars, 40 lines" or "800x600". */
+  summary: string;
+  source: AttachmentSource;
+  /** What the model sees when this attachment is sent as part of a turn. */
   contentBlock: ContentBlock;
+  createdAt: number;
+  /** The `<<...>>` placeholder rendered in the prompt / transcript for this attachment. */
+  label: string;
 }
 
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"]);
@@ -26,19 +42,67 @@ export function resetAttachmentCounter(): void {
   counter = 0;
 }
 
+/** Allocate the next session-unique attachment id. */
+export function nextAttachmentId(): number {
+  return ++counter;
+}
+
+/**
+ * Matches a single attachment tile placeholder: `<<Pasted #1 · ...>>`,
+ * `<<Image #2 · ...>>`, or `<<File #3 · ...>>`.
+ *
+ * `[^>]*` stops at the first `>` rather than lazily matching past it, so a
+ * filename containing `>` can never make the match run into (or past) the
+ * tile's own closing `>>` — such characters are substituted at tile-build
+ * time instead (see `sanitizeTileSummary`). Two adjacent tiles with no space
+ * between them still match separately for the same reason.
+ */
+export const ATTACHMENT_TILE_RE = /<<(?:Pasted|Image|File) #(\d+) · [^>]*>>/;
+
+/** A fresh global copy of `ATTACHMENT_TILE_RE`, for scanning every tile in a string. */
+export function attachmentTileScanner(): RegExp {
+  return new RegExp(ATTACHMENT_TILE_RE.source, "g");
+}
+
+/** Matches the specific tile for attachment `id`, wherever it sits in a string. */
+export function attachmentTileForId(id: number): RegExp {
+  return new RegExp(`<<(?:Pasted|Image|File) #${id} · [^>]*>>`);
+}
+
+/** Display-only substitution so a summary can never contain the tile's own closing delimiter. */
+function sanitizeTileSummary(summary: string): string {
+  return summary.replace(/>/g, "?");
+}
+
+const KIND_LABEL: Record<AttachmentKind, string> = {
+  paste: "Pasted",
+  image: "Image",
+  file: "File",
+};
+
+function buildLabel(kind: AttachmentKind, id: number, summary: string): string {
+  return `<<${KIND_LABEL[kind]} #${id} · ${sanitizeTileSummary(summary)}>>`;
+}
+
 export function createTextAttachment(text: string): Attachment {
-  const id = ++counter;
+  const id = nextAttachmentId();
   const chars = text.length;
   const normalized = text.replace(/\r\n?/g, "\n");
   const lines = normalized.split("\n").length;
   const charsStr = chars >= 1000 ? `${(chars / 1000).toFixed(0)}k` : String(chars);
+  const summary = `${charsStr} chars, ${lines} lines`;
 
-  return {
+  const attachment: Attachment = {
     id,
-    type: "text",
-    label: `<<(${text.slice(0, 10).replace(/[\r\n]/g, " ")}...) Pasted #${id}: ${charsStr} chars and ${lines} lines>>`,
+    kind: "paste",
+    summary,
+    source: { type: "text", text: normalized },
     contentBlock: { type: "text", text: normalized },
+    createdAt: Date.now(),
+    label: buildLabel("paste", id, summary),
   };
+  registerAttachment(attachment);
+  return attachment;
 }
 
 export async function createImageAttachment(filePath: string): Promise<Attachment | null> {
@@ -67,13 +131,14 @@ export async function createImageAttachment(filePath: string): Promise<Attachmen
       }
     } catch {}
 
-    const id = ++counter;
+    const id = nextAttachmentId();
     const dimStr = width && height ? `${width}x${height}` : "unknown size";
 
-    return {
+    const attachment: Attachment = {
       id,
-      type: "image",
-      label: `<<Image #${id}: ${dimStr}>>`,
+      kind: "image",
+      summary: dimStr,
+      source: { type: "image", base64, mediaType, width: width || undefined, height: height || undefined },
       contentBlock: {
         type: "image",
         imageData: base64,
@@ -81,10 +146,76 @@ export async function createImageAttachment(filePath: string): Promise<Attachmen
         imageWidth: width,
         imageHeight: height,
       },
+      createdAt: Date.now(),
+      label: buildLabel("image", id, dimStr),
     };
+    registerAttachment(attachment);
+    return attachment;
   } catch {
     return null;
   }
+}
+
+/**
+ * Build an image attachment straight from already-decoded data — used for a
+ * clipboard screenshot, which arrives as bytes rather than a path on disk.
+ *
+ * This is also the fix for the id bug in the old `handleClipboardImage`: that
+ * code minted its own id via `Date.now()`, which collided with attachments
+ * created in the same millisecond and was never in the shared counter, so a
+ * clipboard image's tile could never be resolved back to a record.
+ */
+export function createImageAttachmentFromData(
+  base64: string,
+  mediaType: string,
+  width?: number,
+  height?: number,
+): Attachment {
+  const id = nextAttachmentId();
+  const dimStr = width && height ? `${width}x${height}` : "image";
+
+  const attachment: Attachment = {
+    id,
+    kind: "image",
+    summary: dimStr,
+    source: { type: "image", base64, mediaType, width, height },
+    contentBlock: {
+      type: "image",
+      imageData: base64,
+      imageMediaType: mediaType,
+      imageWidth: width,
+      imageHeight: height,
+    },
+    createdAt: Date.now(),
+    label: buildLabel("image", id, dimStr),
+  };
+  registerAttachment(attachment);
+  return attachment;
+}
+
+/**
+ * Build a file attachment for a resolved `@mention`, so the tile shown for it
+ * can be resolved back to a record and opened.
+ *
+ * File mentions inline their content directly into the prompt text via
+ * `expandFileMentions` — the attachment here is a display/open record, not a
+ * message payload, so `contentBlock` is a lightweight text marker rather than
+ * a duplicate of the (potentially large) file content already sent.
+ */
+export function createFileAttachment(absPath: string, relPath: string): Attachment {
+  const id = nextAttachmentId();
+
+  const attachment: Attachment = {
+    id,
+    kind: "file",
+    summary: relPath,
+    source: { type: "file", absPath },
+    contentBlock: { type: "text", text: absPath },
+    createdAt: Date.now(),
+    label: buildLabel("file", id, relPath),
+  };
+  registerAttachment(attachment);
+  return attachment;
 }
 
 const LARGE_TEXT_THRESHOLD = 500;

--- a/source/utils/attachments.ts
+++ b/source/utils/attachments.ts
@@ -42,6 +42,15 @@ export function resetAttachmentCounter(): void {
   counter = 0;
 }
 
+/** Reserve ids already present in a restored transcript, preventing stale tiles from resolving to new attachments. */
+export function reserveAttachmentIds(messages: Iterable<string>): void {
+  for (const message of messages) {
+    for (const match of message.matchAll(attachmentTileScanner())) {
+      counter = Math.max(counter, Number(match[1]));
+    }
+  }
+}
+
 /** Allocate the next session-unique attachment id. */
 export function nextAttachmentId(): number {
   return ++counter;
@@ -66,7 +75,7 @@ export function attachmentTileScanner(): RegExp {
 
 /** Matches the specific tile for attachment `id`, wherever it sits in a string. */
 export function attachmentTileForId(id: number): RegExp {
-  return new RegExp(`<<(?:Pasted|Image|File) #${id} · [^>]*>>`);
+  return new RegExp(`<<(?:Pasted|Image|File) #${id}(?!\\d) · [^>]*>>`);
 }
 
 /** Display-only substitution so a summary can never contain the tile's own closing delimiter. */

--- a/source/utils/detect-targets.ts
+++ b/source/utils/detect-targets.ts
@@ -1,0 +1,154 @@
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { isWithinRoot } from "./path-guard.js";
+
+export type DetectedTargetKind = "url" | "path";
+
+export interface DetectedTarget {
+  kind: DetectedTargetKind;
+  /** The exact substring matched in the source text — includes any `:line:col` suffix for a path. */
+  text: string;
+  /** Start/end offsets (in visible characters) within the text that was scanned. */
+  start: number;
+  end: number;
+  /** Resolved absolute path, only present for `kind: "path"`. */
+  absPath?: string;
+  /** `:line[:col]` suffix captured after a path, if any. */
+  line?: number;
+  col?: number;
+  /**
+   * For `kind: "path"` only — the path portion alone, with no `:line:col`
+   * suffix. This, not `text`, is what gets resolved and stat'd: `text` is the
+   * whole matched substring (including a trailing `:12:5`), and no real file
+   * is ever named that literally.
+   */
+  pathOnly?: string;
+}
+
+/**
+ * Matches an http(s) URL. Deliberately excludes trailing punctuation that is
+ * almost always sentence punctuation rather than part of the URL
+ * (`.`, `,`, `;`, `:`, `!`, `?`) as well as closing brackets/quotes that are
+ * more likely to be prose delimiters than part of the link.
+ */
+const URL_RE = /\bhttps?:\/\/[^\s<>"'`)\]}]*[^\s<>"'`)\]}.,;:!?]/g;
+
+/**
+ * Matches a project-relative file path mentioned in prose.
+ *
+ * Requires a `/` separator — bare `package.json` is deliberately *not*
+ * linkified; unqualified filenames are constant in ordinary prose and
+ * linkifying all of them would be noise. Requires a letter-initial 1-10
+ * character extension, which kills numeric-looking false positives like
+ * `3.5/2.1`, `2024/01/02`, `50/50`, `linux/amd64`. `(?<![\w@/.-])` avoids
+ * matching the tail of an email address or the middle of a longer path
+ * fragment; the trailing `(?![\w/])` avoids matching a bare directory that
+ * happens to precede more path-like characters.
+ */
+const PATH_RE = /(?<![\w@/.-])((?:\.{1,2}\/)?(?:[\w.-]+\/)+[\w.-]+\.[A-Za-z][\w]{0,9})(?::(\d+))?(?::(\d+))?(?![\w/])/g;
+
+/** Replace every URL match with spaces of the same length, so path matching cannot see into one. */
+function blankUrls(text: string, urlMatches: { start: number; end: number }[]): string {
+  if (urlMatches.length === 0) return text;
+  const chars = [...text];
+  for (const { start, end } of urlMatches) {
+    for (let i = start; i < end; i++) chars[i] = " ";
+  }
+  return chars.join("");
+}
+
+/** Find every URL and candidate path in `text`, without validating paths against the filesystem yet. */
+function findCandidates(text: string): DetectedTarget[] {
+  const targets: DetectedTarget[] = [];
+
+  const urlMatches: { start: number; end: number }[] = [];
+  for (const match of text.matchAll(URL_RE)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    urlMatches.push({ start, end });
+    targets.push({ kind: "url", text: match[0], start, end });
+  }
+
+  const blanked = blankUrls(text, urlMatches);
+  for (const match of blanked.matchAll(PATH_RE)) {
+    const start = match.index ?? 0;
+    const full = match[0];
+    targets.push({
+      kind: "path",
+      text: full,
+      start,
+      end: start + full.length,
+      pathOnly: match[1],
+      line: match[2] ? Number(match[2]) : undefined,
+      col: match[3] ? Number(match[3]) : undefined,
+    });
+  }
+
+  targets.sort((a, b) => a.start - b.start);
+  return targets;
+}
+
+/** Per-message cache of validated targets, so re-render never re-detects. */
+const detectionCache = new Map<string, DetectedTarget[]>();
+const DETECTION_CACHE_MAX = 300;
+
+/**
+ * Detect URLs and existing project-relative file paths in `text`, validating
+ * each path candidate against the filesystem before it is reported.
+ *
+ * A path candidate is only reported if it resolves inside `root` and exists
+ * on disk. Anything that fails validation is silently dropped — never
+ * reported as invalid — so the caller can render it as ordinary text with no
+ * further bookkeeping: the affordance never lies about what it can open.
+ *
+ * Cached by `cacheKey` (typically a message id), since detection runs
+ * filesystem stats and must not repeat per render.
+ */
+export async function detectTargets(text: string, root: string, cacheKey?: string): Promise<DetectedTarget[]> {
+  if (cacheKey) {
+    const cached = detectionCache.get(cacheKey);
+    if (cached) return cached;
+  }
+
+  const candidates = findCandidates(text);
+  const validated: DetectedTarget[] = [];
+
+  for (const candidate of candidates) {
+    if (candidate.kind === "url") {
+      try {
+        const parsed = new URL(candidate.text);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") continue;
+      } catch {
+        continue;
+      }
+      validated.push(candidate);
+      continue;
+    }
+
+    // kind === "path"
+    try {
+      const absPath = resolve(root, candidate.pathOnly ?? candidate.text);
+      if (!isWithinRoot(root, absPath)) continue;
+      await stat(absPath);
+      validated.push({ ...candidate, absPath });
+    } catch {
+      // Missing file, traversal outside root, or any other stat failure —
+      // not clickable, rendered as plain text.
+    }
+  }
+
+  if (cacheKey) {
+    if (detectionCache.size >= DETECTION_CACHE_MAX) {
+      const firstKey = detectionCache.keys().next().value;
+      if (firstKey !== undefined) detectionCache.delete(firstKey);
+    }
+    detectionCache.set(cacheKey, validated);
+  }
+
+  return validated;
+}
+
+/** Clear the detection cache — used in tests and on session reset. */
+export function clearDetectionCache(): void {
+  detectionCache.clear();
+}

--- a/source/utils/detect-targets.ts
+++ b/source/utils/detect-targets.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises";
+import { stat, realpath } from "node:fs/promises";
 import { resolve } from "node:path";
 import { isWithinRoot } from "./path-guard.js";
 
@@ -50,7 +50,7 @@ const PATH_RE = /(?<![\w@/.-])((?:\.{1,2}\/)?(?:[\w.-]+\/)+[\w.-]+\.[A-Za-z][\w]
 /** Replace every URL match with spaces of the same length, so path matching cannot see into one. */
 function blankUrls(text: string, urlMatches: { start: number; end: number }[]): string {
   if (urlMatches.length === 0) return text;
-  const chars = [...text];
+  const chars = text.split("");
   for (const { start, end } of urlMatches) {
     for (let i = start; i < end; i++) chars[i] = " ";
   }
@@ -105,8 +105,12 @@ const DETECTION_CACHE_MAX = 300;
  * filesystem stats and must not repeat per render.
  */
 export async function detectTargets(text: string, root: string, cacheKey?: string): Promise<DetectedTarget[]> {
-  if (cacheKey) {
-    const cached = detectionCache.get(cacheKey);
+  // Messages retain their id while their assistant text streams. Scope cache
+  // entries to the exact text as well, so an early empty scan cannot hide a
+  // URL or path received in a later chunk.
+  const textCacheKey = cacheKey === undefined ? undefined : `${cacheKey}\0${text}`;
+  if (textCacheKey !== undefined) {
+    const cached = detectionCache.get(textCacheKey);
     if (cached) return cached;
   }
 
@@ -128,21 +132,23 @@ export async function detectTargets(text: string, root: string, cacheKey?: strin
     // kind === "path"
     try {
       const absPath = resolve(root, candidate.pathOnly ?? candidate.text);
-      if (!isWithinRoot(root, absPath)) continue;
       await stat(absPath);
-      validated.push({ ...candidate, absPath });
+      const realRoot = await realpath(root);
+      const realPath = await realpath(absPath);
+      if (!isWithinRoot(realRoot, realPath)) continue;
+      validated.push({ ...candidate, absPath: realPath });
     } catch {
       // Missing file, traversal outside root, or any other stat failure —
       // not clickable, rendered as plain text.
     }
   }
 
-  if (cacheKey) {
+  if (textCacheKey !== undefined) {
     if (detectionCache.size >= DETECTION_CACHE_MAX) {
       const firstKey = detectionCache.keys().next().value;
       if (firstKey !== undefined) detectionCache.delete(firstKey);
     }
-    detectionCache.set(cacheKey, validated);
+    detectionCache.set(textCacheKey, validated);
   }
 
   return validated;

--- a/source/utils/file-mentions.ts
+++ b/source/utils/file-mentions.ts
@@ -1,7 +1,7 @@
 import { relative } from "node:path";
 import type { ContentBlock } from "../providers/types.js";
-import { fileLink } from "./hyperlink.js";
 import { readFileContext, readDirectoryContext, resolveMentionPath, type FileContextKind } from "./file-context.js";
+import { createFileAttachment } from "./attachments.js";
 import { stat } from "node:fs/promises";
 
 const MAX_FILES_PER_PROMPT = 5;
@@ -91,14 +91,18 @@ export async function expandFileMentions(
     summarized: context.summarized,
   }));
   const contextByPath = new Map(contexts.map((context) => [context.path, context]));
-  const fileNumber = new Map(uniquePaths.map((path, index) => [path, index + 1]));
+  // One attachment record per unique file — registered once here so its tile
+  // (however many mentions of the same file appear in the prompt) resolves
+  // back to a single, clickable, openable record.
+  const fileAttachmentLabel = new Map(uniquePaths.map((path) => {
+    const rel = relative(options.cwd, path) || path;
+    return [path, createFileAttachment(path, rel).label];
+  }));
   const absoluteReplacements = new Map<string, string>();
   const displayReplacements = new Map<string, string>();
   for (const [mention, absolute] of resolvedByMention) {
     absoluteReplacements.set(mention, absolute);
-    const number = fileNumber.get(absolute)!;
-    const rel = relative(options.cwd, absolute) || absolute;
-    displayReplacements.set(mention, fileLink(`<<File #${number}: ${rel}>>`, absolute));
+    displayReplacements.set(mention, fileAttachmentLabel.get(absolute)!);
   }
 
   const expandedPrompt = replaceMentions(escapedText, matches, absoluteReplacements).replaceAll(ESCAPED_AT, "@");

--- a/source/utils/hints.ts
+++ b/source/utils/hints.ts
@@ -51,6 +51,8 @@ const HINTS = [
   "/steer clear removes all steers",
   "/model opens an interactive model picker with live API fetch",
   "/git-commit generates a commit message from staged changes",
+  "Ctrl+click (Cmd+click on macOS) opens a file path, URL, or attachment tile",
+  "/open lists every attachment in the session and opens or previews one",
 ];
 
 let lastIndex = -1;

--- a/source/utils/open-external.ts
+++ b/source/utils/open-external.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { rmSync } from "node:fs";
+import { mkdir, writeFile, rm } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join, isAbsolute } from "node:path";
@@ -69,11 +70,53 @@ export function extensionForImage(mediaType: string | undefined): string {
   }
 }
 
+const spooledImagePaths = new Set<string>();
+let cleanupHooksInstalled = false;
+
+function installSpooledImageCleanupHooks(): void {
+  if (cleanupHooksInstalled) return;
+  cleanupHooksInstalled = true;
+  const cleanup = () => {
+    for (const path of spooledImagePaths) {
+      try {
+        rmSync(path, { force: true });
+      } catch {
+        // Process-exit cleanup is best-effort.
+      }
+    }
+    spooledImagePaths.clear();
+  };
+  process.once("exit", cleanup);
+  process.once("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.once("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+}
+
+/** Remove one image file created by this process. Cleanup is best-effort. */
+export async function cleanupSpooledImage(path: string): Promise<void> {
+  if (!spooledImagePaths.delete(path)) return;
+  await rm(path, { force: true }).catch(() => {});
+}
+
+/** Remove all image files created by this process. Cleanup is best-effort. */
+export async function cleanupSpooledImages(): Promise<void> {
+  const paths = [...spooledImagePaths];
+  spooledImagePaths.clear();
+  await Promise.all(paths.map((path) => rm(path, { force: true }).catch(() => {})));
+}
+
 /** Persist image data to a temporary file for a native image viewer. */
 export async function spoolImageToTempFile(base64: string, mediaType: string | undefined): Promise<string> {
   const directory = join(tmpdir(), "agav-images");
   await mkdir(directory, { recursive: true });
   const path = join(directory, `image-${Date.now()}-${randomBytes(4).toString("hex")}${extensionForImage(mediaType)}`);
   await writeFile(path, Buffer.from(base64, "base64"));
+  spooledImagePaths.add(path);
+  installSpooledImageCleanupHooks();
   return path;
 }

--- a/source/utils/open-external.ts
+++ b/source/utils/open-external.ts
@@ -2,14 +2,51 @@ import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, isAbsolute } from "node:path";
 
-/** Open a URL or file using the platform's default handler. */
+/** Matches a URI scheme prefix, e.g. "https:", "vscode:", "file:". */
+const URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * Whether `target` is safe to hand to the platform's "open" launcher without
+ * a shell in the loop. This only validates *shape* — it accepts anything
+ * that looks like a URL (any scheme) or an absolute filesystem path. It is
+ * not an allow-list of schemes or directories; callers that need to restrict
+ * targets further (e.g. to http/https only, or to a specific directory) must
+ * do that themselves.
+ */
+export function isSafeOpenTarget(target: string): boolean {
+  if (URL_SCHEME_RE.test(target)) return true;
+  return isAbsolute(target) && !target.startsWith("-");
+}
+
+/**
+ * Open a URL or file using the platform's default handler.
+ *
+ * Callers passing local files must pass an absolute path — URLs are
+ * naturally absolute already. Relative paths and anything that doesn't look
+ * like an absolute path or a URL are rejected without spawning a process.
+ */
 export function openExternal(target: string): Promise<boolean> {
+  // On Linux, xdg-open falls back to a chain of TTY browsers when there's no
+  // display server, which would hijack the terminal's alt-screen and hang on
+  // stdin. Refuse to spawn anything in that case.
+  if (
+    process.platform === "linux" &&
+    !process.env["DISPLAY"] &&
+    !process.env["WAYLAND_DISPLAY"]
+  ) {
+    return Promise.resolve(false);
+  }
+
+  if (!isSafeOpenTarget(target)) {
+    return Promise.resolve(false);
+  }
+
   const launcher = process.platform === "darwin"
     ? { bin: "open", args: [] as string[] }
     : process.platform === "win32"
-      ? { bin: "cmd.exe", args: ["/c", "start", ""] }
+      ? { bin: "explorer.exe", args: [] as string[] }
       : { bin: "xdg-open", args: [] as string[] };
 
   return new Promise((resolve) => {

--- a/source/utils/open-ref.ts
+++ b/source/utils/open-ref.ts
@@ -1,0 +1,28 @@
+/**
+ * A reference to something clickable in the transcript or the prompt: an
+ * attachment tile, a detected URL, or a detected file path.
+ *
+ * `ClickableLine` only carries an opaque string id per run, so a ref is
+ * serialized to travel through it and parsed back out in the click handler —
+ * see `encodeOpenRef` / `decodeOpenRef`.
+ */
+export type OpenRef =
+  | { kind: "attachment"; id: number }
+  | { kind: "url"; url: string }
+  | { kind: "path"; absPath: string; line?: number; col?: number };
+
+export function encodeOpenRef(ref: OpenRef): string {
+  return JSON.stringify(ref);
+}
+
+export function decodeOpenRef(key: string): OpenRef | null {
+  try {
+    const parsed = JSON.parse(key);
+    if (parsed && typeof parsed === "object" && typeof parsed.kind === "string") {
+      return parsed as OpenRef;
+    }
+  } catch {
+    // Not a ref — a run with a plain string id, or malformed input.
+  }
+  return null;
+}

--- a/source/utils/open-target.ts
+++ b/source/utils/open-target.ts
@@ -1,0 +1,230 @@
+import { access, constants } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { openExternal } from "./open-external.js";
+import { checkPathBoundary } from "./path-guard.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface OpenFileRequest {
+  kind: "file";
+  absPath: string;
+  line?: number;
+  col?: number;
+}
+
+export interface OpenUrlRequest {
+  kind: "url";
+  url: string;
+}
+
+export type OpenRequest = OpenFileRequest | OpenUrlRequest;
+
+export interface OpenOutcome {
+  ok: boolean;
+  /** One line describing what happened, for the system-message feedback channel. */
+  message: string;
+}
+
+/** Schemes ever allowed to reach an external opener. Everything else is refused outright. */
+const ALLOWED_URL_SCHEMES = new Set(["http:", "https:"]);
+
+/** VS Code family CLIs to probe, in preference order — plain `code` first since remote windows prepend their shim to PATH. */
+const VSCODE_CLI_CANDIDATES = ["code", "cursor", "windsurf", "codium", "code-insiders"];
+
+let cachedVsCodeCli: string | null | undefined;
+
+async function commandExists(bin: string): Promise<boolean> {
+  try {
+    await execFileAsync(process.platform === "win32" ? "where" : "which", [bin], { timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect an available VS Code family CLI on PATH, memoised for the process
+ * lifetime (the set of installed CLIs cannot change mid-session).
+ */
+async function findVsCodeCli(): Promise<string | null> {
+  if (cachedVsCodeCli !== undefined) return cachedVsCodeCli;
+  for (const bin of VSCODE_CLI_CANDIDATES) {
+    if (await commandExists(bin)) {
+      cachedVsCodeCli = bin;
+      return bin;
+    }
+  }
+  cachedVsCodeCli = null;
+  return null;
+}
+
+/**
+ * Whether we're running inside VS Code's integrated terminal (or a fork of
+ * it). Every other `VSCODE_*` env var is stripped from the child process
+ * environment by the shell-integration script, so `TERM_PROGRAM` is the only
+ * reliable signal — and every fork (Cursor, Windsurf, VSCodium, Insiders)
+ * reports the same value, so the actual editor is identified by which CLI
+ * binary exists on PATH instead.
+ */
+function isVsCodeTerminal(): boolean {
+  return process.env["TERM_PROGRAM"] === "vscode";
+}
+
+/** Whether a GUI is reachable to open something in. Refusing here avoids `xdg-open`'s TTY-browser fallback chain. */
+function hasGui(): boolean {
+  if (process.platform === "darwin" || process.platform === "win32") return true;
+  return Boolean(process.env["DISPLAY"] || process.env["WAYLAND_DISPLAY"]);
+}
+
+function isCI(): boolean {
+  return Boolean(process.env["CI"]) || !process.stdout.isTTY;
+}
+
+/** Detect whether we're inside WSL with a reachable Windows interop layer (not an SSH session). */
+async function detectWsl(): Promise<boolean> {
+  if (process.platform !== "linux") return false;
+  if (process.env["SSH_CONNECTION"] || process.env["SSH_TTY"]) return false;
+  if (!process.env["WSL_DISTRO_NAME"] && !process.env["WSL_INTEROP"]) return false;
+  try {
+    await access("/mnt/c", constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Extension allow-list before handing a local file to the OS opener — `xdg-open` dispatches on MIME and would run a `.desktop` file's `Exec=` line. */
+const INERT_EXTENSIONS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg", ".ico", ".tif", ".tiff",
+  ".pdf", ".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".tsv", ".log",
+  ".html", ".htm", ".css", ".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs",
+  ".py", ".rb", ".go", ".rs", ".java", ".c", ".cc", ".cpp", ".h", ".hpp",
+  ".sh", ".bash", ".zsh", ".toml", ".ini", ".xml", ".doc", ".docx", ".ppt",
+  ".pptx", ".xls", ".xlsx", ".mp3", ".mp4", ".mov", ".wav", ".zip", ".tar",
+  ".gz",
+]);
+
+function extOf(path: string): string {
+  const dot = path.lastIndexOf(".");
+  return dot === -1 ? "" : path.slice(dot).toLowerCase();
+}
+
+async function openWithVsCode(cli: string, absPath: string, line?: number, col?: number): Promise<boolean> {
+  const target = line !== undefined
+    ? `${absPath}:${line}${col !== undefined ? `:${col}` : ""}`
+    : absPath;
+  try {
+    await execFileAsync(cli, line !== undefined ? ["-r", "-g", target] : ["-r", absPath], { timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function openWsl(target: string): Promise<boolean> {
+  if (await commandExists("wslview")) {
+    try {
+      await execFileAsync("wslview", [target], { timeout: 10_000 });
+      return true;
+    } catch {}
+  }
+  try {
+    const { stdout } = await execFileAsync("wslpath", ["-w", target], { timeout: 5_000 });
+    const winPath = stdout.trim();
+    await execFileAsync("explorer.exe", [winPath], { timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Open a file in an editor or the OS default app, or a URL in the browser,
+ * following the open ladder from the design: `$BROWSER` (URLs only) → refuse
+ * in CI/containers/non-TTY → VS Code (`code -r -g`) → WSL → platform opener →
+ * refuse if there's no GUI to hand it to.
+ *
+ * Every branch that actually spawns something is delegated to `openExternal`,
+ * which carries the Windows/no-GUI/absolute-path hardening — this function
+ * only decides *what* to spawn and applies the higher-level policy (scheme
+ * allow-list, extension allow-list, path boundary check).
+ */
+export async function openTarget(request: OpenRequest): Promise<OpenOutcome> {
+  if (request.kind === "url") {
+    let parsed: URL;
+    try {
+      parsed = new URL(request.url);
+    } catch {
+      return { ok: false, message: `Cannot open: "${request.url}" is not a valid URL.` };
+    }
+    if (!ALLOWED_URL_SCHEMES.has(parsed.protocol)) {
+      return { ok: false, message: `Cannot open: scheme "${parsed.protocol}" is not allowed.` };
+    }
+
+    const browserOverride = process.env["BROWSER"];
+    if (browserOverride) {
+      try {
+        await execFileAsync(browserOverride, [request.url], { timeout: 10_000 });
+        return { ok: true, message: `Opened ${request.url} via $BROWSER.` };
+      } catch {
+        // Fall through to the platform opener.
+      }
+    }
+
+    if (isCI()) {
+      return { ok: false, message: `No GUI detected — copy this link: ${request.url}` };
+    }
+
+    const ok = await openExternal(request.url);
+    return ok
+      ? { ok: true, message: `Opened ${request.url} in your browser.` }
+      : { ok: false, message: `Could not open ${request.url} — no browser available.` };
+  }
+
+  // kind === "file"
+  const absPath = isAbsolute(request.absPath) ? request.absPath : resolve(request.absPath);
+
+  const boundaryError = await checkPathBoundary(absPath, "read");
+  if (boundaryError) {
+    return { ok: false, message: `Cannot open: ${boundaryError}` };
+  }
+
+  try {
+    await access(absPath, constants.F_OK);
+  } catch {
+    return { ok: false, message: `Cannot open: file no longer exists (${absPath}).` };
+  }
+
+  if (isCI()) {
+    return { ok: false, message: `No GUI detected — path copied to clipboard: ${absPath}` };
+  }
+
+  if (isVsCodeTerminal()) {
+    const cli = await findVsCodeCli();
+    if (cli && await openWithVsCode(cli, absPath, request.line, request.col)) {
+      return { ok: true, message: `Opened ${absPath} in VS Code.` };
+    }
+  }
+
+  if (await detectWsl()) {
+    if (await openWsl(absPath)) {
+      return { ok: true, message: `Opened ${absPath}.` };
+    }
+  }
+
+  if (!hasGui()) {
+    return { ok: false, message: `No GUI detected — path copied to clipboard: ${absPath}` };
+  }
+
+  const ext = extOf(absPath);
+  if (ext && !INERT_EXTENSIONS.has(ext)) {
+    return { ok: false, message: `Cannot open: "${ext}" files are not in the allow-list of safe types to hand to the OS.` };
+  }
+
+  const ok = await openExternal(absPath);
+  return ok
+    ? { ok: true, message: `Opened ${absPath}.` }
+    : { ok: false, message: `Could not open ${absPath} — no default app available.` };
+}

--- a/source/utils/open-target.ts
+++ b/source/utils/open-target.ts
@@ -1,4 +1,4 @@
-import { access, constants } from "node:fs/promises";
+import { access, constants, realpath } from "node:fs/promises";
 import { isAbsolute, resolve } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -80,6 +80,20 @@ function hasGui(): boolean {
 
 function isCI(): boolean {
   return Boolean(process.env["CI"]) || !process.stdout.isTTY;
+}
+
+/** Split a $BROWSER command without invoking a shell; quotes group arguments and `%s` is replaced with the URL. */
+function parseBrowserCommand(value: string): string[] | null {
+  const args: string[] = [];
+  const tokens = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([^\s"']+)/g;
+  let match: RegExpExecArray | null;
+  let end = 0;
+  while ((match = tokens.exec(value))) {
+    if (value.slice(end, match.index).trim()) return null;
+    args.push((match[1] ?? match[2] ?? match[3] ?? "").replace(/\\([\\"'])/g, "$1"));
+    end = tokens.lastIndex;
+  }
+  return args.length > 0 && !value.slice(end).trim() ? args : null;
 }
 
 /** Detect whether we're inside WSL with a reachable Windows interop layer (not an SSH session). */
@@ -164,9 +178,13 @@ export async function openTarget(request: OpenRequest): Promise<OpenOutcome> {
     }
 
     const browserOverride = process.env["BROWSER"];
-    if (browserOverride) {
+    const browserCommand = browserOverride && parseBrowserCommand(browserOverride);
+    if (browserCommand) {
       try {
-        await execFileAsync(browserOverride, [request.url], { timeout: 10_000 });
+        const hasUrlPlaceholder = browserCommand.some((argument) => argument.includes("%s"));
+        const browserArgs = browserCommand.slice(1).map((argument) => argument.replaceAll("%s", request.url));
+        if (!hasUrlPlaceholder) browserArgs.push(request.url);
+        await execFileAsync(browserCommand[0]!, browserArgs, { timeout: 10_000 });
         return { ok: true, message: `Opened ${request.url} via $BROWSER.` };
       } catch {
         // Fall through to the platform opener.
@@ -191,40 +209,49 @@ export async function openTarget(request: OpenRequest): Promise<OpenOutcome> {
     return { ok: false, message: `Cannot open: ${boundaryError}` };
   }
 
+  let resolvedPath: string;
   try {
-    await access(absPath, constants.F_OK);
+    // Re-resolve immediately before dispatching to an external opener so a
+    // symlink swap after the policy check cannot redirect the open target.
+    resolvedPath = await realpath(absPath);
   } catch {
     return { ok: false, message: `Cannot open: file no longer exists (${absPath}).` };
   }
+  if (resolvedPath !== absPath) {
+    const resolvedBoundaryError = await checkPathBoundary(resolvedPath, "read");
+    if (resolvedBoundaryError) {
+      return { ok: false, message: `Cannot open: ${resolvedBoundaryError}` };
+    }
+  }
 
   if (isCI()) {
-    return { ok: false, message: `No GUI detected — path copied to clipboard: ${absPath}` };
+    return { ok: false, message: `No GUI detected — copy this path manually: ${absPath}` };
   }
 
   if (isVsCodeTerminal()) {
     const cli = await findVsCodeCli();
-    if (cli && await openWithVsCode(cli, absPath, request.line, request.col)) {
-      return { ok: true, message: `Opened ${absPath} in VS Code.` };
+    if (cli && await openWithVsCode(cli, resolvedPath, request.line, request.col)) {
+      return { ok: true, message: `Opened ${resolvedPath} in VS Code.` };
     }
   }
 
   if (await detectWsl()) {
-    if (await openWsl(absPath)) {
-      return { ok: true, message: `Opened ${absPath}.` };
+    if (await openWsl(resolvedPath)) {
+      return { ok: true, message: `Opened ${resolvedPath}.` };
     }
   }
 
   if (!hasGui()) {
-    return { ok: false, message: `No GUI detected — path copied to clipboard: ${absPath}` };
+    return { ok: false, message: `No GUI detected — copy this path manually: ${resolvedPath}` };
   }
 
-  const ext = extOf(absPath);
+  const ext = extOf(resolvedPath);
   if (ext && !INERT_EXTENSIONS.has(ext)) {
     return { ok: false, message: `Cannot open: "${ext}" files are not in the allow-list of safe types to hand to the OS.` };
   }
 
-  const ok = await openExternal(absPath);
+  const ok = await openExternal(resolvedPath);
   return ok
-    ? { ok: true, message: `Opened ${absPath}.` }
-    : { ok: false, message: `Could not open ${absPath} — no default app available.` };
+    ? { ok: true, message: `Opened ${resolvedPath}.` }
+    : { ok: false, message: `Could not open ${resolvedPath} — no default app available.` };
 }

--- a/source/utils/path-guard.ts
+++ b/source/utils/path-guard.ts
@@ -1,6 +1,12 @@
-import { resolve, dirname, basename, sep } from "node:path";
+import { resolve, dirname, basename, sep, relative } from "node:path";
 import { realpath } from "node:fs/promises";
 import { tmpdir, homedir } from "node:os";
+
+/** Whether `candidate` resolves to a path at or under `root` (no symlink resolution — callers needing that should resolve first). */
+export function isWithinRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !rel.startsWith(sep));
+}
 
 /**
  * Paths that are always denied for read or write operations — credential

--- a/source/utils/render-clickable.ts
+++ b/source/utils/render-clickable.ts
@@ -26,13 +26,10 @@ import type { LineRunSpec } from "./wrap-runs.js";
  * within it, makes a straddling target's ownership span the boundary the same
  * way `wrapTextToRuns` already does for plain (non-styled) text.
  *
- * Offsets are matched by indexOf on the ANSI-stripped text and then converted
- * through `sliceStyled`, which counts by grapheme cluster. For the ASCII-only
- * targets this module ever receives (paths, URLs) that lines up exactly with
- * a code-unit index; a wide/combining character earlier in the text could in
- * principle shift alignment, which would only ever under-detect (fail to
- * linkify) rather than mis-slice, since `sliceStyled` itself is always safe
- * against arbitrary indices.
+ * Offsets are matched by indexOf on ANSI-stripped text (UTF-16 code units),
+ * then converted to grapheme offsets separately for each wrapped line before
+ * slicing styled output. This keeps targets after emoji or combining text
+ * aligned with `sliceStyled`, whose offsets are grapheme based.
  */
 export function buildClickableLines(
   styledText: string,
@@ -46,6 +43,14 @@ export function buildClickableLines(
   if (targets.length === 0) return wrapped.map((line) => [{ text: line, ...plainRunStyle }]);
 
   const fullVisible = stripAnsi(styledText);
+  const graphemeOffsetAt = (text: string, codeUnitOffset: number) => {
+    let offset = 0;
+    for (const { index } of new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text)) {
+      if (index >= codeUnitOffset) break;
+      offset++;
+    }
+    return offset;
+  };
 
   type Occurrence = { start: number; end: number; target: DetectedTarget };
   const occurrences: Occurrence[] = [];
@@ -97,7 +102,7 @@ export function buildClickableLines(
       const target = owner[lineStart + i] ?? null;
       let j = i;
       while (j < visibleLine.length && (owner[lineStart + j] ?? null) === target) j++;
-      const chunk = sliceStyled(line, i, j);
+      const chunk = sliceStyled(line, graphemeOffsetAt(visibleLine, i), graphemeOffsetAt(visibleLine, j));
       if (target) {
         runs.push({ text: chunk, targetId: makeTargetId(target), color: style.color, underline: style.underline });
       } else {

--- a/source/utils/render-clickable.ts
+++ b/source/utils/render-clickable.ts
@@ -1,0 +1,111 @@
+import { wrapStyled, sliceStyled } from "../components/markdown-text.js";
+import { stripAnsi } from "./wrap-text.js";
+import type { DetectedTarget } from "./detect-targets.js";
+import type { LineRunSpec } from "./wrap-runs.js";
+
+/**
+ * Wrap an already-markdown-rendered (ANSI-styled) string to `width` columns,
+ * and turn every detected target's exact matched text into its own clickable
+ * run — including a target whose rendered text is split across a wrap
+ * boundary, whose two halves both resolve to the same target.
+ *
+ * Targets were detected against the *raw* (pre-markdown) text, so a target is
+ * only made clickable here if its literal substring still appears in the
+ * rendered text — true for the overwhelming majority of URLs and file paths,
+ * since markdown syntax rarely alters them, and simply falls back to plain
+ * text (never lying about the affordance) on the rare case it doesn't.
+ *
+ * Occurrences are located once, against the *whole* rendered text — not
+ * line-by-line. A per-line search only ever finds a target that happens to
+ * land entirely within one wrapped line; a longer path or URL that gets
+ * broken mid-token by the wrap (exactly the case `wrapStyled` hard-breaks) has
+ * no single line containing its complete substring, so it silently rendered
+ * as plain, unclickable text — the inconsistency where only *some*
+ * agent-mentioned paths were clickable. Building one ownership map over the
+ * whole text before wrapping, then re-deriving where each wrapped line falls
+ * within it, makes a straddling target's ownership span the boundary the same
+ * way `wrapTextToRuns` already does for plain (non-styled) text.
+ *
+ * Offsets are matched by indexOf on the ANSI-stripped text and then converted
+ * through `sliceStyled`, which counts by grapheme cluster. For the ASCII-only
+ * targets this module ever receives (paths, URLs) that lines up exactly with
+ * a code-unit index; a wide/combining character earlier in the text could in
+ * principle shift alignment, which would only ever under-detect (fail to
+ * linkify) rather than mis-slice, since `sliceStyled` itself is always safe
+ * against arbitrary indices.
+ */
+export function buildClickableLines(
+  styledText: string,
+  width: number,
+  targets: DetectedTarget[],
+  makeTargetId: (target: DetectedTarget) => string,
+  style: { color?: string; underline?: boolean },
+  plainRunStyle: { dimColor?: boolean } = {},
+): LineRunSpec[][] {
+  const wrapped = wrapStyled(styledText, width);
+  if (targets.length === 0) return wrapped.map((line) => [{ text: line, ...plainRunStyle }]);
+
+  const fullVisible = stripAnsi(styledText);
+
+  type Occurrence = { start: number; end: number; target: DetectedTarget };
+  const occurrences: Occurrence[] = [];
+  for (const target of targets) {
+    let idx = fullVisible.indexOf(target.text);
+    while (idx !== -1) {
+      occurrences.push({ start: idx, end: idx + target.text.length, target });
+      idx = fullVisible.indexOf(target.text, idx + target.text.length);
+    }
+  }
+
+  if (occurrences.length === 0) return wrapped.map((line) => [{ text: line, ...plainRunStyle }]);
+
+  occurrences.sort((a, b) => a.start - b.start);
+  const merged: Occurrence[] = [];
+  let lastEnd = -1;
+  for (const occurrence of occurrences) {
+    if (occurrence.start >= lastEnd) {
+      merged.push(occurrence);
+      lastEnd = occurrence.end;
+    }
+  }
+
+  // Map every visible position of the *whole* rendered text to the target (if
+  // any) that owns it, so a wrap that lands anywhere — including mid-target —
+  // carries the right id on both sides.
+  const owner: (DetectedTarget | null)[] = new Array(fullVisible.length).fill(null);
+  for (const occurrence of merged) {
+    for (let i = occurrence.start; i < occurrence.end && i < fullVisible.length; i++) {
+      owner[i] = occurrence.target;
+    }
+  }
+
+  let cursor = 0;
+  return wrapped.map((line) => {
+    const visibleLine = stripAnsi(line);
+    // `wrapStyled` drops the separating space between words when it breaks a
+    // line, so re-sync to the next occurrence of this line's visible content
+    // rather than assuming a fixed-width advance — the same trick
+    // `wrapTextToRuns` uses for plain text. Lines are produced in order and
+    // never overlap, so searching forward from `cursor` is safe.
+    let lineStart = fullVisible.indexOf(visibleLine, cursor);
+    if (lineStart === -1) lineStart = cursor;
+    cursor = lineStart + visibleLine.length;
+
+    const runs: LineRunSpec[] = [];
+    let i = 0;
+    while (i < visibleLine.length) {
+      const target = owner[lineStart + i] ?? null;
+      let j = i;
+      while (j < visibleLine.length && (owner[lineStart + j] ?? null) === target) j++;
+      const chunk = sliceStyled(line, i, j);
+      if (target) {
+        runs.push({ text: chunk, targetId: makeTargetId(target), color: style.color, underline: style.underline });
+      } else {
+        runs.push({ text: chunk, ...plainRunStyle });
+      }
+      i = j;
+    }
+
+    return runs.length > 0 ? runs : [{ text: line, ...plainRunStyle }];
+  });
+}

--- a/source/utils/wrap-runs.ts
+++ b/source/utils/wrap-runs.ts
@@ -1,0 +1,93 @@
+import { wrapToWidth } from "./wrap-text.js";
+import type { DetectedTarget } from "./detect-targets.js";
+import type { OpenRef } from "./open-ref.js";
+
+/** One visual line's worth of runs, ready for `ClickableLine`. */
+export interface LineRunSpec {
+  text: string;
+  targetId?: string;
+  color?: string;
+  backgroundColor?: string;
+  underline?: boolean;
+  dimColor?: boolean;
+  bold?: boolean;
+}
+
+/**
+ * Split plain (unstyled) `text` into wrapped visual lines, each expressed as
+ * a list of runs — some plain, some carrying a `targetId` for a detected
+ * target that overlaps that span of the line.
+ *
+ * `targets` are offsets into the *original* `text`, not into any individual
+ * wrapped line — this function is responsible for translating each target's
+ * `[start, end)` range across the wrap boundaries, including targets that
+ * straddle a wrap (both halves get the same `targetId`, so either one opens
+ * the same thing).
+ *
+ * Deliberately operates on plain text: wrapping and slicing styled markdown
+ * output is handled separately via `sliceStyled`/`wrapStyled` by the caller
+ * for assistant messages; this function is for the simpler unstyled case
+ * (system messages, or callers that pre-render color per run instead).
+ */
+export function wrapTextToRuns(
+  text: string,
+  width: number,
+  targets: DetectedTarget[],
+  makeTargetId: (target: DetectedTarget) => string,
+  style: { color?: string; underline?: boolean } = {},
+  plainRunStyle: { color?: string; backgroundColor?: string; dimColor?: boolean; bold?: boolean } = {},
+): LineRunSpec[][] {
+  if (targets.length === 0) {
+    return wrapToWidth(text, width).map((line) => [{ text: line, ...plainRunStyle }]);
+  }
+
+  // Map each character of `text` to the target (if any) that covers it, so a
+  // wrap that lands anywhere — including mid-target — carries the right id
+  // on both sides.
+  const owner: (DetectedTarget | null)[] = new Array(text.length).fill(null);
+  for (const target of targets) {
+    for (let i = target.start; i < target.end && i < text.length; i++) {
+      owner[i] = target;
+    }
+  }
+
+  const lines = wrapToWidth(text, width);
+  const result: LineRunSpec[][] = [];
+  let cursor = 0;
+
+  for (const line of lines) {
+    const runs: LineRunSpec[] = [];
+    // `wrapToWidth` drops the separating space between words when it breaks a
+    // line, so re-sync `cursor` to the next occurrence of this line's content
+    // rather than assuming a fixed-width advance. Lines are produced in order
+    // and never overlap, so searching forward from `cursor` is safe.
+    let lineStart = text.indexOf(line, cursor);
+    if (lineStart === -1) lineStart = cursor;
+
+    let i = 0;
+    while (i < line.length) {
+      const absPos = lineStart + i;
+      const target = owner[absPos] ?? null;
+      let j = i;
+      while (j < line.length && (owner[lineStart + j] ?? null) === target) j++;
+      const chunk = line.slice(i, j);
+      if (target) {
+        runs.push({ text: chunk, targetId: makeTargetId(target), color: style.color, underline: style.underline });
+      } else {
+        runs.push({ text: chunk, ...plainRunStyle });
+      }
+      i = j;
+    }
+
+    result.push(runs.length > 0 ? runs : [{ text: "", ...plainRunStyle }]);
+    cursor = lineStart + line.length;
+  }
+
+  return result;
+}
+
+/** Convenience wrapper that encodes each `DetectedTarget` as an `OpenRef` string id. */
+export function targetToRefId(target: DetectedTarget, encode: (ref: OpenRef) => string): string {
+  if (target.kind === "url") return encode({ kind: "url", url: target.text });
+  return encode({ kind: "path", absPath: target.absPath!, line: target.line, col: target.col });
+}

--- a/source/utils/wrap-text.ts
+++ b/source/utils/wrap-text.ts
@@ -1,3 +1,5 @@
+import stringWidth from "string-width";
+
 /**
  * Line breaking for text drawn inside a padded background band.
  *
@@ -15,7 +17,7 @@ export function stripAnsi(value: string): string {
 }
 
 export function visualLen(value: string): number {
-  return stripAnsi(value).length;
+  return stringWidth(stripAnsi(value));
 }
 
 /**
@@ -41,8 +43,17 @@ export function wrapToWidth(content: string, width: number): string[] {
       if (current) lines.push(current);
       current = word;
       while (visualLen(current) > usable) {
-        lines.push(current.slice(0, usable));
-        current = current.slice(usable);
+        let cut = 0;
+        let used = 0;
+        for (const { segment, index } of new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(current)) {
+          const segmentWidth = stringWidth(segment);
+          if (cut > 0 && used + segmentWidth > usable) break;
+          used += segmentWidth;
+          cut = index + segment.length;
+          if (used >= usable) break;
+        }
+        lines.push(current.slice(0, cut));
+        current = current.slice(cut);
       }
     }
     // Pushed unconditionally so a blank line stays blank instead of collapsing.


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR does and why -->

- Lets the user open or preview the things Agav shows them: ctrl+click (cmd+click on macOS) a pasted-text tile, an image, a file mention, or any detected file path / URL in the transcript or prompt — with `/open` as the keyboard-only fallback for terminals where mouse reporting doesn't work.
- Fixes three bugs surfaced while building/dogfooding this: agent-generated multi-line markdown (bulleted lists) rendering as one run-on line, ctrl+click not working at all on user-typed file paths, and ctrl+click working only inconsistently on agent-mentioned paths.
- Adds double-paste-to-expand: pasting the same text a second time swaps its compacted tile back into full literal text in the input, instead of attaching a duplicate — matching Claude Code's behavior.

## Changes

<!-- List the key changes made -->

- **New attachment model** (`utils/attachments.ts`) — replaces the old ad-hoc `type`/`label` record with `{ id, kind, summary, source, contentBlock, label }` and a single tile grammar `<<Kind #id · summary>>` shared by the prompt's caret/backspace handling and the transcript renderer. Fixes a real bug where `handleClipboardImage` minted ids via `Date.now()` (could collide and was never resolvable back to a record).
- **Session-scoped attachment registry** (`utils/attachment-registry.ts`, new) — tiles stay clickable in the scrolled-back transcript for the whole session (not cleared on submit like the pending list), with eviction past a 200-record cap and image compaction (spool to temp file, drop base64 after the turn is sent).
- **Target detection** (`utils/detect-targets.ts`, new) — finds URLs and existing file paths in agent/user text via regex, then validates each path candidate against the filesystem and the project boundary before it's ever made clickable, so nothing underlined is ever unopenable.
- **Clickable rendering primitives** — `components/clickable-line.tsx` (sibling `<Text>` spans, since a `<Text>` nested inside another `<Text>` isn't individually hit-testable in this Ink fork), `sliceStyled` in `markdown-text.tsx` (ANSI-safe slicing by grapheme index), and `utils/render-clickable.ts` / `utils/wrap-runs.ts` to turn a detected target into one or more clickable runs across a wrapped line.
- **Open ladder** (`utils/open-target.ts`, new) — VS Code (`code -r -g`) → WSL → platform opener → in-document preview fallback, with an `http(s)`-only scheme allow-list, an inert-extension allow-list before handing a file to the OS, and CI/no-GUI guards.
- **Security hardening** (`utils/open-external.ts`) — replaced the Windows `cmd.exe /c start` launcher (a command-injection vector: `&`, `|`, `^`, `%` reach cmd's parser unescaped) with `explorer.exe`; added a Linux no-GUI guard so `xdg-open` never falls back into a TTY browser inside the app's alt-screen; enforced absolute-path-only targets.
- **`/open` command + in-document preview panel** (`commands/open.ts`, `components/attachment-preview.tsx`, both new) — lists every attachment in the session and opens/previews by number; the preview panel follows the same in-document pattern as `ToolDetailPanel`/`PlanDetailPanel` (read-only, so it doesn't need to seize the keyboard).
- **Bug fix — broken multi-line rendering**: `wrapStyled` treated an embedded `\n` as a zero-width character to wrap through rather than a hard line break, so a rendered bulleted list (or any multi-line markdown) collapsed onto a single run-on terminal row. Now splits on `\n` first and wraps each segment independently.
- **Bug fix — ctrl+click didn't work on user-typed paths**: user messages were a single opaque `<Text>` band with no per-run click targets at all. Extracted a `UserMessage` component that runs the same detection as agent messages and lays out each wrapped line via `ClickableLine`, preserving the background-band styling and right-edge padding per run.
- **Bug fix — ctrl+click was inconsistent on agent-mentioned paths**: `marked-terminal`'s `reflowText` option pre-wrapped prose *inside* `renderMarkdown`'s own output, inserting a literal `\n` through any file path/URL long enough to straddle the column width — before detection ever saw the intact token. Separately, `buildClickableLines` only searched for a target's text within one already-wrapped line, so even an intact token split by the (correct, necessary) downstream wrap was never matched. Disabled `reflowText` and rewrote the target-matching to build one ownership map over the whole rendered text before wrapping.
- **Double-paste-to-expand** — `app.tsx` tracks the most recent compacted paste; an identical paste immediately after it calls into `InputPrompt` (via a new `onRegisterExpand` callback) to swap that specific tile for its full literal text in the live buffer, adjusting the caret to the equivalent logical position. Falls back to attaching a fresh copy if the tile was edited/removed in between.
- New `linkColor` theme field (`config/theme.ts`), a discoverability hint (`utils/hints.ts`), and `open` added to `RESERVED_COMMAND_NAMES`.

## Related Issues

<!-- Link related issues: Closes #N, Fixes #N, or Relates to #N -->

## Type

<!-- Check one -->

- [x] Feature
- [x] Bug fix

## Testing

<!-- How was this tested? -->

- [x] `npx tsc --noEmit` passes
- [x] Manually tested in terminal
- [ ] Tested with `--provider openai`
- [ ] Tested with `--provider anthropic`
- [ ] Tested with `--provider ollama`
- [ ] Tested pipe mode (`-P`)

Full test suite: **776/776 passing** across 91 files, including 10 new/updated test files covering the attachment model, registry, target detection, clickable-line rendering, the open ladder, the `/open` command, and the double-paste-to-expand flow. Also manually reproduced and verified the fix for each of the three rendering/click bugs using standalone repro scripts against real temp-directory file trees before writing regression tests for them.

## Screenshots / Terminal Output

<!-- If applicable, paste terminal output showing the feature working -->
