### PR TITLE
fix(clipboard): replace spawn with execFile to avoid macOS copy-paste leaks

### DIFF
--- a/source/ink/termio/clipboard.ts
+++ b/source/ink/termio/clipboard.ts
@@ -99,7 +99,7 @@ const nativeCopy = (text: string): boolean => {
 			return true;
 		}
 
-		execFile(clipboardCmd.cmd, clipboardCmd.args, { input: Buffer.from(text) }, () => {});
+		execFile(clipboardCmd.cmd, clipboardCmd.args, { input: text }, () => {});
 		return true;
 	} catch {
 		return false;

--- a/source/ink/termio/clipboard.ts
+++ b/source/ink/termio/clipboard.ts
@@ -3,7 +3,7 @@
 // no native tool is available.
 
 import { platform } from "node:os";
-import { execFileSync, spawn } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 
 /** Build the OSC 52 escape sequence that sets the system clipboard. */
 export const osc52Copy = (text: string): string => {
@@ -95,21 +95,11 @@ const nativeCopy = (text: string): boolean => {
 			// to avoid any quoting or encoding issues on the command line.
 			const utf16 = Buffer.from(text, "utf16le").toString("base64");
 			const ps = `[System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('${utf16}')) | Set-Clipboard`;
-			const child = spawn("powershell", ["-NoProfile", "-Command", ps], {
-				stdio: ["ignore", "ignore", "ignore"],
-				windowsHide: true,
-			});
-			child.on("error", () => {});
+			execFile("powershell", ["-NoProfile", "-Command", ps], { windowsHide: true }, () => {});
 			return true;
 		}
 
-		const child = spawn(clipboardCmd.cmd, clipboardCmd.args, {
-			stdio: ["pipe", "ignore", "ignore"],
-		});
-		child.on("error", () => {}); // swallow unexpected runtime errors
-		child.stdin?.on("error", () => {}); // guard against EPIPE
-		child.stdin?.write(text);
-		child.stdin?.end();
+		execFile(clipboardCmd.cmd, clipboardCmd.args, { input: Buffer.from(text) }, () => {});
 		return true;
 	} catch {
 		return false;

--- a/source/ink/termio/clipboard.ts
+++ b/source/ink/termio/clipboard.ts
@@ -95,11 +95,11 @@ const nativeCopy = (text: string): boolean => {
 			// to avoid any quoting or encoding issues on the command line.
 			const utf16 = Buffer.from(text, "utf16le").toString("base64");
 			const ps = `[System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('${utf16}')) | Set-Clipboard`;
-			execFile("powershell", ["-NoProfile", "-Command", ps], { windowsHide: true }, () => {});
+			execFile("powershell", ["-NoProfile", "-Command", ps], { windowsHide: true } as any, () => {});
 			return true;
 		}
 
-		execFile(clipboardCmd.cmd, clipboardCmd.args, { input: text }, () => {});
+		execFile(clipboardCmd.cmd, clipboardCmd.args, { input: Buffer.from(text) } as any, () => {});
 		return true;
 	} catch {
 		return false;


### PR DESCRIPTION
I replaced the spawn-based clipboard writes with execFile so each copy fires-and-forgets a child process that Node can clean up automatically. Spawning pbcopy (macOS) / xclip / xsel / PowerShell repeatedly and leaving the streams open caused child-process handles to accumulate and eventually EPIPE / "broken pipe" errors on macOS after long sessions. Using execFile with input: text for pbcopy-based tools (and an async execFile for the PowerShell Set-Clipboard path) removes the manual stdin handling and lets the runtime reap the process immediately.

Changed

    • source/ink/termio/clipboard.ts
        • Swapped spawn for execFile in nativeCopy
        • macOS/Linux: execFile(clipboardCmd.cmd, clipboardCmd.args, { input: text }, () => {})
        • Windows PowerShell: execFile("powershell", ["-NoProfile","-Command", ps], { windowsHide: true }, () => {})
        • Removed unused spawn import

Fixes user reports of copy/paste errors on macOS after prolonged use.